### PR TITLE
fix(receiver): prevent hardware device context memory leak on reconnect

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/decoder.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/decoder.c
@@ -196,9 +196,12 @@ static int open_decoder(struct tb_decoder *d) {
     if (!d->ctx) return -1;
 
     if (hw_pix_fmt != AV_PIX_FMT_NONE) {
-        if (av_hwdevice_ctx_create(&d->hw_dev, type, NULL, NULL, 0) < 0) {
-            fprintf(stderr, "[dec] av_hwdevice_ctx_create failed\n");
-        } else {
+        if (!d->hw_dev) {
+            if (av_hwdevice_ctx_create(&d->hw_dev, type, NULL, NULL, 0) < 0) {
+                fprintf(stderr, "[dec] av_hwdevice_ctx_create failed\n");
+            }
+        }
+        if (d->hw_dev) {
             d->ctx->hw_device_ctx = av_buffer_ref(d->hw_dev);
             d->ctx->get_format    = get_hw_format;
         }


### PR DESCRIPTION
Ensure the FFmpeg hardware device context (d->hw_dev) is reused across sessions if it has already been allocated, rather than being blindly re-created.

How memory leaked before the fix:
1. When a client connects for the first time, `open_decoder` calls `av_hwdevice_ctx_create(&d->hw_dev, ...)` to allocate a VideoToolbox hardware device context (setting `d->hw_dev`'s reference count to 1).
2. When the client disconnects, `tb_dec_reset` frees `d->ctx` (which decrements the reference to the hardware context in the codec context), but deliberately preserves `d->hw_dev` in the `tb_decoder` structure for future reuse to save context creation overhead.
3. When a client reconnects, `open_decoder` was called again and blindly executed `av_hwdevice_ctx_create(&d->hw_dev, ...)` without checking if `d->hw_dev` was already pointing to an existing context.
4. This overwrote the `d->hw_dev` pointer in the struct with the new allocation, losing the reference to the previous context and permanently leaking the entire VideoToolbox hardware device context on the heap on every reconnect.

This patch checks `if (!d->hw_dev)` prior to calling `av_hwdevice_ctx_create`, guaranteeing clean reuse across successive connections and zero leaks.