### PR TITLE
Set YUV conversion mode to BT.709 explicitly

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -267,6 +267,7 @@ struct tb_display *tb_disp_create(int fullscreen) {
         fprintf(stderr, "[disp] CreateRenderer: %s\n", SDL_GetError());
         SDL_DestroyWindow(d->win); free(d); return NULL;
     }
+    SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_BT709);
     SDL_RenderSetLogicalSize(d->ren, 0, 0);
 
     /* report which backend SDL picked */


### PR DESCRIPTION
Problem Diagnosis:
The receiver receives HEVC video frames that use the standard Rec. 709 Limited Range colorspace. By default, SDL2 uses the automatic YUV conversion mode, which can select BT.601 or fluctuate depending on the window configuration, leading to incorrect mapping of luma values (where black is mapped to dark grey).

How this change helps:
Explicitly locks the global YUV conversion mode to Rec. 709 (SDL_YUV_CONVERSION_BT709). This ensures accurate YUV-to-RGB conversion, preventing resolution-based fallbacks to BT.601 and securing consistent, deep black levels.