### PR TITLE
Force OpenGL renderer backend to resolve macOS Tahoe Metal flickering, fixes #11

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -231,6 +231,9 @@ static void tb_disp_refresh_window_mode(struct tb_display *d) {
 }
 
 struct tb_display *tb_disp_create(int fullscreen) {
+    /* Force OpenGL renderer driver to avoid Metal's HDR/swapchain flickering on macOS Tahoe. */
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+
     /* Best-quality scaling (linear filter; Metal backend uses bilinear
      * regardless but this sets the hint correctly). "best" enables
      * anisotropic where supported. Must be set BEFORE renderer creation. */


### PR DESCRIPTION
Problem Diagnosis:
Under macOS Tahoe, SDL2's default Metal renderer backend suffers from severe swapchain presentation and compositor synchronization conflicts:
Variable frame-presentation rates (caused by high-rate cursor updates interleaved with slower video frames) trigger Apple's dynamic WindowServer compositor adjustments (such as EDR/HDR, ProMotion, and TrueTone transitions), causing the entire screen to constantly flicker.

How this change helps:
Forces the renderer to utilize the OpenGL backend driver via SDL_HINT_RENDER_DRIVER. OpenGL is implemented via Apple's mature, ultra-stable OpenGL-to-Metal translation stack. It utilizes a rock-solid, stable frame presentation swapchain that completely eliminates visual flickering, while maintaining full GPU hardware acceleration.