### PR TITLE
improve release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,18 @@ jobs:
       - name: Zip App Bundle
         run: |
           cd build
-          zip -r TargetBridge.app.zip TargetBridge.app
+          zip -r TargetBridge-arm64.app.zip TargetBridge.app
 
       - name: Generate build provenance attestation
         uses: actions/attest@v4
         with:
-          subject-path: build/TargetBridge.app.zip
+          subject-path: build/TargetBridge-arm64.app.zip
 
       - name: Upload Sender Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: TargetBridge.app.zip
-          path: build/TargetBridge.app.zip
+          name: TargetBridge-arm64.app.zip
+          path: build/TargetBridge-arm64.app.zip
           retention-days: 1
 
   build-receiver:
@@ -95,7 +95,7 @@ jobs:
       - name: Download Sender Artifact
         uses: actions/download-artifact@v8
         with:
-          name: TargetBridge.app.zip
+          name: TargetBridge-arm64.app.zip
           path: ./artifacts
 
       - name: Download Receiver Artifact (x86_64)
@@ -115,7 +115,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
-            ./artifacts/TargetBridge.app.zip \
+            ./artifacts/TargetBridge-arm64.app.zip \
             ./artifacts/TargetBridge-Receiver-x86_64.app.zip \
             ./artifacts/TargetBridge-Receiver-arm64.app.zip \
             --title "TargetBridge ${{ github.ref_name }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,15 @@ jobs:
           retention-days: 1
 
   build-receiver:
-    name: Build Receiver (Intel x86_64)
-    runs-on: macos-15-intel
+    name: Build Receiver (macOS ${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-15-intel
+            arch: x86_64
+          - os: macos-15
+            arch: arm64
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -56,13 +63,13 @@ jobs:
       - name: Zip App Bundle
         run: |
           cd build
-          zip -r TargetBridge-Receiver.app.zip "TargetBridge Receiver.app"
+          zip -r TargetBridge-Receiver-${{ matrix.arch }}.app.zip "TargetBridge Receiver.app"
 
       - name: Upload Receiver Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: TargetBridge-Receiver.app.zip
-          path: build/TargetBridge-Receiver.app.zip
+          name: TargetBridge-Receiver-${{ matrix.arch }}.app.zip
+          path: build/TargetBridge-Receiver-${{ matrix.arch }}.app.zip
           retention-days: 1
 
   publish-release:
@@ -79,10 +86,16 @@ jobs:
           name: TargetBridge.app.zip
           path: ./artifacts
 
-      - name: Download Receiver Artifact
+      - name: Download Receiver Artifact (x86_64)
         uses: actions/download-artifact@v8
         with:
-          name: TargetBridge-Receiver.app.zip
+          name: TargetBridge-Receiver-x86_64.app.zip
+          path: ./artifacts
+
+      - name: Download Receiver Artifact (arm64)
+        uses: actions/download-artifact@v8
+        with:
+          name: TargetBridge-Receiver-arm64.app.zip
           path: ./artifacts
 
       - name: Create Draft Release
@@ -91,7 +104,8 @@ jobs:
         run: |
           gh release create "${{ github.ref_name }}" \
             ./artifacts/TargetBridge.app.zip \
-            ./artifacts/TargetBridge-Receiver.app.zip \
+            ./artifacts/TargetBridge-Receiver-x86_64.app.zip \
+            ./artifacts/TargetBridge-Receiver-arm64.app.zip \
             --title "TargetBridge ${{ github.ref_name }}" \
             --draft \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-sender:
@@ -29,6 +31,11 @@ jobs:
         run: |
           cd build
           zip -r TargetBridge.app.zip TargetBridge.app
+
+      - name: Generate build provenance attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: build/TargetBridge.app.zip
 
       - name: Upload Sender Artifact
         uses: actions/upload-artifact@v7
@@ -64,6 +71,11 @@ jobs:
         run: |
           cd build
           zip -r TargetBridge-Receiver-${{ matrix.arch }}.app.zip "TargetBridge Receiver.app"
+
+      - name: Generate build provenance attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: build/TargetBridge-Receiver-${{ matrix.arch }}.app.zip
 
       - name: Upload Receiver Artifact
         uses: actions/upload-artifact@v7

--- a/docs/verify-binaries.md
+++ b/docs/verify-binaries.md
@@ -1,0 +1,61 @@
+# GitHub Build Provenance Attestation
+
+TargetBridge release binaries are cryptographically signed using **GitHub
+Artifact Attestations** (built on Sigstore). This provides a secure,
+tamper-proof software supply chain by enabling anyone to verify that the
+distributed release ZIP archives were built directly inside our official
+GitHub Actions pipeline from the authentic source code.
+
+---
+
+## How It Works
+
+During the release build process, GitHub Actions dynamically requests a
+short-lived cryptographic identity token from the GitHub OIDC provider and
+signs the build artifacts. The signed attestations are stored in Sigstore's
+public transparency log, creating a cryptographically verifiable link between
+the source code and the compiled release binaries.
+
+---
+
+## Verifying Release Binaries
+
+To verify that a downloaded TargetBridge release binary is authentic and has
+not been tampered with or built from a malicious fork, you can use the
+**GitHub CLI (`gh`)**.
+
+### Prerequisites
+
+1. Install the GitHub CLI: `brew install gh`
+
+2. Log in to your GitHub account (optional but recommended):
+   ```bash
+   gh auth login
+   ```
+
+### Verification Command
+
+Run the `gh attestation verify` command on the downloaded ZIP file, specifying
+the official repository owner and name:
+
+```bash
+gh attestation verify "/path/to/TargetBridge.app.zip" --owner "swellweb" --repo "targetBridge"
+```
+
+### Expected Successful Output
+
+If the binary is authentic and was built by the official TargetBridge
+pipeline, the command will output a confirmation similar to the following:
+
+```text
+Loaded 1 attestation for TargetBridge.app.zip
+✓ Verified 1 attestation
+✓ Deposited in public transparency log
+✓ Signed by GitHub Actions
+✓ Originated from swellweb/targetBridge (ref: refs/tags/v1.0.0)
+```
+
+> [!IMPORTANT]
+> If verification fails, it indicates that the file was either modified after
+> compilation, generated outside the official GitHub Action runners, or
+> uploaded from an unauthorized fork. Do not run unverified binaries.

--- a/docs/verify-binaries.md
+++ b/docs/verify-binaries.md
@@ -39,7 +39,7 @@ Run the `gh attestation verify` command on the downloaded ZIP file, specifying
 the official repository owner and name:
 
 ```bash
-gh attestation verify "/path/to/TargetBridge.app.zip" --owner "swellweb" --repo "targetBridge"
+gh attestation verify "/path/to/TargetBridge-arm64.app.zip" --owner "swellweb" --repo "targetBridge"
 ```
 
 ### Expected Successful Output
@@ -48,7 +48,7 @@ If the binary is authentic and was built by the official TargetBridge
 pipeline, the command will output a confirmation similar to the following:
 
 ```text
-Loaded 1 attestation for TargetBridge.app.zip
+Loaded 1 attestation for TargetBridge-arm64.app.zip
 ✓ Verified 1 attestation
 ✓ Deposited in public transparency log
 ✓ Signed by GitHub Actions


### PR DESCRIPTION
- also release apple silicon binary
- use -arm64 and -x86_64 in filenames
- add github attestation + docs how to verify release binaries