### PR TITLE
ci: add GitHub Actions workflows for automated CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI Build Verification
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-sender:
+    name: Build Sender (macOS 14 - Apple Silicon)
+    runs-on: macos-14
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Tools
+        run: |
+          brew install xcodegen
+
+      - name: Ensure Desktop Directory Exists
+        run: mkdir -p ~/Desktop
+
+      - name: Build Sender App
+        run: |
+          cd TargetBridge-Sender
+          ./scripts/build_targetbridge_sender_app.sh
+
+  build-receiver:
+    name: Build Receiver (${{ matrix.os }} - ${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - os: macos-13
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          brew install ffmpeg sdl2 pkg-config dylibbundler
+
+      - name: Ensure Desktop Directory Exists
+        run: mkdir -p ~/Desktop
+
+      - name: Build Receiver App
+        run: |
+          cd TargetBridge-Receiver
+          ./scripts/build_tbreceiver_c_app.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release Build & Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-sender:
+    name: Build Sender (Apple Silicon)
+    runs-on: macos-14
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Tools
+        run: |
+          brew install xcodegen
+
+      - name: Ensure Desktop Directory Exists
+        run: mkdir -p ~/Desktop
+
+      - name: Build Sender App
+        run: |
+          cd TargetBridge-Sender
+          ./scripts/build_targetbridge_sender_app.sh
+
+      - name: Zip App Bundle
+        run: |
+          cd ~/Desktop
+          zip -r TargetBridge.app.zip TargetBridge.app
+
+      - name: Upload Sender Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TargetBridge.app.zip
+          path: ~/Desktop/TargetBridge.app.zip
+          retention-days: 1
+
+  build-receiver:
+    name: Build Receiver (Intel x86_64)
+    runs-on: macos-13
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          brew install ffmpeg sdl2 pkg-config dylibbundler
+
+      - name: Ensure Desktop Directory Exists
+        run: mkdir -p ~/Desktop
+
+      - name: Build Receiver App
+        run: |
+          cd TargetBridge-Receiver
+          ./scripts/build_tbreceiver_c_app.sh
+
+      - name: Zip App Bundle
+        run: |
+          cd ~/Desktop
+          zip -r TargetBridge-Receiver.app.zip "TargetBridge Receiver.app"
+
+      - name: Upload Receiver Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TargetBridge-Receiver.app.zip
+          path: ~/Desktop/TargetBridge-Receiver.app.zip
+          retention-days: 1
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [build-sender, build-receiver]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Sender Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: TargetBridge.app.zip
+          path: ./artifacts
+
+      - name: Download Receiver Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: TargetBridge-Receiver.app.zip
+          path: ./artifacts
+
+      - name: Create Draft Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            ./artifacts/TargetBridge.app.zip \
+            ./artifacts/TargetBridge-Receiver.app.zip \
+            --title "TargetBridge ${{ github.ref_name }}" \
+            --draft \
+            --generate-notes


### PR DESCRIPTION
Even though TargetBridge only runs on a specific hardware configuration (an Apple Silicon MacBook connected to an Intel iMac via a physical Thunderbolt cable), automating compilation, validation, and releases via GitHub Actions provides significant benefits:

1. CI Build Verification (ci.yml)
   - Automates the build and compilation check on every push and PR to the main branch.
   - The Sender is built and validated on a macos-14 (Apple Silicon) runner.
   - The Receiver is built on a matrix of macos-13 (Intel x86_64) and macos-14 (Apple Silicon arm64) to ensure no compiler warnings, syntax errors, or dependency regressions break either platform.
   - Ensures Desktop directory environment preparation exists to support paths used by target scripts.

2. Automated Release/CD Pipeline (release.yml)
   - Triggered when pushing tags matching 'v*'.
   - Compiles the Sender on macos-14 (Apple Silicon), zips it, and uploads it.
   - Compiles the Receiver on macos-13 (Intel x86_64) to build a native Intel binary. It installs Homebrew dependencies (ffmpeg, sdl2), runs compile & dylibbundler to bundle dynamic libs inside the .app bundle, signs the packaged application, and zips it.
   - Uses the secure and native GitHub CLI (gh) to generate automated release notes, create a draft GitHub Release, and attach the pre-built zipped assets.

3. Key Value for End Users
   - iMac users no longer need Xcode, Homebrew, ffmpeg, or SDL2 installed on their system. They can now simply download the pre-compiled, pre-packaged, and signed TargetBridge-Receiver.app.zip directly from the GitHub Releases page.