### PR TITLE
Add 5K extended display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,19 @@ Unzip and double-click. On first launch, grant Screen Recording to the sender.
 
 ## Stream profiles
 
-- `Standard · 2560 × 1440` — low latency, high stability
-- `5K · 5120 × 2880` — sharper image, HEVC, slightly more load
+- `Standard · 2560 × 1440` — conservative baseline
+- `Smooth · 2560 × 1440 @ 60` — lower latency motion
+- `Smooth+ · 3200 × 1800 @ 60` — sharper motion profile
+- `Crisp · 3840 × 2160 @ 48` — clearer text with HEVC
+- `5K · 5120 × 2880 @ 48` — native iMac 5K stream with HEVC
+
+The sender can stream either an extended virtual display or a mirror of the MacBook display.
+
+## Extended Desktop
+
+For an extended desktop, choose `Extended display` on the sender before connecting. After the virtual display appears, open macOS **System Settings → Displays → Arrange** on the sender Mac and position the external display where you want it.
+
+If the receiver does not fill the iMac panel or the cursor/desktop feels scaled incorrectly, select the external TargetBridge display in macOS Display Settings and choose the matching resolution. For the 27-inch 5K iMac path, use a high-clarity stream profile such as `Crisp` or `5K` with the external display set to the matching 2560 × 1440 HiDPI mode.
 
 ## Projects
 

--- a/TargetBridge-QuickStart-EN.md
+++ b/TargetBridge-QuickStart-EN.md
@@ -67,22 +67,35 @@ Write down the IP address shown in the startup window.
 1. Start `TargetBridge Receiver` on the iMac first
 2. Read the Thunderbolt Bridge IP shown by the receiver
 3. Open `TargetBridge` on the MacBook
-4. Enter that IP in the `Receiver IP` field
-5. Press `Connect`
+4. Choose `Extended display` to use the iMac as a separate desktop, or `Mirror MacBook` to duplicate the MacBook screen
+5. Enter that IP in the `Receiver IP` field
+6. Press `Connect`
 
 When the first frame arrives, the receiver switches to fullscreen automatically.
+
+For extended desktop, open macOS **System Settings → Displays → Arrange** on the sender Mac after connecting. Place the external TargetBridge display where you want it, then select that display in Display Settings and choose the matching resolution if the iMac does not fill correctly. For the 27-inch 5K path, use the `5K` stream profile with the external display set to the matching 5120 × 2880 / 2560 × 1440 HiDPI mode.
 
 ## Stream profiles
 
 - `Standard · 2560 × 1440`
-  - lower latency
-  - higher stability
-  - less sharp than native 5K
+  - conservative baseline
+  - highest compatibility
 
-- `5K · 5120 × 2880`
-  - sharper image
+- `Smooth · 2560 × 1440 @ 60`
+  - lower latency motion
+
+- `Smooth+ · 3200 × 1800 @ 60`
+  - sharper motion profile
+
+- `Crisp · 3840 × 2160 @ 48`
+  - clearer text
   - uses `HEVC`
-  - more load and slightly higher latency
+  - lighter than native 5K
+
+- `5K · 5120 × 2880 @ 48`
+  - native iMac 5K stream
+  - uses `HEVC`
+  - highest load
 
 ## Auto-start the receiver
 
@@ -103,6 +116,7 @@ cd TargetBridge-Receiver
 ## Practical notes
 
 - the receiver should be started before the sender
+- extended desktop requires arranging the new display in macOS Display Settings on the sender
 - the sender can show or hide its top bar icon
-- if 5K is not responsive enough, switch back to the `Standard` profile
+- if 5K is not responsive enough, switch back to `Crisp` or `Smooth+`
 - the sender build script uses a local DerivedData folder at `TargetBridge-Sender/.build/DerivedData`

--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -240,6 +240,7 @@ struct tb_display *tb_disp_create(int fullscreen) {
         fprintf(stderr, "[disp] SDL_Init: %s\n", SDL_GetError());
         return NULL;
     }
+    SDL_DisableScreenSaver();
 
     struct tb_display *d = (struct tb_display *)calloc(1, sizeof(*d));
     if (!d) return NULL;
@@ -303,6 +304,7 @@ void tb_disp_destroy(struct tb_display *d) {
     if (d->tex) SDL_DestroyTexture(d->tex);
     if (d->ren) SDL_DestroyRenderer(d->ren);
     if (d->win) SDL_DestroyWindow(d->win);
+    SDL_EnableScreenSaver();
     SDL_Quit();
     free(d);
 }

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -161,17 +161,22 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
         }
         {
             char preset[64];
+            char source[64];
             char codec[64];
             int capture_w = 0;
             int capture_h = 0;
             preset[0] = '\0';
+            source[0] = '\0';
             codec[0] = '\0';
             extract_json_string_field(payload, len, "\"capturePreset\"", preset, sizeof(preset));
+            extract_json_string_field(payload, len, "\"captureSource\"", source, sizeof(source));
             extract_json_string_field(payload, len, "\"codec\"", codec, sizeof(codec));
             (void)extract_json_int_field(payload, len, "\"captureWidth\"", &capture_w);
             (void)extract_json_int_field(payload, len, "\"captureHeight\"", &capture_h);
 
-            if (capture_w > 0 && capture_h > 0 && preset[0] != '\0' && codec[0] != '\0') {
+            if (capture_w > 0 && capture_h > 0 && source[0] != '\0' && preset[0] != '\0' && codec[0] != '\0') {
+                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s, %s, %s)", capture_w, capture_h, source, preset, codec);
+            } else if (capture_w > 0 && capture_h > 0 && preset[0] != '\0' && codec[0] != '\0') {
                 snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s, %s)", capture_w, capture_h, preset, codec);
             } else if (capture_w > 0 && capture_h > 0 && preset[0] != '\0') {
                 snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s)", capture_w, capture_h, preset);

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
@@ -12,7 +12,7 @@ struct TBDisplaySenderApp: App {
                     statusItemController.activate()
                 }
         }
-        .defaultSize(width: 440, height: 360)
+        .defaultSize(width: 460, height: 420)
         .windowResizability(.contentSize)
     }
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -66,6 +66,14 @@ struct TBDisplaySenderContentView: View {
 
             GroupBox(TBDisplaySenderL10n.streamResolutionGroup(service.language)) {
                 VStack(alignment: .leading, spacing: 10) {
+                    Picker(TBDisplaySenderL10n.captureSource(service.language), selection: $service.captureSource) {
+                        ForEach(TBDisplayCaptureSource.allCases) { source in
+                            Text(source.title(service.language)).tag(source)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .disabled(service.isConnected || service.isStreaming)
+
                     Picker(TBDisplaySenderL10n.streamProfile(service.language), selection: $service.capturePreset) {
                         ForEach(TBDisplayCapturePreset.allCases) { preset in
                             Text("\(preset.title(service.language)) · \(preset.description)").tag(preset)

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -40,9 +40,9 @@ enum TBDisplaySenderStatusState {
     case receiverTerminatedSession
     case creatingVirtualDisplay
     case virtualDisplayCreationFailed
-    case startingCapture(String)
+    case startingCapture(String, TBDisplayCaptureSource)
     case captureStartedWaitingFirstFrame
-    case captureActive(String, String)
+    case captureActive(String, String, TBDisplayCaptureSource)
     case captureError(String)
     case captureDesktopError(String)
     case noShareableDisplay(String)
@@ -84,14 +84,16 @@ enum TBDisplaySenderStatusState {
         case (.virtualDisplayCreationFailed, .italian): return "Creazione virtual display fallita"
         case (.virtualDisplayCreationFailed, .english): return "Virtual display creation failed"
 
-        case let (.startingCapture(resolution), .italian): return "Avvio cattura del virtual display iMac (\(resolution))…"
-        case let (.startingCapture(resolution), .english): return "Starting iMac virtual display capture (\(resolution))…"
+        case let (.startingCapture(resolution, source), .italian):
+            return "Avvio \(source.title(language).lowercased()) (\(resolution))…"
+        case let (.startingCapture(resolution, source), .english):
+            return "Starting \(source.title(language).lowercased()) capture (\(resolution))…"
 
         case (.captureStartedWaitingFirstFrame, .italian): return "Cattura avviata, attendo il primo frame…"
         case (.captureStartedWaitingFirstFrame, .english): return "Capture started, waiting for the first frame…"
 
-        case let (.captureActive(resolution, codec), .italian): return "Virtual display iMac attivo (\(resolution), \(codec))"
-        case let (.captureActive(resolution, codec), .english): return "iMac virtual display active (\(resolution), \(codec))"
+        case let (.captureActive(resolution, codec, source), .italian): return "\(source.title(language)) attivo (\(resolution), \(codec))"
+        case let (.captureActive(resolution, codec, source), .english): return "\(source.title(language)) active (\(resolution), \(codec))"
 
         case let (.captureError(error), .italian): return "Errore capture: \(error)"
         case let (.captureError(error), .english): return "Capture error: \(error)"
@@ -165,21 +167,25 @@ enum TBDisplaySenderL10n {
         language == .italian ? "Profilo stream" : "Stream profile"
     }
 
+    static func captureSource(_ language: TBDisplaySenderLanguage) -> String {
+        language == .italian ? "Sorgente" : "Source"
+    }
+
     static func streamHint1(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian:
-            return "`Smooth+` privilegia fluidità. `Crisp` aumenta la nitidezza del testo. `5K` massimizza i pixel."
+            return "`Desktop esteso` usa il monitor virtuale. `Duplica MacBook` cattura il display principale."
         case .english:
-            return "`Smooth+` prioritizes motion. `Crisp` improves text clarity. `5K` maximizes pixels."
+            return "`Extended display` uses the virtual monitor. `Mirror MacBook` captures the main display."
         }
     }
 
     static func streamHint2(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian:
-            return "`Crisp` usa 3840 × 2160 @ 48 FPS con HEVC: più chiaro di Smooth+, più leggero di 5K."
+            return "`Smooth+` privilegia fluidità. `Crisp` aumenta la nitidezza. `5K` massimizza i pixel."
         case .english:
-            return "`Crisp` uses 3840 × 2160 @ 48 FPS with HEVC: clearer than Smooth+, lighter than 5K."
+            return "`Smooth+` prioritizes motion. `Crisp` improves clarity. `5K` maximizes pixels."
         }
     }
 
@@ -223,8 +229,8 @@ enum TBDisplaySenderL10n {
 
     static func modeLine3(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
-        case .italian: return "Pipeline: sessione virtual display + virtual display iMac → ScreenCaptureKit → codec hardware → TCP"
-        case .english: return "Pipeline: virtual display session + iMac virtual display → ScreenCaptureKit → hardware codec → TCP"
+        case .italian: return "Pipeline: virtual display o mirror → capture diretta → codec hardware → TCP"
+        case .english: return "Pipeline: virtual display or mirror → direct capture → hardware codec → TCP"
         }
     }
 
@@ -237,8 +243,8 @@ enum TBDisplaySenderL10n {
 
     static func modeLine5(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
-        case .italian: return "Usa Smooth per mouse e animazioni più fluidi; usa 5K per massima nitidezza."
-        case .english: return "Use Smooth for better mouse and animation motion; use 5K for maximum sharpness."
+        case .italian: return "Scegli desktop esteso o mirror, poi bilancia fluidità e nitidezza col profilo stream."
+        case .english: return "Choose extended display or mirror, then balance motion and clarity with the stream profile."
         }
     }
 
@@ -305,8 +311,8 @@ enum TBDisplaySenderL10n {
         }
     }
 
-    static func streamSummary(preset: TBDisplayCapturePreset, language: TBDisplaySenderLanguage) -> String {
-        "\(preset.description) (\(preset.title(language)), \(preset.codecName))"
+    static func streamSummary(preset: TBDisplayCapturePreset, source: TBDisplayCaptureSource, language: TBDisplaySenderLanguage) -> String {
+        "\(source.title(language)) · \(preset.description) (\(preset.title(language)), \(preset.codecName))"
     }
 
     static func missingScreenRecordingPermission(language: TBDisplaySenderLanguage) -> String {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -523,8 +523,13 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
             directDisplayStream.stop()
             self.directDisplayStream = nil
         }
-        scStream?.stopCapture(completionHandler: nil)
-        scStream = nil
+        if let stream = scStream {
+            if let delegate = captureDelegate {
+                try? stream.removeStreamOutput(delegate, type: .screen)
+            }
+            stream.stopCapture(completionHandler: nil)
+            scStream = nil
+        }
         captureDelegate = nil
         if let activity = streamingActivity {
             ProcessInfo.processInfo.endActivity(activity)
@@ -534,6 +539,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
         vtEncoder = nil
         vtEncoderRef?.release()
         vtEncoderRef = nil
+        connection?.stateUpdateHandler = nil
         connection?.cancel()
         connection = nil
         let currentSession = session

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -235,6 +235,22 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
     }
 }
 
+enum TBDisplayCaptureSource: String, CaseIterable, Identifiable {
+    case extendedVirtualDisplay
+    case mainDisplayMirror
+
+    var id: String { rawValue }
+
+    func title(_ language: TBDisplaySenderLanguage) -> String {
+        switch (self, language) {
+        case (.extendedVirtualDisplay, .italian): return "Desktop esteso"
+        case (.extendedVirtualDisplay, .english): return "Extended display"
+        case (.mainDisplayMirror, .italian): return "Duplica MacBook"
+        case (.mainDisplayMirror, .english): return "Mirror MacBook"
+        }
+    }
+}
+
 private final class TBDirectDisplayStreamCapture {
     private let serviceRef: UnsafeMutableRawPointer
     private let queue: DispatchQueue
@@ -318,11 +334,18 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
     @Published var capturePreset: TBDisplayCapturePreset = .standard1440p {
         didSet {
             if !isStreaming {
-                streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: capturePreset, language: language)
+                streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: capturePreset, source: captureSource, language: language)
             }
         }
     }
-    @Published var streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: .standard1440p, language: TBDisplaySenderLanguage.load())
+    @Published var captureSource: TBDisplayCaptureSource = .extendedVirtualDisplay {
+        didSet {
+            if !isStreaming {
+                streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: capturePreset, source: captureSource, language: language)
+            }
+        }
+    }
+    @Published var streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: .standard1440p, source: .extendedVirtualDisplay, language: TBDisplaySenderLanguage.load())
 
     private var connection: NWConnection?
     private let connectionQueue = DispatchQueue(label: "fd.tbmonitor.sender.connection", qos: .userInteractive)
@@ -397,7 +420,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
 
     private func refreshLocalizedText() {
         statusText = statusState.text(language)
-        streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: capturePreset, language: language)
+        streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: capturePreset, source: captureSource, language: language)
 
         if let profile = activeProfile {
             receiverPanelText = TBDisplaySenderL10n.receiverSummary(profile, language: language)
@@ -544,6 +567,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
             value: TBMonitorHelloReceiver(
                 senderName: name,
                 capturePreset: preset.title,
+                captureSource: captureSource.title(language),
                 captureWidth: preset.width,
                 captureHeight: preset.height,
                 codec: preset.codecName
@@ -632,7 +656,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
                 id: self.session.displayID,
                 language: self.language
             )
-            self.setStatus(.startingCapture(self.capturePreset.description))
+            self.setStatus(.startingCapture(self.capturePreset.description, self.captureSource))
             let started = await self.startCapture(for: profile)
             guard started else {
                 self.stop(resetStatusTo: nil)
@@ -647,10 +671,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
 
     private func startCapture(for profile: TBMonitorDisplayProfile) async -> Bool {
         do {
-            let display = try await waitForVirtualDisplay(
-                matching: session.displayID,
-                baselineDisplayIDs: baselineDisplayIDs
-            )
+            let display = try await waitForCaptureDisplay()
             let preset = capturePreset
             if startDirectDisplayStream(for: display, preset: preset) {
                 return true
@@ -673,7 +694,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
                 codecType: preset.codecType,
                 averageBitRate: preset.averageBitRate
             )
-            streamResolutionText = "\(preset.description) (\(preset.title), \(preset.codecName))"
+            streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: preset, source: captureSource, language: language)
 
             let delegate = CaptureDelegate()
             delegate.onFrame = { [weak self] sampleBuffer in
@@ -706,7 +727,8 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
             startFPSTimer()
             return true
         } catch {
-            if error.localizedDescription.hasPrefix("nessun SCDisplay disponibile") {
+            if error.localizedDescription.hasPrefix("nessun SCDisplay") ||
+                error.localizedDescription.hasPrefix("virtual display") {
                 setStatus(.noShareableDisplay(error.localizedDescription))
             } else {
                 setStatus(.captureDesktopError(formattedCaptureErrorMessage(for: error)))
@@ -726,7 +748,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
         guard vtEncoder != nil else { return false }
 
         displayStreamFrameSequence = 0
-        streamResolutionText = "\(preset.description) (\(preset.title), \(preset.codecName))"
+        streamResolutionText = TBDisplaySenderL10n.streamSummary(preset: preset, source: captureSource, language: language)
 
         let directCapture = TBDirectDisplayStreamCapture(service: self, queue: connectionQueue)
         guard directCapture.start(displayID: display.displayID, preset: preset, showCursor: !largeCursor) else {
@@ -742,6 +764,18 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
         )
         startFPSTimer()
         return true
+    }
+
+    private func waitForCaptureDisplay() async throws -> SCDisplay {
+        switch captureSource {
+        case .extendedVirtualDisplay:
+            return try await waitForVirtualDisplay(
+                matching: session.displayID,
+                baselineDisplayIDs: baselineDisplayIDs
+            )
+        case .mainDisplayMirror:
+            return try await waitForMirrorDisplay(excluding: session.displayID)
+        }
     }
 
     private func waitForVirtualDisplay(
@@ -794,6 +828,39 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
         }
         throw DisplayLookupError.notFound(
             details: "nessun SCDisplay virtuale disponibile (target=\(targetDisplayID), baseline=[\(baselineIDs)], disponibili=[\(availableIDs)], online=[\(onlineIDs)])"
+        )
+    }
+
+    private func waitForMirrorDisplay(excluding sessionDisplayID: CGDirectDisplayID) async throws -> SCDisplay {
+        enum DisplayLookupError: LocalizedError {
+            case notFound(details: String)
+
+            var errorDescription: String? {
+                switch self {
+                case .notFound(let details):
+                    return details
+                }
+            }
+        }
+
+        for _ in 0..<12 {
+            let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            let mainDisplayID = CGMainDisplayID()
+            if mainDisplayID != sessionDisplayID,
+               let display = content.displays.first(where: { $0.displayID == mainDisplayID }) {
+                return display
+            }
+
+            if let display = content.displays.first(where: { $0.displayID != sessionDisplayID }) {
+                return display
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let availableIDs = content.displays.map { String($0.displayID) }.sorted().joined(separator: ", ")
+        throw DisplayLookupError.notFound(
+            details: "nessun SCDisplay mirror disponibile (main=\(CGMainDisplayID()), virtual=\(sessionDisplayID), disponibili=[\(availableIDs)])"
         )
     }
 
@@ -948,7 +1015,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
             if let packet = TBMonitorProtocol.makeJSONPacket(type: .createSessionAck, value: ack) {
                 send(packet)
             }
-            setStatus(.captureActive(capturePreset.description, capturePreset.codecName))
+            setStatus(.captureActive(capturePreset.description, capturePreset.codecName, captureSource))
         }
 
         let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[CFString: Any]]

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -727,7 +727,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
             isStreaming = true
             if largeCursor { startCursorUpdates(displayID: display.displayID) }
             streamingActivity = ProcessInfo.processInfo.beginActivity(
-                options: .userInitiatedAllowingIdleSystemSleep,
+                options: [.userInitiated, .idleSystemSleepDisabled],
                 reason: "TargetBridge streaming active"
             )
             startFPSTimer()
@@ -765,7 +765,7 @@ final class TBDisplaySenderService: NSObject, ObservableObject, @unchecked Senda
         isStreaming = true
         if largeCursor { startCursorUpdates(displayID: display.displayID) }
         streamingActivity = ProcessInfo.processInfo.beginActivity(
-            options: .userInitiatedAllowingIdleSystemSleep,
+            options: [.userInitiated, .idleSystemSleepDisabled],
             reason: "TargetBridge streaming active"
         )
         startFPSTimer()

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -14,6 +14,7 @@ enum TBMonitorPacketType: UInt8 {
 struct TBMonitorHelloReceiver: Codable {
     var senderName: String
     var capturePreset: String?
+    var captureSource: String?
     var captureWidth: Int?
     var captureHeight: Int?
     var codec: String?

--- a/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
+++ b/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
@@ -193,7 +193,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TargetBridge;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "TargetBridge - Free & Open Source";
-				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "TargetBridge richiede il permesso di registrazione schermo per catturare il desktop duplicato destinato all'iMac.";
+				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "TargetBridge richiede il permesso di registrazione schermo per catturare il monitor virtuale o duplicare il desktop sull'iMac.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -219,7 +219,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TargetBridge;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "TargetBridge - Free & Open Source";
-				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "TargetBridge richiede il permesso di registrazione schermo per catturare il desktop duplicato destinato all'iMac.";
+				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "TargetBridge richiede il permesso di registrazione schermo per catturare il monitor virtuale o duplicare il desktop sull'iMac.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/TargetBridge-Sender/project.yml
+++ b/TargetBridge-Sender/project.yml
@@ -23,7 +23,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.targetbridge.sender
         INFOPLIST_KEY_CFBundleDisplayName: "TargetBridge"
         INFOPLIST_KEY_NSHumanReadableCopyright: "TargetBridge - Free & Open Source"
-        INFOPLIST_KEY_NSScreenCaptureUsageDescription: "TargetBridge richiede il permesso di registrazione schermo per catturare il desktop duplicato destinato all'iMac."
+        INFOPLIST_KEY_NSScreenCaptureUsageDescription: "TargetBridge richiede il permesso di registrazione schermo per catturare il monitor virtuale o duplicare il desktop sull'iMac."
         MARKETING_VERSION: "0.1.0-rc1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"


### PR DESCRIPTION
## Summary
- rebase onto the updated main streaming stack and keep the upstream direct-capture, cursor, TCP latency, and backpressure changes intact
- add a sender source selector for Extended display vs Mirror MacBook while using the new main capture pipeline
- send the selected capture source in the hello payload so the receiver status can show what is being streamed
- update sender copy, screen-recording permission text, and English docs for the expanded stream profiles

## Validation
- make in TargetBridge-Receiver/TBReceiverC
- xcodebuild -scheme TBDisplaySender -configuration Debug -derivedDataPath TargetBridge-Sender/.build/DerivedData CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build
- git diff --check origin/main...HEAD

## Notes
- The app build script also compiled successfully, but its final Desktop copy step is blocked in this sandbox, so validation used direct xcodebuild for a clean exit.
- The generated TBDisplaySenderBuildInfo.swift build stamp is intentionally excluded from this PR.