### PR TITLE
feat(i18n): add Chinese (zh-Hans) UI and Settings sheet refactor

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -6,6 +6,7 @@
  */
 
 #include "display.h"
+#include "i18n.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
@@ -178,29 +179,56 @@ static void tb_disp_rebuild_status_texture(struct tb_display *d,
     tb_disp_fill_rect(ctx, 48, 52, (CGFloat)drawable_w - 96, (CGFloat)drawable_h - 104, 0.12, 0.13, 0.16, 1.0);
     tb_disp_fill_rect(ctx, 48, (CGFloat)drawable_h - 152, (CGFloat)drawable_w - 96, 2, 0.23, 0.25, 0.30, 1.0);
 
-    tb_disp_draw_text(ctx, "TARGETBRIDGE RECEIVER", "Helvetica-Bold", 30, 72, (CGFloat)drawable_h - 76, 0.95, 0.97, 1.0);
-    tb_disp_draw_text(ctx, "5K / HiDPI receiver ready for sender", "Helvetica", 18, 72, (CGFloat)drawable_h - 118, 0.72, 0.76, 0.84);
-    tb_disp_draw_text(ctx, TB_RECEIVER_VERSION, "Menlo-Bold", 18, (CGFloat)drawable_w - 220, (CGFloat)drawable_h - 78, 0.64, 0.69, 0.78);
-    tb_disp_draw_text(ctx, TB_RECEIVER_BUILD, "Menlo", 14, (CGFloat)drawable_w - 220, (CGFloat)drawable_h - 120, 0.53, 0.57, 0.66);
+    /* Pick fonts based on locale. CoreText cannot render CJK glyphs with
+     * Helvetica / Menlo, so when Chinese is active we fall back to
+     * PingFang SC (Semibold) and PingFang SC (Regular) which ship with
+     * macOS. ASCII fields (IP address, version) keep Menlo for the
+     * monospaced look since they only contain digits / latin letters. */
+    const int zh = tb_locale_is_chinese();
+    const char *title_font     = zh ? "PingFangSC-Semibold" : "Helvetica-Bold";
+    const char *body_font      = zh ? "PingFangSC-Regular"  : "Helvetica";
+    const char *section_font   = zh ? "PingFangSC-Semibold" : "Helvetica-Bold";
+    const char *value_font     = zh ? "PingFangSC-Regular"  : "Helvetica";
+    /* IP / mode strings are mostly ASCII numerics; keep monospaced look. */
+    const char *mono_font      = "Menlo";
+    const char *mono_bold_font = "Menlo-Bold";
 
-    tb_disp_draw_text(ctx, "IP THUNDERBOLT BRIDGE", "Helvetica-Bold", 16, 72, (CGFloat)drawable_h - 190, 0.54, 0.62, 0.76);
-    tb_disp_draw_text(ctx, ip, "Menlo-Bold", 36, 72, (CGFloat)drawable_h - 235, 0.43, 0.93, 0.60);
+    tb_disp_draw_text(ctx, tb_tr("TARGETBRIDGE RECEIVER", "TARGETBRIDGE 接收端"),
+                      title_font, 30, 72, (CGFloat)drawable_h - 76, 0.95, 0.97, 1.0);
+    tb_disp_draw_text(ctx, tb_tr("5K / HiDPI receiver ready for sender", "5K / HiDPI 接收端，等待发送端连接"),
+                      body_font, 18, 72, (CGFloat)drawable_h - 118, 0.72, 0.76, 0.84);
+    tb_disp_draw_text(ctx, TB_RECEIVER_VERSION, mono_bold_font, 18, (CGFloat)drawable_w - 220, (CGFloat)drawable_h - 78, 0.64, 0.69, 0.78);
+    tb_disp_draw_text(ctx, TB_RECEIVER_BUILD, mono_font, 14, (CGFloat)drawable_w - 220, (CGFloat)drawable_h - 120, 0.53, 0.57, 0.66);
 
-    tb_disp_draw_text(ctx, "STATUS", "Helvetica-Bold", 16, 72, (CGFloat)drawable_h - 300, 0.54, 0.62, 0.76);
-    tb_disp_draw_text(ctx, status, "Helvetica", 24, 72, (CGFloat)drawable_h - 338, 0.94, 0.96, 0.99);
+    tb_disp_draw_text(ctx, tb_tr("IP THUNDERBOLT BRIDGE", "Thunderbolt Bridge IP"),
+                      section_font, 16, 72, (CGFloat)drawable_h - 190, 0.54, 0.62, 0.76);
+    tb_disp_draw_text(ctx, ip, mono_bold_font, 36, 72, (CGFloat)drawable_h - 235, 0.43, 0.93, 0.60);
 
-    tb_disp_draw_text(ctx, "SENDER", "Helvetica-Bold", 16, 72, (CGFloat)drawable_h - 400, 0.54, 0.62, 0.76);
-    tb_disp_draw_text(ctx, sender, "Helvetica", 22, 72, (CGFloat)drawable_h - 436, 0.94, 0.96, 0.99);
+    tb_disp_draw_text(ctx, tb_tr("STATUS", "状态"),
+                      section_font, 16, 72, (CGFloat)drawable_h - 300, 0.54, 0.62, 0.76);
+    tb_disp_draw_text(ctx, status, value_font, 24, 72, (CGFloat)drawable_h - 338, 0.94, 0.96, 0.99);
 
-    tb_disp_draw_text(ctx, "DISPLAY", "Helvetica-Bold", 16, 72, (CGFloat)drawable_h - 498, 0.54, 0.62, 0.76);
-    tb_disp_draw_text(ctx, panel, "Menlo", 22, 72, (CGFloat)drawable_h - 534, 0.94, 0.96, 0.99);
+    tb_disp_draw_text(ctx, tb_tr("SENDER", "发送端"),
+                      section_font, 16, 72, (CGFloat)drawable_h - 400, 0.54, 0.62, 0.76);
+    tb_disp_draw_text(ctx, sender, value_font, 22, 72, (CGFloat)drawable_h - 436, 0.94, 0.96, 0.99);
 
-    tb_disp_draw_text(ctx, "STREAM PROFILE", "Helvetica-Bold", 16, 72, (CGFloat)drawable_h - 596, 0.54, 0.62, 0.76);
-    tb_disp_draw_text(ctx, mode, "Menlo", 22, 72, (CGFloat)drawable_h - 632, 0.94, 0.96, 0.99);
+    tb_disp_draw_text(ctx, tb_tr("DISPLAY", "显示器"),
+                      section_font, 16, 72, (CGFloat)drawable_h - 498, 0.54, 0.62, 0.76);
+    tb_disp_draw_text(ctx, panel, zh ? value_font : mono_font, 22, 72, (CGFloat)drawable_h - 534, 0.94, 0.96, 0.99);
 
-    tb_disp_draw_text(ctx, "Start the sender on your MacBook and enter this IP address.", "Helvetica", 18, 72, 146, 0.76, 0.80, 0.88);
-    tb_disp_draw_text(ctx, "When the first frame arrives, the receiver switches to fullscreen automatically.", "Helvetica", 18, 72, 116, 0.76, 0.80, 0.88);
-    tb_disp_draw_text(ctx, "If the sender stops, the receiver returns here ready for a new session.", "Helvetica", 18, 72, 86, 0.76, 0.80, 0.88);
+    tb_disp_draw_text(ctx, tb_tr("STREAM PROFILE", "码流配置"),
+                      section_font, 16, 72, (CGFloat)drawable_h - 596, 0.54, 0.62, 0.76);
+    tb_disp_draw_text(ctx, mode, zh ? value_font : mono_font, 22, 72, (CGFloat)drawable_h - 632, 0.94, 0.96, 0.99);
+
+    tb_disp_draw_text(ctx, tb_tr("Start the sender on your MacBook and enter this IP address.",
+                                 "在 MacBook 上启动发送端，并填入上方的 IP 地址。"),
+                      body_font, 18, 72, 146, 0.76, 0.80, 0.88);
+    tb_disp_draw_text(ctx, tb_tr("When the first frame arrives, the receiver switches to fullscreen automatically.",
+                                 "收到第一帧画面后，接收端会自动切换到全屏。"),
+                      body_font, 18, 72, 116, 0.76, 0.80, 0.88);
+    tb_disp_draw_text(ctx, tb_tr("If the sender stops, the receiver returns here ready for a new session.",
+                                 "发送端停止后，接收端会返回此界面，等待下一次会话。"),
+                      body_font, 18, 72, 86, 0.76, 0.80, 0.88);
 
     CGContextRelease(ctx);
 

--- a/TargetBridge-Receiver/TBReceiverC/src/i18n.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/i18n.h
@@ -1,0 +1,61 @@
+/* i18n.h — Lightweight runtime locale switch for the C receiver.
+ *
+ * Header-only (inline) so it does not change the Makefile.
+ *
+ * The receiver reads its preferred language once and then renders all UI
+ * strings (banner, status messages, window title) in that language.
+ *
+ * Selection priority:
+ *   1. TBR_LANG environment variable: "zh" (or "zh-*") -> Chinese,
+ *      anything else (e.g. "en") -> English.
+ *   2. LC_ALL / LANG / LC_MESSAGES: starts with "zh" / "ZH" -> Chinese.
+ *   3. Fallback: English.
+ *
+ * The result is cached after the first call.
+ */
+#ifndef TB_I18N_H
+#define TB_I18N_H
+
+#include <stdlib.h>
+#include <string.h>
+
+static inline int tb_i18n__match_zh(const char *value) {
+    if (!value || !*value) return 0;
+    return (strncmp(value, "zh", 2) == 0) || (strncmp(value, "ZH", 2) == 0);
+}
+
+/* Returns 1 when the receiver should render Chinese text, 0 for English. */
+static inline int tb_locale_is_chinese(void) {
+    static int cached = -1;
+    if (cached != -1) return cached;
+
+    const char *override = getenv("TBR_LANG");
+    if (override && *override) {
+        if (tb_i18n__match_zh(override)) {
+            cached = 1;
+            return 1;
+        }
+        /* Explicit non-zh override (e.g. "en") forces English. */
+        cached = 0;
+        return 0;
+    }
+
+    const char *vars[] = { "LC_ALL", "LC_MESSAGES", "LANG", NULL };
+    for (int i = 0; vars[i]; ++i) {
+        const char *v = getenv(vars[i]);
+        if (tb_i18n__match_zh(v)) {
+            cached = 1;
+            return 1;
+        }
+    }
+
+    cached = 0;
+    return 0;
+}
+
+/* Convenience: pick between an English and a Chinese literal at runtime. */
+static inline const char *tb_tr(const char *en, const char *zh) {
+    return tb_locale_is_chinese() ? zh : en;
+}
+
+#endif /* TB_I18N_H */

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -17,6 +17,7 @@
 #include "decoder.h"
 #include "display.h"
 #include "proto.h"
+#include "i18n.h"
 
 #include <SDL.h>
 #include <dns_sd.h>
@@ -91,7 +92,9 @@ static void on_bonjour_register(DNSServiceRef sdRef,
 static void bonjour_update(struct app *a, uint16_t port) {
     bonjour_deinit(a);
 
-    if (a->ip_text[0] == '\0' || strcmp(a->ip_text, "not detected") == 0) return;
+    if (a->ip_text[0] == '\0' ||
+        strcmp(a->ip_text, "not detected") == 0 ||
+        strcmp(a->ip_text, "未检测到") == 0) return;
 
     TXTRecordRef txt;
     TXTRecordCreate(&txt, 0, NULL);
@@ -215,8 +218,9 @@ static void on_frame(const uint8_t *y, int y_stride,
                      int w, int h, void *ud) {
     struct app *a = (struct app *)ud;
     a->have_video_frame = 1;
-    snprintf(a->status_text, sizeof(a->status_text), "%s", "stream active");
-    snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px receiving", w, h);
+    snprintf(a->status_text, sizeof(a->status_text), "%s", tb_tr("stream active", "码流进行中"));
+    snprintf(a->mode_text, sizeof(a->mode_text),
+             tb_tr("%d x %d px receiving", "正在接收 %d x %d px"), w, h);
     tb_disp_render_nv12(a->disp, y, y_stride, uv, uv_stride, w, h);
     a->frames++;
 }
@@ -229,7 +233,7 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
     case TB_PKT_HELLO_RECEIVER:
         extract_json_string_field(payload, len, "\"senderName\"", a->sender_text, sizeof(a->sender_text));
         if (a->sender_text[0] == '\0') {
-            snprintf(a->sender_text, sizeof(a->sender_text), "%s", "sender connected");
+            snprintf(a->sender_text, sizeof(a->sender_text), "%s", tb_tr("sender connected", "发送端已连接"));
         }
         {
             char preset[64];
@@ -247,23 +251,40 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
             (void)extract_json_int_field(payload, len, "\"captureHeight\"", &capture_h);
 
             if (capture_w > 0 && capture_h > 0 && source[0] != '\0' && preset[0] != '\0' && codec[0] != '\0') {
-                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s, %s, %s)", capture_w, capture_h, source, preset, codec);
+                snprintf(a->mode_text, sizeof(a->mode_text),
+                         tb_tr("%d x %d px requested (%s, %s, %s)",
+                               "请求 %d x %d px（%s，%s，%s）"),
+                         capture_w, capture_h, source, preset, codec);
             } else if (capture_w > 0 && capture_h > 0 && preset[0] != '\0' && codec[0] != '\0') {
-                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s, %s)", capture_w, capture_h, preset, codec);
+                snprintf(a->mode_text, sizeof(a->mode_text),
+                         tb_tr("%d x %d px requested (%s, %s)",
+                               "请求 %d x %d px（%s，%s）"),
+                         capture_w, capture_h, preset, codec);
             } else if (capture_w > 0 && capture_h > 0 && preset[0] != '\0') {
-                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s)", capture_w, capture_h, preset);
+                snprintf(a->mode_text, sizeof(a->mode_text),
+                         tb_tr("%d x %d px requested (%s)",
+                               "请求 %d x %d px（%s）"),
+                         capture_w, capture_h, preset);
             } else if (capture_w > 0 && capture_h > 0 && codec[0] != '\0') {
-                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested (%s)", capture_w, capture_h, codec);
+                snprintf(a->mode_text, sizeof(a->mode_text),
+                         tb_tr("%d x %d px requested (%s)",
+                               "请求 %d x %d px（%s）"),
+                         capture_w, capture_h, codec);
             } else if (capture_w > 0 && capture_h > 0) {
-                snprintf(a->mode_text, sizeof(a->mode_text), "%d x %d px requested", capture_w, capture_h);
+                snprintf(a->mode_text, sizeof(a->mode_text),
+                         tb_tr("%d x %d px requested",
+                               "请求 %d x %d px"),
+                         capture_w, capture_h);
             }
         }
         fprintf(stderr, "[main] hello from sender\n");
-        snprintf(a->status_text, sizeof(a->status_text), "%s", "sender connected, profile sent");
+        snprintf(a->status_text, sizeof(a->status_text), "%s",
+                 tb_tr("sender connected, profile sent", "发送端已连接，已发送配置"));
         break;
     case TB_PKT_CREATE_SESSION_ACK:
         fprintf(stderr, "[main] sender session ack: %.*s\n", (int)len, (const char *)payload);
-        snprintf(a->status_text, sizeof(a->status_text), "%s", "session accepted, waiting for frames");
+        snprintf(a->status_text, sizeof(a->status_text), "%s",
+                 tb_tr("session accepted, waiting for frames", "会话已接受，等待画面帧"));
         break;
     case TB_PKT_PARAM_SETS:
         /* tb_dec_set_param_sets is now a no-op if the sets are unchanged,
@@ -297,7 +318,8 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
         break;
     case TB_PKT_TEARDOWN:
         fprintf(stderr, "[main] teardown requested by sender\n");
-        snprintf(a->status_text, sizeof(a->status_text), "%s", "session closed by sender");
+        snprintf(a->status_text, sizeof(a->status_text), "%s",
+                 tb_tr("session closed by sender", "发送端已关闭会话"));
         a->close_requested = 1;
         break;
     default:
@@ -417,8 +439,10 @@ static void close_client(struct app *a) {
     a->have_video_frame = 0;
     tb_disp_set_connection_state(a->disp, 0);
     tb_disp_set_cursor(a->disp, 0, 0, 1, 1, 0, 0);
-    snprintf(a->status_text, sizeof(a->status_text), "%s", "waiting for sender");
-    snprintf(a->sender_text, sizeof(a->sender_text), "%s", "waiting");
+    snprintf(a->status_text, sizeof(a->status_text), "%s",
+             tb_tr("waiting for sender", "等待发送端"));
+    snprintf(a->sender_text, sizeof(a->sender_text), "%s",
+             tb_tr("waiting", "等待中"));
     tb_parser_free(&a->parser);
     tb_parser_init(&a->parser, on_packet, a);
     tb_dec_reset(a->dec);   /* fresh decoder for next session */
@@ -456,10 +480,15 @@ int main(int argc, char **argv) {
         }
         snprintf(a.bonjour_name, sizeof(a.bonjour_name), "TargetBridge %s", host);
     }
-    snprintf(a.ip_text, sizeof(a.ip_text), "%s", ip[0] ? ip : "not detected");
-    snprintf(a.status_text, sizeof(a.status_text), "%s", "waiting for sender");
-    snprintf(a.sender_text, sizeof(a.sender_text), "%s", "waiting");
-    snprintf(a.mode_text, sizeof(a.mode_text), "%s", "2560 x 1440 HiDPI on 5K display");
+    snprintf(a.ip_text, sizeof(a.ip_text), "%s",
+             ip[0] ? ip : tb_tr("not detected", "未检测到"));
+    snprintf(a.status_text, sizeof(a.status_text), "%s",
+             tb_tr("waiting for sender", "等待发送端"));
+    snprintf(a.sender_text, sizeof(a.sender_text), "%s",
+             tb_tr("waiting", "等待中"));
+    snprintf(a.mode_text, sizeof(a.mode_text), "%s",
+             tb_tr("2560 x 1440 HiDPI on 5K display",
+                   "2560 x 1440 HiDPI（5K 显示器）"));
 
     a.disp = tb_disp_create(fullscreen);
     if (!a.disp) { fprintf(stderr, "tb_disp_create failed\n"); return 1; }
@@ -469,7 +498,8 @@ int main(int argc, char **argv) {
         snprintf(a.panel_text, sizeof(a.panel_text), "%u x %u px (%s)",
                  boot_info.active_w, boot_info.active_h, boot_info.name);
     } else {
-        snprintf(a.panel_text, sizeof(a.panel_text), "%s", "5K display");
+        snprintf(a.panel_text, sizeof(a.panel_text), "%s",
+                 tb_tr("5K display", "5K 显示器"));
     }
     bonjour_update(&a, TB_PORT);
 
@@ -505,8 +535,10 @@ int main(int argc, char **argv) {
             if (c >= 0) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
-                snprintf(a.status_text, sizeof(a.status_text), "%s", "sender connected, negotiating");
-                snprintf(a.sender_text, sizeof(a.sender_text), "%s", "identifying");
+                snprintf(a.status_text, sizeof(a.status_text), "%s",
+                         tb_tr("sender connected, negotiating", "发送端已连接，协商中"));
+                snprintf(a.sender_text, sizeof(a.sender_text), "%s",
+                         tb_tr("identifying", "识别中"));
                 fprintf(stderr, "[main] client connected\n");
                 send_receiver_info(&a);
             }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -2,21 +2,19 @@ import SwiftUI
 
 struct TBDisplaySenderContentView: View {
     @ObservedObject var service: TBDisplaySenderService
+    @State private var showsSettings = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 headerCard
                 connectionCard
-                languageCard
 
                 ForEach(service.sessions) { session in
                     TBDisplaySenderSessionCard(service: service, session: session)
                 }
 
                 modeCard
-
-                settingsCard
 
                 HStack {
                     Spacer()
@@ -31,6 +29,9 @@ struct TBDisplaySenderContentView: View {
         .background(Color.black.opacity(0.02))
         .task {
             service.refreshBridgeInterfaces()
+        }
+        .sheet(isPresented: $showsSettings) {
+            TBDisplaySenderSettingsView(service: service, isPresented: $showsSettings)
         }
     }
 
@@ -66,10 +67,29 @@ struct TBDisplaySenderContentView: View {
                 Spacer(minLength: 16)
 
                 VStack(alignment: .trailing, spacing: 8) {
-                    statusChip(
-                        service.summaryStatusText(),
-                        tint: service.anyStreaming ? .green : .secondary
-                    )
+                    HStack(spacing: 8) {
+                        statusChip(
+                            service.summaryStatusText(),
+                            tint: service.anyStreaming ? .green : .secondary
+                        )
+                        Button {
+                            showsSettings = true
+                        } label: {
+                            Image(systemName: "gearshape.fill")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(8)
+                                .background(
+                                    Circle().fill(Color.white.opacity(0.06))
+                                )
+                                .overlay(
+                                    Circle().strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(TBDisplaySenderL10n.settingsButtonAccessibility(service.language))
+                        .accessibilityLabel(TBDisplaySenderL10n.settingsButtonAccessibility(service.language))
+                    }
                     Text(service.bridgeSummaryText)
                         .font(.system(.footnote, design: .monospaced))
                         .foregroundStyle(.secondary)
@@ -121,21 +141,6 @@ struct TBDisplaySenderContentView: View {
         }
     }
 
-    private var languageCard: some View {
-        SurfaceCard {
-            VStack(alignment: .leading, spacing: 12) {
-                sectionHeading(TBDisplaySenderL10n.languageGroup(service.language))
-                Picker(TBDisplaySenderL10n.languageGroup(service.language), selection: $service.language) {
-                    ForEach(TBDisplaySenderLanguage.allCases) { language in
-                        Text(language.pickerTitle).tag(language)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.segmented)
-            }
-        }
-    }
-
     private var modeCard: some View {
         SurfaceCard {
             VStack(alignment: .leading, spacing: 10) {
@@ -154,32 +159,11 @@ struct TBDisplaySenderContentView: View {
         }
     }
 
-    private var settingsCard: some View {
-        SurfaceCard {
-            VStack(alignment: .leading, spacing: 12) {
-                sectionHeading(settingsTitle)
-
-                Toggle(TBDisplaySenderL10n.showMenuBarIcon(service.language), isOn: $service.showsMenuBarIcon)
-
-                Toggle(TBDisplaySenderL10n.largeCursor(service.language), isOn: $service.largeCursor)
-                    .disabled(service.anyConnected)
-            }
-        }
-    }
-
     private func sectionHeading(_ title: String) -> some View {
         Text(title.uppercased())
             .font(.system(.caption, design: .rounded, weight: .bold))
             .tracking(1.1)
             .foregroundStyle(.secondary)
-    }
-
-    private var settingsTitle: String {
-        switch service.language {
-        case .italian: return "Preferenze"
-        case .english: return "Settings"
-        case .german: return "Einstellungen"
-        }
     }
 
     private func statusChip(_ text: String, tint: Color) -> some View {
@@ -196,6 +180,89 @@ struct TBDisplaySenderContentView: View {
                 Capsule(style: .continuous)
                     .stroke(tint.opacity(0.28), lineWidth: 1)
             )
+    }
+}
+
+// MARK: - Settings sheet
+
+struct TBDisplaySenderSettingsView: View {
+    @ObservedObject var service: TBDisplaySenderService
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(TBDisplaySenderL10n.settingsTitle(service.language))
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                Spacer()
+                Button(TBDisplaySenderL10n.settingsDoneButton(service.language)) {
+                    isPresented = false
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    languageSection
+                    appearanceSection
+                    aboutSection
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(width: 460, height: 420)
+    }
+
+    private var languageSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeading(TBDisplaySenderL10n.settingsLanguageSection(service.language))
+            Picker(TBDisplaySenderL10n.settingsLanguageSection(service.language), selection: $service.language) {
+                ForEach(TBDisplaySenderLanguage.allCases) { language in
+                    Text(language.pickerTitle).tag(language)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var appearanceSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeading(TBDisplaySenderL10n.settingsAppearanceSection(service.language))
+            Toggle(TBDisplaySenderL10n.showMenuBarIcon(service.language), isOn: $service.showsMenuBarIcon)
+            Toggle(TBDisplaySenderL10n.largeCursor(service.language), isOn: $service.largeCursor)
+                .disabled(service.anyConnected)
+        }
+    }
+
+    private var aboutSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeading(TBDisplaySenderL10n.settingsAboutSection(service.language))
+            HStack {
+                Text(TBDisplaySenderL10n.appName(service.language))
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text(TBDisplaySenderBuildInfo.versionDisplay)
+                    .font(.system(.subheadline, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Text(TBDisplaySenderL10n.appSubtitle(service.language))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func sectionHeading(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(.caption, design: .rounded, weight: .bold))
+            .tracking(1.1)
+            .foregroundStyle(.secondary)
     }
 }
 
@@ -414,6 +481,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "Instradamento"
         case .english: return "Routing"
         case .german: return "Verbindung"
+        case .chinese: return "路由"
         }
     }
 
@@ -422,6 +490,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "Uscita"
         case .english: return "Output"
         case .german: return "Ausgabe"
+        case .chinese: return "输出"
         }
     }
 
@@ -430,6 +499,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "Sessione Monitor"
         case .english: return "Session Monitor"
         case .german: return "Monitor-Sitzung"
+        case .chinese: return "会话监视"
         }
     }
 
@@ -438,6 +508,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "Attivo"
         case .english: return "Live"
         case .german: return "Aktiv"
+        case .chinese: return "进行中"
         }
     }
 
@@ -446,6 +517,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "Connesso"
         case .english: return "Connected"
         case .german: return "Verbunden"
+        case .chinese: return "已连接"
         }
     }
 
@@ -454,6 +526,7 @@ private struct TBDisplaySenderSessionCard: View {
         case .italian: return "In attesa"
         case .english: return "Idle"
         case .german: return "Bereit"
+        case .chinese: return "空闲"
         }
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -4,6 +4,7 @@ enum TBDisplaySenderLanguage: String, CaseIterable, Identifiable {
     case italian
     case english
     case german
+    case chinese
 
     static let defaultsKey = "fd.tbdisplaysender.language"
 
@@ -14,15 +15,34 @@ enum TBDisplaySenderLanguage: String, CaseIterable, Identifiable {
         case .italian: return "Italiano"
         case .english: return "English"
         case .german: return "Deutsch"
+        case .chinese: return "中文"
         }
     }
 
+    /// Loads the language from UserDefaults if previously persisted.
+    /// Otherwise picks a sensible default based on the system locale:
+    ///   * zh-Hans / zh-Hant / zh-CN / zh-TW … → .chinese
+    ///   * it-* → .italian
+    ///   * de-* → .german
+    ///   * everything else → .english
     static func load() -> TBDisplaySenderLanguage {
-        guard let raw = UserDefaults.standard.string(forKey: defaultsKey),
-              let language = TBDisplaySenderLanguage(rawValue: raw) else {
-            return .italian
+        if let raw = UserDefaults.standard.string(forKey: defaultsKey),
+           let language = TBDisplaySenderLanguage(rawValue: raw) {
+            return language
         }
-        return language
+        return preferredFromLocale()
+    }
+
+    private static func preferredFromLocale() -> TBDisplaySenderLanguage {
+        let candidates = Locale.preferredLanguages + [Locale.current.identifier]
+        for raw in candidates {
+            let lower = raw.lowercased()
+            if lower.hasPrefix("zh") { return .chinese }
+            if lower.hasPrefix("it") { return .italian }
+            if lower.hasPrefix("de") { return .german }
+            if lower.hasPrefix("en") { return .english }
+        }
+        return .english
     }
 
     func persist() {
@@ -57,50 +77,62 @@ enum TBDisplaySenderStatusState {
         case (.ready, .italian): return "Pronto"
         case (.ready, .english): return "Ready"
         case (.ready, .german): return "Bereit"
+        case (.ready, .chinese): return "就绪"
 
         case let (.connecting(ip), .italian): return "Connessione a \(ip)…"
         case let (.connecting(ip), .english): return "Connecting to \(ip)…"
         case let (.connecting(ip), .german): return "Verbinden mit \(ip)…"
+        case let (.connecting(ip), .chinese): return "正在连接 \(ip)…"
 
         case (.testingCable, .italian): return "Test del cavo in corso…"
         case (.testingCable, .english): return "Testing cable performance…"
         case (.testingCable, .german): return "Kabel-Performance wird getestet…"
+        case (.testingCable, .chinese): return "正在测试线缆性能…"
 
         case (.waitingDisplayProfile, .italian): return "Receiver connesso, attendo profilo display…"
         case (.waitingDisplayProfile, .english): return "Receiver connected, waiting for display profile…"
         case (.waitingDisplayProfile, .german): return "Empfänger verbunden, warte auf Display-Profil…"
+        case (.waitingDisplayProfile, .chinese): return "接收端已连接，等待显示配置…"
 
         case let (.connectionFailed(error), .italian): return "Connessione fallita: \(error)"
         case let (.connectionFailed(error), .english): return "Connection failed: \(error)"
         case let (.connectionFailed(error), .german): return "Verbindung fehlgeschlagen: \(error)"
+        case let (.connectionFailed(error), .chinese): return "连接失败：\(error)"
 
         case (.stopped, .italian): return "Interrotto"
         case (.stopped, .english): return "Stopped"
         case (.stopped, .german): return "Gestoppt"
+        case (.stopped, .chinese): return "已停止"
 
         case let (.connectionClosed(error), .italian): return "Connessione chiusa: \(error)"
         case let (.connectionClosed(error), .english): return "Connection closed: \(error)"
         case let (.connectionClosed(error), .german): return "Verbindung geschlossen: \(error)"
+        case let (.connectionClosed(error), .chinese): return "连接已关闭：\(error)"
 
         case (.receiverClosedDuringCapture, .italian): return "Receiver chiuso durante l'avvio cattura"
         case (.receiverClosedDuringCapture, .english): return "Receiver closed while capture was starting"
         case (.receiverClosedDuringCapture, .german): return "Empfänger während des Aufnahmestarts geschlossen"
+        case (.receiverClosedDuringCapture, .chinese): return "捕获启动时接收端已关闭"
 
         case (.receiverClosedConnection, .italian): return "Receiver ha chiuso la connessione"
         case (.receiverClosedConnection, .english): return "Receiver closed the connection"
         case (.receiverClosedConnection, .german): return "Empfänger hat die Verbindung geschlossen"
+        case (.receiverClosedConnection, .chinese): return "接收端已关闭连接"
 
         case (.receiverTerminatedSession, .italian): return "Receiver ha terminato la sessione"
         case (.receiverTerminatedSession, .english): return "Receiver terminated the session"
         case (.receiverTerminatedSession, .german): return "Empfänger hat die Sitzung beendet"
+        case (.receiverTerminatedSession, .chinese): return "接收端已终止会话"
 
         case (.creatingVirtualDisplay, .italian): return "Creo virtual display…"
         case (.creatingVirtualDisplay, .english): return "Creating virtual display…"
         case (.creatingVirtualDisplay, .german): return "Virtuelles Display wird erstellt…"
+        case (.creatingVirtualDisplay, .chinese): return "正在创建虚拟显示器…"
 
         case (.virtualDisplayCreationFailed, .italian): return "Creazione virtual display fallita"
         case (.virtualDisplayCreationFailed, .english): return "Virtual display creation failed"
         case (.virtualDisplayCreationFailed, .german): return "Virtuelles Display konnte nicht erstellt werden"
+        case (.virtualDisplayCreationFailed, .chinese): return "虚拟显示器创建失败"
 
         case let (.startingCapture(resolution, source), .italian):
             return "Avvio \(source.title(language).lowercased()) (\(resolution))…"
@@ -108,34 +140,43 @@ enum TBDisplaySenderStatusState {
             return "Starting \(source.title(language).lowercased()) capture (\(resolution))…"
         case let (.startingCapture(resolution, source), .german):
             return "\(source.title(language)) wird gestartet (\(resolution))…"
+        case let (.startingCapture(resolution, source), .chinese):
+            return "正在启动 \(source.title(language))（\(resolution)）…"
 
         case (.captureStartedWaitingFirstFrame, .italian): return "Cattura avviata, attendo il primo frame…"
         case (.captureStartedWaitingFirstFrame, .english): return "Capture started, waiting for the first frame…"
         case (.captureStartedWaitingFirstFrame, .german): return "Aufnahme gestartet, warte auf ersten Bildinhalt…"
+        case (.captureStartedWaitingFirstFrame, .chinese): return "捕获已启动，等待首帧…"
 
         case let (.captureActive(resolution, codec, source), .italian): return "\(source.title(language)) attivo (\(resolution), \(codec))"
         case let (.captureActive(resolution, codec, source), .english): return "\(source.title(language)) active (\(resolution), \(codec))"
         case let (.captureActive(resolution, codec, source), .german): return "\(source.title(language)) aktiv (\(resolution), \(codec))"
+        case let (.captureActive(resolution, codec, source), .chinese): return "\(source.title(language)) 进行中（\(resolution)，\(codec)）"
 
         case let (.captureError(error), .italian): return "Errore capture: \(error)"
         case let (.captureError(error), .english): return "Capture error: \(error)"
         case let (.captureError(error), .german): return "Aufnahmefehler: \(error)"
+        case let (.captureError(error), .chinese): return "捕获错误：\(error)"
 
         case let (.captureDesktopError(error), .italian): return "Errore cattura desktop: \(error)"
         case let (.captureDesktopError(error), .english): return "Desktop capture error: \(error)"
         case let (.captureDesktopError(error), .german): return "Desktop-Aufnahmefehler: \(error)"
+        case let (.captureDesktopError(error), .chinese): return "桌面捕获错误：\(error)"
 
         case let (.noShareableDisplay(details), .italian): return details
         case let (.noShareableDisplay(details), .english): return details
         case let (.noShareableDisplay(details), .german): return details
+        case let (.noShareableDisplay(details), .chinese): return details
 
         case (.hevcNoFrames, .italian): return "5K avviato ma il path HEVC non sta producendo frame"
         case (.hevcNoFrames, .english): return "5K started but the HEVC path is not producing frames"
         case (.hevcNoFrames, .german): return "5K gestartet, aber der HEVC-Pfad erzeugt keine Bildinhalte"
+        case (.hevcNoFrames, .chinese): return "5K 已启动，但 HEVC 通道未输出任何帧"
 
         case (.noFirstFrame, .italian): return "Cattura avviata ma non e' arrivato il primo frame"
         case (.noFirstFrame, .english): return "Capture started but the first frame never arrived"
         case (.noFirstFrame, .german): return "Aufnahme gestartet, aber der erste Bildinhalt ist nie angekommen"
+        case (.noFirstFrame, .chinese): return "捕获已启动，但始终未收到首帧"
         }
     }
 }
@@ -153,6 +194,8 @@ enum TBDisplaySenderL10n {
             return "Creates an iMac virtual display on macOS and sends its contents to the 5K receiver."
         case .german:
             return "Erstellt ein virtuelles iMac-Display auf macOS und sendet dessen Inhalt an den 5K-Empfänger."
+        case .chinese:
+            return "在 macOS 上创建一个 iMac 虚拟显示器，并将其内容发送到 5K 接收端。"
         }
     }
 
@@ -161,6 +204,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Test Cavo"
         case .english: return "Cable Test"
         case .german: return "Kabeltest"
+        case .chinese: return "线缆测试"
         }
     }
 
@@ -169,6 +213,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Esegui Test Cavo"
         case .english: return "Run Cable Test"
         case .german: return "Kabeltest ausführen"
+        case .chinese: return "运行线缆测试"
         }
     }
 
@@ -177,6 +222,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Test in corso…"
         case .english: return "Testing…"
         case .german: return "Test läuft…"
+        case .chinese: return "测试中…"
         }
     }
 
@@ -185,6 +231,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Velocità:"
         case .english: return "Transfer Rate:"
         case .german: return "Übertragungsrate:"
+        case .chinese: return "传输速率："
         }
     }
 
@@ -193,6 +240,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Nessun test eseguito"
         case .english: return "No test run yet"
         case .german: return "Noch kein Test ausgeführt"
+        case .chinese: return "尚未运行测试"
         }
     }
 
@@ -201,6 +249,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Connessione"
         case .english: return "Connection"
         case .german: return "Verbindung"
+        case .chinese: return "连接"
         }
     }
 
@@ -209,6 +258,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "IP Thunderbolt locale"
         case .english: return "Local Thunderbolt IP"
         case .german: return "Lokale Thunderbolt-IP"
+        case .chinese: return "本机 Thunderbolt IP"
         }
     }
 
@@ -217,6 +267,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Interfacce Thunderbolt"
         case .english: return "Thunderbolt interfaces"
         case .german: return "Thunderbolt-Schnittstellen"
+        case .chinese: return "Thunderbolt 接口"
         }
     }
 
@@ -225,6 +276,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Non rilevato"
         case .english: return "Not detected"
         case .german: return "Nicht erkannt"
+        case .chinese: return "未检测到"
         }
     }
 
@@ -233,6 +285,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "IP receiver"
         case .english: return "Receiver IP"
         case .german: return "Empfänger-IP"
+        case .chinese: return "接收端 IP"
         }
     }
 
@@ -241,6 +294,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Receiver trovato"
         case .english: return "Discovered receiver"
         case .german: return "Gefundener Empfänger"
+        case .chinese: return "已发现的接收端"
         }
     }
 
@@ -249,6 +303,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Inserimento manuale"
         case .english: return "Manual entry"
         case .german: return "Manuelle Eingabe"
+        case .chinese: return "手动输入"
         }
     }
 
@@ -257,11 +312,15 @@ enum TBDisplaySenderL10n {
         case .italian: return "Connetti"
         case .english: return "Connect"
         case .german: return "Verbinden"
+        case .chinese: return "连接"
         }
     }
 
     static func stopButton(_ language: TBDisplaySenderLanguage) -> String {
-        "Stop"
+        switch language {
+        case .chinese: return "停止"
+        default: return "Stop"
+        }
     }
 
     static func refreshIPButton(_ language: TBDisplaySenderLanguage) -> String {
@@ -269,6 +328,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Aggiorna IP"
         case .english: return "Refresh IP"
         case .german: return "IP aktualisieren"
+        case .chinese: return "刷新 IP"
         }
     }
 
@@ -277,6 +337,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Aggiungi sessione"
         case .english: return "Add session"
         case .german: return "Sitzung hinzufügen"
+        case .chinese: return "新增会话"
         }
     }
 
@@ -285,6 +346,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Ferma tutto"
         case .english: return "Stop all"
         case .german: return "Alle stoppen"
+        case .chinese: return "全部停止"
         }
     }
 
@@ -293,6 +355,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Rimuovi sessione"
         case .english: return "Remove session"
         case .german: return "Sitzung entfernen"
+        case .chinese: return "移除会话"
         }
     }
 
@@ -301,6 +364,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Lingua"
         case .english: return "Language"
         case .german: return "Sprache"
+        case .chinese: return "语言"
         }
     }
 
@@ -309,6 +373,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Risoluzione stream"
         case .english: return "Stream resolution"
         case .german: return "Stream-Auflösung"
+        case .chinese: return "码流分辨率"
         }
     }
 
@@ -317,6 +382,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Profilo stream"
         case .english: return "Stream profile"
         case .german: return "Stream-Profil"
+        case .chinese: return "码流配置"
         }
     }
 
@@ -325,6 +391,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Sorgente"
         case .english: return "Source"
         case .german: return "Quelle"
+        case .chinese: return "来源"
         }
     }
 
@@ -336,6 +403,8 @@ enum TBDisplaySenderL10n {
             return "`Duplicate Desktop` creates a virtual monitor and mirrors the main display onto it. `Extended Desktop` creates a separate virtual monitor visible in Display Settings."
         case .german:
             return "`Desktop duplizieren` erstellt ein virtuelles Display und spiegelt den Hauptbildschirm darauf. `Erweiterter Desktop` erstellt ein separates virtuelles Display, das in den Anzeigeeinstellungen sichtbar ist."
+        case .chinese:
+            return "`镜像桌面` 会创建一个虚拟显示器，并将主屏镜像到上面。`扩展桌面` 会创建一个独立的虚拟显示器，可在「显示器」设置中看到。"
         }
     }
 
@@ -347,6 +416,8 @@ enum TBDisplaySenderL10n {
             return "`Smooth+` prioritizes motion. `Crisp` improves clarity. `5K` maximizes pixels."
         case .german:
             return "`Smooth+` bevorzugt flüssige Bewegung. `Crisp` verbessert die Schärfe. `5K` maximiert die Pixel."
+        case .chinese:
+            return "`Smooth+` 偏向流畅。`Crisp` 提升清晰度。`5K` 像素最高。"
         }
     }
 
@@ -358,6 +429,8 @@ enum TBDisplaySenderL10n {
             return "Each session uses its own local Thunderbolt IP and an independent stream to its target iMac."
         case .german:
             return "Jede Sitzung verwendet eine eigene lokale Thunderbolt-IP und einen unabhängigen Stream zu ihrem Ziel-iMac."
+        case .chinese:
+            return "每个会话独占一个本机 Thunderbolt IP，向各自的 iMac 推送独立的码流。"
         }
     }
 
@@ -369,14 +442,17 @@ enum TBDisplaySenderL10n {
             return "Selecting a discovered receiver fills in the receiver IP automatically."
         case .german:
             return "Wenn du einen gefundenen Empfänger auswählst, wird die Empfänger-IP automatisch eingetragen."
+        case .chinese:
+            return "选择已发现的接收端时，接收端 IP 会自动填入。"
         }
     }
 
     static func monitorSessionGroup(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Sessione monitor"
-        case .english: return "Monitor session"  // "Monitor" means "Display/Screen" here (noun)
+        case .english: return "Monitor session"
         case .german: return "Bildschirmsitzung"
+        case .chinese: return "显示会话"
         }
     }
 
@@ -385,6 +461,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Receiver"
         case .english: return "Receiver"
         case .german: return "Empfänger"
+        case .chinese: return "接收端"
         }
     }
 
@@ -393,11 +470,15 @@ enum TBDisplaySenderL10n {
         case .italian: return "Virtual display"
         case .english: return "Virtual display"
         case .german: return "Virtuelles Display"
+        case .chinese: return "虚拟显示器"
         }
     }
 
     static func streamLabel(_ language: TBDisplaySenderLanguage) -> String {
-        "Stream"
+        switch language {
+        case .chinese: return "码流"
+        default: return "Stream"
+        }
     }
 
     static func fpsLabel(_ language: TBDisplaySenderLanguage) -> String {
@@ -405,6 +486,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "FPS sender"
         case .english: return "Sender FPS"
         case .german: return "Sender-FPS"
+        case .chinese: return "发送端 FPS"
         }
     }
 
@@ -413,6 +495,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Modalità v1"
         case .english: return "Mode v1"
         case .german: return "Modus v1"
+        case .chinese: return "v1 模式"
         }
     }
 
@@ -421,6 +504,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Pannello iMac target: 5120 × 2880 (5K)"
         case .english: return "Target iMac panel: 5120 × 2880 (5K)"
         case .german: return "Ziel-iMac-Bildschirm: 5120 × 2880 (5K)"
+        case .chinese: return "目标 iMac 面板：5120 × 2880（5K）"
         }
     }
 
@@ -429,6 +513,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Monitor esposto al MacBook: 2560 × 1440 HiDPI @ 60 Hz"
         case .english: return "Display exposed to the MacBook: 2560 × 1440 HiDPI @ 60 Hz"
         case .german: return "Dem MacBook bereitgestelltes Display: 2560 × 1440 HiDPI @ 60 Hz"
+        case .chinese: return "暴露给 MacBook 的显示器：2560 × 1440 HiDPI @ 60 Hz"
         }
     }
 
@@ -437,6 +522,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Pipeline: virtual display reale (esteso o mirror) → capture diretta → codec hardware → TCP"
         case .english: return "Pipeline: real virtual display (extended or mirrored) → direct capture → hardware codec → TCP"
         case .german: return "Pipeline: echtes virtuelles Display (erweitert oder gespiegelt) → direkte Aufnahme → Hardware-Codec → TCP"
+        case .chinese: return "流水线：真实虚拟显示器（扩展或镜像）→ 直接捕获 → 硬件编码 → TCP"
         }
     }
 
@@ -445,6 +531,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Il receiver va in fullscreen solo quando arriva il primo frame."
         case .english: return "The receiver switches to fullscreen only when the first frame arrives."
         case .german: return "Der Empfänger schaltet erst auf Vollbild um, wenn der erste Bildinhalt ankommt."
+        case .chinese: return "接收端仅在收到首帧后才会切换到全屏。"
         }
     }
 
@@ -453,6 +540,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Scegli la sorgente, poi bilancia fluidità e nitidezza col profilo stream."
         case .english: return "Choose the source, then balance motion and clarity with the stream profile."
         case .german: return "Quelle wählen, dann Bewegungsfluss und Schärfe mit dem Stream-Profil abstimmen."
+        case .chinese: return "先选择来源，再用码流配置在流畅度与清晰度之间取舍。"
         }
     }
 
@@ -461,6 +549,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Versione"
         case .english: return "Version"
         case .german: return "Version"
+        case .chinese: return "版本"
         }
     }
 
@@ -469,6 +558,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Mostra icona nella topbar"
         case .english: return "Show icon in top bar"
         case .german: return "Symbol in Menüleiste anzeigen"
+        case .chinese: return "在菜单栏显示图标"
         }
     }
 
@@ -477,6 +567,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Cursore ingrandito sul receiver"
         case .english: return "Large cursor on receiver"
         case .german: return "Großer Zeiger auf dem Empfänger"
+        case .chinese: return "在接收端使用大光标"
         }
     }
 
@@ -485,6 +576,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Mostra finestra principale"
         case .english: return "Show main window"
         case .german: return "Hauptfenster anzeigen"
+        case .chinese: return "显示主窗口"
         }
     }
 
@@ -493,6 +585,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "IP TB: \(ip)"
         case .english: return "TB IP: \(ip)"
         case .german: return "TB-IP: \(ip)"
+        case .chinese: return "TB IP：\(ip)"
         }
     }
 
@@ -501,6 +594,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Sessione \(index)"
         case .english: return "Session \(index)"
         case .german: return "Sitzung \(index)"
+        case .chinese: return "会话 \(index)"
         }
     }
 
@@ -509,6 +603,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "\(active) sessioni collegate su \(total)"
         case .english: return "\(active) connected sessions of \(total)"
         case .german: return "\(active) verbundene Sitzungen von \(total)"
+        case .chinese: return "\(total) 个会话中已连接 \(active) 个"
         }
     }
 
@@ -517,6 +612,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "\(active) sessioni attive su \(total)"
         case .english: return "\(active) active sessions of \(total)"
         case .german: return "\(active) aktive Sitzungen von \(total)"
+        case .chinese: return "\(total) 个会话中活跃 \(active) 个"
         }
     }
 
@@ -525,6 +621,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Nascondi icona dalla topbar"
         case .english: return "Hide top bar icon"
         case .german: return "Symbol in Menüleiste ausblenden"
+        case .chinese: return "隐藏菜单栏图标"
         }
     }
 
@@ -533,6 +630,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Esci da TargetBridge"
         case .english: return "Quit TargetBridge"
         case .german: return "TargetBridge beenden"
+        case .chinese: return "退出 TargetBridge"
         }
     }
 
@@ -544,6 +642,8 @@ enum TBDisplaySenderL10n {
             return "TargetBridge - Software target display monitor"
         case .german:
             return "TargetBridge - Software Target-Display-Monitor"
+        case .chinese:
+            return "TargetBridge - 软件目标显示器"
         }
     }
 
@@ -552,6 +652,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "In attesa del profilo receiver"
         case .english: return "Waiting for receiver profile"
         case .german: return "Warte auf Empfänger-Profil"
+        case .chinese: return "正在等待接收端配置"
         }
     }
 
@@ -560,6 +661,7 @@ enum TBDisplaySenderL10n {
         case .italian: return "Virtual display non creato"
         case .english: return "Virtual display not created"
         case .german: return "Virtuelles Display nicht erstellt"
+        case .chinese: return "尚未创建虚拟显示器"
         }
     }
 
@@ -571,6 +673,8 @@ enum TBDisplaySenderL10n {
             return "\(profile.receiverName): panel \(profile.panelWidth)×\(profile.panelHeight), mode \(profile.modeWidth)×\(profile.modeHeight) HiDPI"
         case .german:
             return "\(profile.receiverName): Panel \(profile.panelWidth)×\(profile.panelHeight), Modus \(profile.modeWidth)×\(profile.modeHeight) HiDPI"
+        case .chinese:
+            return "\(profile.receiverName)：面板 \(profile.panelWidth)×\(profile.panelHeight)，模式 \(profile.modeWidth)×\(profile.modeHeight) HiDPI"
         }
     }
 
@@ -582,6 +686,8 @@ enum TBDisplaySenderL10n {
             return "Virtual display: \(name) (\(id))"
         case .german:
             return "Virtuelles Display: \(name) (\(id))"
+        case .chinese:
+            return "虚拟显示器：\(name)（\(id)）"
         }
     }
 
@@ -597,6 +703,8 @@ enum TBDisplaySenderL10n {
             return "TargetBridge does not have Screen Recording permission. Check Privacy & Security > Screen Recording."
         case .german:
             return "TargetBridge hat keine Berechtigung für die Bildschirmaufnahme. Überprüfen Sie Systemeinstellungen > Datenschutz & Sicherheit > Bildschirmaufnahme."
+        case .chinese:
+            return "TargetBridge 没有「屏幕录制」权限。请前往「隐私与安全性 → 屏幕录制」检查。"
         }
     }
 
@@ -608,28 +716,76 @@ enum TBDisplaySenderL10n {
             return "ScreenCaptureKit failed even though Screen Recording permission appears granted. Details: \(details)"
         case .german:
             return "ScreenCaptureKit fehlgeschlagen, obwohl die Berechtigung zur Bildschirmaufnahme erteilt zu sein scheint. Details: \(details)"
+        case .chinese:
+            return "屏幕录制权限看起来已授予，但 ScreenCaptureKit 仍然失败。详情：\(details)"
+        }
+    }
+
+    // MARK: - Settings sheet (introduced when languageCard was moved into a Settings sheet)
+
+    static func settingsTitle(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Preferenze"
+        case .english: return "Settings"
+        case .german: return "Einstellungen"
+        case .chinese: return "设置"
+        }
+    }
+
+    static func settingsDoneButton(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Fatto"
+        case .english: return "Done"
+        case .german: return "Fertig"
+        case .chinese: return "完成"
+        }
+    }
+
+    static func settingsLanguageSection(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Lingua"
+        case .english: return "Language"
+        case .german: return "Sprache"
+        case .chinese: return "语言"
+        }
+    }
+
+    static func settingsAppearanceSection(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Aspetto"
+        case .english: return "Appearance"
+        case .german: return "Darstellung"
+        case .chinese: return "外观"
+        }
+    }
+
+    static func settingsAboutSection(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Informazioni"
+        case .english: return "About"
+        case .german: return "Über"
+        case .chinese: return "关于"
+        }
+    }
+
+    static func settingsButtonAccessibility(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Apri preferenze"
+        case .english: return "Open settings"
+        case .german: return "Einstellungen öffnen"
+        case .chinese: return "打开设置"
         }
     }
 }
 
 extension TBDisplayCapturePreset {
     func title(_ language: TBDisplaySenderLanguage) -> String {
-        switch (self, language) {
-        case (.standard1440p, .italian): return "Standard"
-        case (.standard1440p, .english): return "Standard"
-        case (.standard1440p, .german): return "Standard"
-        case (.smooth1440p60, .italian): return "Smooth"
-        case (.smooth1440p60, .english): return "Smooth"
-        case (.smooth1440p60, .german): return "Smooth"
-        case (.smooth1800p60, .italian): return "Smooth+"
-        case (.smooth1800p60, .english): return "Smooth+"
-        case (.smooth1800p60, .german): return "Smooth+"
-        case (.crisp2160p60, .italian): return "Crisp"
-        case (.crisp2160p60, .english): return "Crisp"
-        case (.crisp2160p60, .german): return "Crisp"
-        case (.native5k, .italian): return "5K"
-        case (.native5k, .english): return "5K"
-        case (.native5k, .german): return "5K"
+        switch self {
+        case .standard1440p: return "Standard"
+        case .smooth1440p60: return "Smooth"
+        case .smooth1800p60: return "Smooth+"
+        case .crisp2160p60:  return "Crisp"
+        case .native5k:      return "5K"
         }
     }
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -232,9 +232,11 @@ enum TBDisplayCaptureSource: String, CaseIterable, Identifiable {
         case (.desktopMirror, .italian): return "Duplica Desktop"
         case (.desktopMirror, .english): return "Duplicate Desktop"
         case (.desktopMirror, .german): return "Desktop duplizieren"
+        case (.desktopMirror, .chinese): return "镜像桌面"
         case (.extendedDesktop, .italian): return "Desktop Esteso"
         case (.extendedDesktop, .english): return "Extended Desktop"
         case (.extendedDesktop, .german): return "Erweiterter Desktop"
+        case (.extendedDesktop, .chinese): return "扩展桌面"
         }
     }
 

--- a/localization/translations.draft.json
+++ b/localization/translations.draft.json
@@ -1,0 +1,470 @@
+{
+  "$comment": "Draft localization payload pending the upstream JSON localization schema. Keys mirror existing Swift L10n function names (sender) and C tb_tr() call sites (receiver) for easy cross-reference. Placeholders use {name} syntax — translate to ICU / printf / Swift interpolation as needed when wiring into the real runtime. Generated from branch feat/i18n-chinese-ui; safe to discard the Swift/C edits in that branch and reuse only this file.",
+  "metadata": {
+    "schemaVersion": "draft-0.1",
+    "languages": {
+      "it": "Italiano",
+      "en": "English",
+      "de": "Deutsch",
+      "zh-Hans": "简体中文"
+    },
+    "sourceBranch": "feat/i18n-chinese-ui",
+    "generatedAt": "2026-05-22",
+    "notes": [
+      "Sender entries cover all 4 languages because Italian / English / German already existed upstream; only the 'zh-Hans' values are new in this PR.",
+      "Receiver entries only carry 'en' + 'zh-Hans' because the C receiver was English-only prior to this branch.",
+      "Placeholder convention: {name} (e.g. {ip}, {error}, {width}). For receiver entries derived from printf-style C strings, the 'placeholders' array records the original positional order of %d / %s."
+    ]
+  },
+
+  "sender": {
+    "language.pickerTitle": {
+      "it": "Italiano", "en": "English", "de": "Deutsch", "zh-Hans": "中文"
+    },
+
+    "status.ready": {
+      "it": "Pronto", "en": "Ready", "de": "Bereit", "zh-Hans": "就绪"
+    },
+    "status.connecting": {
+      "placeholders": ["ip"],
+      "it": "Connessione a {ip}…", "en": "Connecting to {ip}…", "de": "Verbinden mit {ip}…", "zh-Hans": "正在连接 {ip}…"
+    },
+    "status.testingCable": {
+      "it": "Test del cavo in corso…", "en": "Testing cable performance…", "de": "Kabel-Performance wird getestet…", "zh-Hans": "正在测试线缆性能…"
+    },
+    "status.waitingDisplayProfile": {
+      "it": "Receiver connesso, attendo profilo display…", "en": "Receiver connected, waiting for display profile…", "de": "Empfänger verbunden, warte auf Display-Profil…", "zh-Hans": "接收端已连接，等待显示配置…"
+    },
+    "status.connectionFailed": {
+      "placeholders": ["error"],
+      "it": "Connessione fallita: {error}", "en": "Connection failed: {error}", "de": "Verbindung fehlgeschlagen: {error}", "zh-Hans": "连接失败：{error}"
+    },
+    "status.stopped": {
+      "it": "Interrotto", "en": "Stopped", "de": "Gestoppt", "zh-Hans": "已停止"
+    },
+    "status.connectionClosed": {
+      "placeholders": ["error"],
+      "it": "Connessione chiusa: {error}", "en": "Connection closed: {error}", "de": "Verbindung geschlossen: {error}", "zh-Hans": "连接已关闭：{error}"
+    },
+    "status.receiverClosedDuringCapture": {
+      "it": "Receiver chiuso durante l'avvio cattura", "en": "Receiver closed while capture was starting", "de": "Empfänger während des Aufnahmestarts geschlossen", "zh-Hans": "捕获启动时接收端已关闭"
+    },
+    "status.receiverClosedConnection": {
+      "it": "Receiver ha chiuso la connessione", "en": "Receiver closed the connection", "de": "Empfänger hat die Verbindung geschlossen", "zh-Hans": "接收端已关闭连接"
+    },
+    "status.receiverTerminatedSession": {
+      "it": "Receiver ha terminato la sessione", "en": "Receiver terminated the session", "de": "Empfänger hat die Sitzung beendet", "zh-Hans": "接收端已终止会话"
+    },
+    "status.creatingVirtualDisplay": {
+      "it": "Creo virtual display…", "en": "Creating virtual display…", "de": "Virtuelles Display wird erstellt…", "zh-Hans": "正在创建虚拟显示器…"
+    },
+    "status.virtualDisplayCreationFailed": {
+      "it": "Creazione virtual display fallita", "en": "Virtual display creation failed", "de": "Virtuelles Display konnte nicht erstellt werden", "zh-Hans": "虚拟显示器创建失败"
+    },
+    "status.startingCapture": {
+      "placeholders": ["source", "resolution"],
+      "comment": "Italian / English lowercase the source name; German / Chinese keep it as-is. Decide on a uniform casing rule when wiring up.",
+      "it": "Avvio {source} ({resolution})…",
+      "en": "Starting {source} capture ({resolution})…",
+      "de": "{source} wird gestartet ({resolution})…",
+      "zh-Hans": "正在启动 {source}（{resolution}）…"
+    },
+    "status.captureStartedWaitingFirstFrame": {
+      "it": "Cattura avviata, attendo il primo frame…", "en": "Capture started, waiting for the first frame…", "de": "Aufnahme gestartet, warte auf ersten Bildinhalt…", "zh-Hans": "捕获已启动，等待首帧…"
+    },
+    "status.captureActive": {
+      "placeholders": ["source", "resolution", "codec"],
+      "it": "{source} attivo ({resolution}, {codec})", "en": "{source} active ({resolution}, {codec})", "de": "{source} aktiv ({resolution}, {codec})", "zh-Hans": "{source} 进行中（{resolution}，{codec}）"
+    },
+    "status.captureError": {
+      "placeholders": ["error"],
+      "it": "Errore capture: {error}", "en": "Capture error: {error}", "de": "Aufnahmefehler: {error}", "zh-Hans": "捕获错误：{error}"
+    },
+    "status.captureDesktopError": {
+      "placeholders": ["error"],
+      "it": "Errore cattura desktop: {error}", "en": "Desktop capture error: {error}", "de": "Desktop-Aufnahmefehler: {error}", "zh-Hans": "桌面捕获错误：{error}"
+    },
+    "status.hevcNoFrames": {
+      "it": "5K avviato ma il path HEVC non sta producendo frame", "en": "5K started but the HEVC path is not producing frames", "de": "5K gestartet, aber der HEVC-Pfad erzeugt keine Bildinhalte", "zh-Hans": "5K 已启动，但 HEVC 通道未输出任何帧"
+    },
+    "status.noFirstFrame": {
+      "it": "Cattura avviata ma non e' arrivato il primo frame", "en": "Capture started but the first frame never arrived", "de": "Aufnahme gestartet, aber der erste Bildinhalt ist nie angekommen", "zh-Hans": "捕获已启动，但始终未收到首帧"
+    },
+
+    "app.name": {
+      "it": "TargetBridge", "en": "TargetBridge", "de": "TargetBridge", "zh-Hans": "TargetBridge"
+    },
+    "app.subtitle": {
+      "it": "Crea un display virtuale iMac su macOS e ne invia il contenuto al receiver 5K.",
+      "en": "Creates an iMac virtual display on macOS and sends its contents to the 5K receiver.",
+      "de": "Erstellt ein virtuelles iMac-Display auf macOS und sendet dessen Inhalt an den 5K-Empfänger.",
+      "zh-Hans": "在 macOS 上创建一个 iMac 虚拟显示器，并将其内容发送到 5K 接收端。"
+    },
+
+    "cableTest.group": {
+      "it": "Test Cavo", "en": "Cable Test", "de": "Kabeltest", "zh-Hans": "线缆测试"
+    },
+    "cableTest.runButton": {
+      "it": "Esegui Test Cavo", "en": "Run Cable Test", "de": "Kabeltest ausführen", "zh-Hans": "运行线缆测试"
+    },
+    "cableTest.testingButton": {
+      "it": "Test in corso…", "en": "Testing…", "de": "Test läuft…", "zh-Hans": "测试中…"
+    },
+    "cableTest.transferRateLabel": {
+      "it": "Velocità:", "en": "Transfer Rate:", "de": "Übertragungsrate:", "zh-Hans": "传输速率："
+    },
+    "cableTest.noResult": {
+      "it": "Nessun test eseguito", "en": "No test run yet", "de": "Noch kein Test ausgeführt", "zh-Hans": "尚未运行测试"
+    },
+
+    "connection.group": {
+      "it": "Connessione", "en": "Connection", "de": "Verbindung", "zh-Hans": "连接"
+    },
+    "connection.localTBIP": {
+      "it": "IP Thunderbolt locale", "en": "Local Thunderbolt IP", "de": "Lokale Thunderbolt-IP", "zh-Hans": "本机 Thunderbolt IP"
+    },
+    "connection.availableTBInterfaces": {
+      "it": "Interfacce Thunderbolt", "en": "Thunderbolt interfaces", "de": "Thunderbolt-Schnittstellen", "zh-Hans": "Thunderbolt 接口"
+    },
+    "connection.notDetected": {
+      "it": "Non rilevato", "en": "Not detected", "de": "Nicht erkannt", "zh-Hans": "未检测到"
+    },
+    "connection.receiverIP": {
+      "it": "IP receiver", "en": "Receiver IP", "de": "Empfänger-IP", "zh-Hans": "接收端 IP"
+    },
+    "connection.discoveredReceiver": {
+      "it": "Receiver trovato", "en": "Discovered receiver", "de": "Gefundener Empfänger", "zh-Hans": "已发现的接收端"
+    },
+    "connection.manualEntry": {
+      "it": "Inserimento manuale", "en": "Manual entry", "de": "Manuelle Eingabe", "zh-Hans": "手动输入"
+    },
+    "connection.connectButton": {
+      "it": "Connetti", "en": "Connect", "de": "Verbinden", "zh-Hans": "连接"
+    },
+    "connection.stopButton": {
+      "it": "Stop", "en": "Stop", "de": "Stop", "zh-Hans": "停止"
+    },
+    "connection.refreshIPButton": {
+      "it": "Aggiorna IP", "en": "Refresh IP", "de": "IP aktualisieren", "zh-Hans": "刷新 IP"
+    },
+    "connection.addSessionButton": {
+      "it": "Aggiungi sessione", "en": "Add session", "de": "Sitzung hinzufügen", "zh-Hans": "新增会话"
+    },
+    "connection.stopAllButton": {
+      "it": "Ferma tutto", "en": "Stop all", "de": "Alle stoppen", "zh-Hans": "全部停止"
+    },
+    "connection.removeSessionButton": {
+      "it": "Rimuovi sessione", "en": "Remove session", "de": "Sitzung entfernen", "zh-Hans": "移除会话"
+    },
+    "connection.discoveryHint": {
+      "it": "Se selezioni un receiver trovato automaticamente, l'IP viene compilato da solo.",
+      "en": "Selecting a discovered receiver fills in the receiver IP automatically.",
+      "de": "Wenn du einen gefundenen Empfänger auswählst, wird die Empfänger-IP automatisch eingetragen.",
+      "zh-Hans": "选择已发现的接收端时，接收端 IP 会自动填入。"
+    },
+    "connection.multiSessionHint": {
+      "it": "Ogni sessione usa un IP Thunderbolt locale dedicato e uno stream indipendente verso il suo iMac.",
+      "en": "Each session uses its own local Thunderbolt IP and an independent stream to its target iMac.",
+      "de": "Jede Sitzung verwendet eine eigene lokale Thunderbolt-IP und einen unabhängigen Stream zu ihrem Ziel-iMac.",
+      "zh-Hans": "每个会话独占一个本机 Thunderbolt IP，向各自的 iMac 推送独立的码流。"
+    },
+
+    "language.group": {
+      "it": "Lingua", "en": "Language", "de": "Sprache", "zh-Hans": "语言"
+    },
+
+    "stream.resolutionGroup": {
+      "it": "Risoluzione stream", "en": "Stream resolution", "de": "Stream-Auflösung", "zh-Hans": "码流分辨率"
+    },
+    "stream.profile": {
+      "it": "Profilo stream", "en": "Stream profile", "de": "Stream-Profil", "zh-Hans": "码流配置"
+    },
+    "stream.captureSource": {
+      "it": "Sorgente", "en": "Source", "de": "Quelle", "zh-Hans": "来源"
+    },
+    "stream.hint1": {
+      "it": "`Duplica Desktop` crea un monitor virtuale e lo mette in mirror col display principale. `Desktop Esteso` crea un monitor virtuale separato visibile nelle impostazioni schermo.",
+      "en": "`Duplicate Desktop` creates a virtual monitor and mirrors the main display onto it. `Extended Desktop` creates a separate virtual monitor visible in Display Settings.",
+      "de": "`Desktop duplizieren` erstellt ein virtuelles Display und spiegelt den Hauptbildschirm darauf. `Erweiterter Desktop` erstellt ein separates virtuelles Display, das in den Anzeigeeinstellungen sichtbar ist.",
+      "zh-Hans": "`镜像桌面` 会创建一个虚拟显示器，并将主屏镜像到上面。`扩展桌面` 会创建一个独立的虚拟显示器，可在「显示器」设置中看到。"
+    },
+    "stream.hint2": {
+      "it": "`Smooth+` privilegia fluidità. `Crisp` aumenta la nitidezza. `5K` massimizza i pixel.",
+      "en": "`Smooth+` prioritizes motion. `Crisp` improves clarity. `5K` maximizes pixels.",
+      "de": "`Smooth+` bevorzugt flüssige Bewegung. `Crisp` verbessert die Schärfe. `5K` maximiert die Pixel.",
+      "zh-Hans": "`Smooth+` 偏向流畅。`Crisp` 提升清晰度。`5K` 像素最高。"
+    },
+
+    "captureSource.desktopMirror": {
+      "it": "Duplica Desktop", "en": "Duplicate Desktop", "de": "Desktop duplizieren", "zh-Hans": "镜像桌面",
+      "comment": "Sender originally had only it/en/de via TBDisplayCaptureSource.title; .chinese added in this branch."
+    },
+    "captureSource.extendedDesktop": {
+      "it": "Desktop Esteso", "en": "Extended Desktop", "de": "Erweiterter Desktop", "zh-Hans": "扩展桌面"
+    },
+
+    "monitor.sessionGroup": {
+      "it": "Sessione monitor", "en": "Monitor session", "de": "Bildschirmsitzung", "zh-Hans": "显示会话"
+    },
+    "monitor.receiverLabel": {
+      "it": "Receiver", "en": "Receiver", "de": "Empfänger", "zh-Hans": "接收端"
+    },
+    "monitor.virtualDisplayLabel": {
+      "it": "Virtual display", "en": "Virtual display", "de": "Virtuelles Display", "zh-Hans": "虚拟显示器"
+    },
+    "monitor.streamLabel": {
+      "it": "Stream", "en": "Stream", "de": "Stream", "zh-Hans": "码流"
+    },
+    "monitor.fpsLabel": {
+      "it": "FPS sender", "en": "Sender FPS", "de": "Sender-FPS", "zh-Hans": "发送端 FPS"
+    },
+
+    "mode.group": {
+      "it": "Modalità v1", "en": "Mode v1", "de": "Modus v1", "zh-Hans": "v1 模式"
+    },
+    "mode.line1": {
+      "it": "Pannello iMac target: 5120 × 2880 (5K)",
+      "en": "Target iMac panel: 5120 × 2880 (5K)",
+      "de": "Ziel-iMac-Bildschirm: 5120 × 2880 (5K)",
+      "zh-Hans": "目标 iMac 面板：5120 × 2880（5K）"
+    },
+    "mode.line2": {
+      "it": "Monitor esposto al MacBook: 2560 × 1440 HiDPI @ 60 Hz",
+      "en": "Display exposed to the MacBook: 2560 × 1440 HiDPI @ 60 Hz",
+      "de": "Dem MacBook bereitgestelltes Display: 2560 × 1440 HiDPI @ 60 Hz",
+      "zh-Hans": "暴露给 MacBook 的显示器：2560 × 1440 HiDPI @ 60 Hz"
+    },
+    "mode.line3": {
+      "it": "Pipeline: virtual display reale (esteso o mirror) → capture diretta → codec hardware → TCP",
+      "en": "Pipeline: real virtual display (extended or mirrored) → direct capture → hardware codec → TCP",
+      "de": "Pipeline: echtes virtuelles Display (erweitert oder gespiegelt) → direkte Aufnahme → Hardware-Codec → TCP",
+      "zh-Hans": "流水线：真实虚拟显示器（扩展或镜像）→ 直接捕获 → 硬件编码 → TCP"
+    },
+    "mode.line4": {
+      "it": "Il receiver va in fullscreen solo quando arriva il primo frame.",
+      "en": "The receiver switches to fullscreen only when the first frame arrives.",
+      "de": "Der Empfänger schaltet erst auf Vollbild um, wenn der erste Bildinhalt ankommt.",
+      "zh-Hans": "接收端仅在收到首帧后才会切换到全屏。"
+    },
+    "mode.line5": {
+      "it": "Scegli la sorgente, poi bilancia fluidità e nitidezza col profilo stream.",
+      "en": "Choose the source, then balance motion and clarity with the stream profile.",
+      "de": "Quelle wählen, dann Bewegungsfluss und Schärfe mit dem Stream-Profil abstimmen.",
+      "zh-Hans": "先选择来源，再用码流配置在流畅度与清晰度之间取舍。"
+    },
+
+    "about.version": {
+      "it": "Versione", "en": "Version", "de": "Version", "zh-Hans": "版本"
+    },
+
+    "toggle.showMenuBarIcon": {
+      "it": "Mostra icona nella topbar", "en": "Show icon in top bar", "de": "Symbol in Menüleiste anzeigen", "zh-Hans": "在菜单栏显示图标"
+    },
+    "toggle.largeCursor": {
+      "it": "Cursore ingrandito sul receiver", "en": "Large cursor on receiver", "de": "Großer Zeiger auf dem Empfänger", "zh-Hans": "在接收端使用大光标"
+    },
+
+    "menu.showMainWindow": {
+      "it": "Mostra finestra principale", "en": "Show main window", "de": "Hauptfenster anzeigen", "zh-Hans": "显示主窗口"
+    },
+    "menu.hideMenuBarIcon": {
+      "it": "Nascondi icona dalla topbar", "en": "Hide top bar icon", "de": "Symbol in Menüleiste ausblenden", "zh-Hans": "隐藏菜单栏图标"
+    },
+    "menu.quitApp": {
+      "it": "Esci da TargetBridge", "en": "Quit TargetBridge", "de": "TargetBridge beenden", "zh-Hans": "退出 TargetBridge"
+    },
+
+    "topBar.ip": {
+      "placeholders": ["ip"],
+      "it": "IP TB: {ip}", "en": "TB IP: {ip}", "de": "TB-IP: {ip}", "zh-Hans": "TB IP：{ip}"
+    },
+    "topBar.toolTip": {
+      "it": "TargetBridge - Monitor target display software",
+      "en": "TargetBridge - Software target display monitor",
+      "de": "TargetBridge - Software Target-Display-Monitor",
+      "zh-Hans": "TargetBridge - 软件目标显示器"
+    },
+
+    "session.title": {
+      "placeholders": ["index"],
+      "it": "Sessione {index}", "en": "Session {index}", "de": "Sitzung {index}", "zh-Hans": "会话 {index}"
+    },
+    "multiSession.summary.connected": {
+      "placeholders": ["active", "total"],
+      "comment": "Note: zh-Hans deliberately reorders 'total' before 'active' for natural Chinese phrasing.",
+      "it": "{active} sessioni collegate su {total}",
+      "en": "{active} connected sessions of {total}",
+      "de": "{active} verbundene Sitzungen von {total}",
+      "zh-Hans": "{total} 个会话中已连接 {active} 个"
+    },
+    "multiSession.summary.streaming": {
+      "placeholders": ["active", "total"],
+      "it": "{active} sessioni attive su {total}",
+      "en": "{active} active sessions of {total}",
+      "de": "{active} aktive Sitzungen von {total}",
+      "zh-Hans": "{total} 个会话中活跃 {active} 个"
+    },
+
+    "service.waitingReceiverProfile": {
+      "it": "In attesa del profilo receiver", "en": "Waiting for receiver profile", "de": "Warte auf Empfänger-Profil", "zh-Hans": "正在等待接收端配置"
+    },
+    "service.virtualDisplayNotCreated": {
+      "it": "Virtual display non creato", "en": "Virtual display not created", "de": "Virtuelles Display nicht erstellt", "zh-Hans": "尚未创建虚拟显示器"
+    },
+    "service.receiverSummary": {
+      "placeholders": ["receiverName", "panelWidth", "panelHeight", "modeWidth", "modeHeight"],
+      "it": "{receiverName}: pannello {panelWidth}×{panelHeight}, modalità {modeWidth}×{modeHeight} HiDPI",
+      "en": "{receiverName}: panel {panelWidth}×{panelHeight}, mode {modeWidth}×{modeHeight} HiDPI",
+      "de": "{receiverName}: Panel {panelWidth}×{panelHeight}, Modus {modeWidth}×{modeHeight} HiDPI",
+      "zh-Hans": "{receiverName}：面板 {panelWidth}×{panelHeight}，模式 {modeWidth}×{modeHeight} HiDPI"
+    },
+    "service.virtualDisplaySummary": {
+      "placeholders": ["name", "id"],
+      "it": "Virtual display: {name} ({id})",
+      "en": "Virtual display: {name} ({id})",
+      "de": "Virtuelles Display: {name} ({id})",
+      "zh-Hans": "虚拟显示器：{name}（{id}）"
+    },
+
+    "permissions.missingScreenRecording": {
+      "it": "TargetBridge non ha il permesso Registrazione Schermo. Verifica Privacy e Sicurezza > Registrazione Schermo.",
+      "en": "TargetBridge does not have Screen Recording permission. Check Privacy & Security > Screen Recording.",
+      "de": "TargetBridge hat keine Berechtigung für die Bildschirmaufnahme. Überprüfen Sie Systemeinstellungen > Datenschutz & Sicherheit > Bildschirmaufnahme.",
+      "zh-Hans": "TargetBridge 没有「屏幕录制」权限。请前往「隐私与安全性 → 屏幕录制」检查。"
+    },
+    "permissions.screenCaptureKitPermissionMismatch": {
+      "placeholders": ["details"],
+      "it": "ScreenCaptureKit ha fallito anche se il permesso Registrazione Schermo risulta concesso. Dettagli: {details}",
+      "en": "ScreenCaptureKit failed even though Screen Recording permission appears granted. Details: {details}",
+      "de": "ScreenCaptureKit fehlgeschlagen, obwohl die Berechtigung zur Bildschirmaufnahme erteilt zu sein scheint. Details: {details}",
+      "zh-Hans": "屏幕录制权限看起来已授予，但 ScreenCaptureKit 仍然失败。详情：{details}"
+    },
+
+    "settings.title": {
+      "comment": "These 'settings.*' keys are new in this PR (gear-button Settings sheet). Discard them if the upstream UI refactor obsoletes the sheet.",
+      "it": "Preferenze", "en": "Settings", "de": "Einstellungen", "zh-Hans": "设置"
+    },
+    "settings.doneButton": {
+      "it": "Fatto", "en": "Done", "de": "Fertig", "zh-Hans": "完成"
+    },
+    "settings.section.language": {
+      "it": "Lingua", "en": "Language", "de": "Sprache", "zh-Hans": "语言"
+    },
+    "settings.section.appearance": {
+      "it": "Aspetto", "en": "Appearance", "de": "Darstellung", "zh-Hans": "外观"
+    },
+    "settings.section.about": {
+      "it": "Informazioni", "en": "About", "de": "Über", "zh-Hans": "关于"
+    },
+    "settings.buttonAccessibility": {
+      "it": "Apri preferenze", "en": "Open settings", "de": "Einstellungen öffnen", "zh-Hans": "打开设置"
+    }
+  },
+
+  "receiver": {
+    "$comment": "Receiver was English-only before this branch; only 'en' + 'zh-Hans' provided. Italian / German / etc. can be derived from the sender wording when the JSON system is wired up.",
+
+    "banner.title": {
+      "en": "TARGETBRIDGE RECEIVER", "zh-Hans": "TARGETBRIDGE 接收端"
+    },
+    "banner.subtitle": {
+      "en": "5K / HiDPI receiver ready for sender", "zh-Hans": "5K / HiDPI 接收端，等待发送端连接"
+    },
+    "banner.section.ipBridge": {
+      "en": "IP THUNDERBOLT BRIDGE", "zh-Hans": "Thunderbolt Bridge IP"
+    },
+    "banner.section.status": {
+      "en": "STATUS", "zh-Hans": "状态"
+    },
+    "banner.section.sender": {
+      "en": "SENDER", "zh-Hans": "发送端"
+    },
+    "banner.section.display": {
+      "en": "DISPLAY", "zh-Hans": "显示器"
+    },
+    "banner.section.streamProfile": {
+      "en": "STREAM PROFILE", "zh-Hans": "码流配置"
+    },
+    "banner.footer.line1": {
+      "en": "Start the sender on your MacBook and enter this IP address.",
+      "zh-Hans": "在 MacBook 上启动发送端，并填入上方的 IP 地址。"
+    },
+    "banner.footer.line2": {
+      "en": "When the first frame arrives, the receiver switches to fullscreen automatically.",
+      "zh-Hans": "收到第一帧画面后，接收端会自动切换到全屏。"
+    },
+    "banner.footer.line3": {
+      "en": "If the sender stops, the receiver returns here ready for a new session.",
+      "zh-Hans": "发送端停止后，接收端会返回此界面，等待下一次会话。"
+    },
+
+    "status.streamActive": {
+      "en": "stream active", "zh-Hans": "码流进行中"
+    },
+    "status.modeReceiving": {
+      "placeholders": ["width", "height"],
+      "comment": "Original C printf: '%d x %d px receiving' (width, height).",
+      "en": "{width} x {height} px receiving",
+      "zh-Hans": "正在接收 {width} x {height} px"
+    },
+    "status.connectedNegotiating": {
+      "en": "sender connected, negotiating", "zh-Hans": "发送端已连接，协商中"
+    },
+    "status.connectedProfileSent": {
+      "en": "sender connected, profile sent", "zh-Hans": "发送端已连接，已发送配置"
+    },
+    "status.sessionAccepted": {
+      "en": "session accepted, waiting for frames", "zh-Hans": "会话已接受，等待画面帧"
+    },
+    "status.sessionClosed": {
+      "en": "session closed by sender", "zh-Hans": "发送端已关闭会话"
+    },
+    "status.waitingForSender": {
+      "en": "waiting for sender", "zh-Hans": "等待发送端"
+    },
+
+    "status.requested.full": {
+      "placeholders": ["width", "height", "extra1", "extra2", "extra3"],
+      "comment": "Original C printf: '%d x %d px requested (%s, %s, %s)'.",
+      "en": "{width} x {height} px requested ({extra1}, {extra2}, {extra3})",
+      "zh-Hans": "请求 {width} x {height} px（{extra1}，{extra2}，{extra3}）"
+    },
+    "status.requested.twoExtras": {
+      "placeholders": ["width", "height", "extra1", "extra2"],
+      "en": "{width} x {height} px requested ({extra1}, {extra2})",
+      "zh-Hans": "请求 {width} x {height} px（{extra1}，{extra2}）"
+    },
+    "status.requested.oneExtra": {
+      "placeholders": ["width", "height", "extra1"],
+      "en": "{width} x {height} px requested ({extra1})",
+      "zh-Hans": "请求 {width} x {height} px（{extra1}）"
+    },
+    "status.requested.bare": {
+      "placeholders": ["width", "height"],
+      "en": "{width} x {height} px requested",
+      "zh-Hans": "请求 {width} x {height} px"
+    },
+
+    "sender.connected": {
+      "en": "sender connected", "zh-Hans": "发送端已连接"
+    },
+    "sender.waiting": {
+      "en": "waiting", "zh-Hans": "等待中"
+    },
+    "sender.identifying": {
+      "en": "identifying", "zh-Hans": "识别中"
+    },
+
+    "ip.notDetected": {
+      "en": "not detected", "zh-Hans": "未检测到"
+    },
+
+    "display.fiveK": {
+      "en": "5K display", "zh-Hans": "5K 显示器"
+    },
+    "mode.standard": {
+      "en": "2560 x 1440 HiDPI on 5K display",
+      "zh-Hans": "2560 x 1440 HiDPI（5K 显示器）"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Simplified Chinese (zh-Hans) UI to both the macOS sender app and the C receiver, and refactors sender preferences into a Settings sheet for a cleaner main panel.

Default UI language is now auto-detected from the system locale (`Locale.preferredLanguages` on the sender, `LC_ALL` / `LC_MESSAGES` / `LANG` plus `TBR_LANG` override on the receiver). English / Italian / German behavior is preserved.

## Sender (SwiftUI)

- `TBDisplaySenderLocalization.swift`
  - Add `.chinese` case to `TBDisplaySenderLanguage`, picker title `中文`.
  - Auto-detect default language from `Locale.preferredLanguages` (zh / it / de / en prefix match), fall back to English.
  - Translate ~80 user-facing strings into Chinese.
  - New strings for the Settings sheet (title, Done button, language / appearance / about section headers, gear button accessibility label).
- `TBDisplaySenderContentView.swift`
  - Remove the standalone `languageCard` and `settingsCard` from the main panel.
  - Add a gear button at the top-right of the header card; tapping opens a new `TBDisplaySenderSettingsView` sheet (460 × 420) with three sections: Language, Appearance, About.
  - Add `.chinese` branches to all helper titles (routing / output / session monitor / live / connected / idle).
- `TBDisplaySenderService.swift`
  - `TBDisplayCaptureSource.title` adds `.chinese` cases (`镜像桌面`, `扩展桌面`).

## Receiver (C / SDL2 + CoreText)

- New `src/i18n.h` — header-only inline module, no Makefile changes.
  - `tb_locale_is_chinese()` with cached lookup, priority `TBR_LANG` > `LC_ALL` > `LC_MESSAGES` > `LANG`.
  - `tb_tr(en, zh)` macro-style helper for inline string selection.
- `src/display.c`
  - Switch banner fonts based on locale: `PingFangSC-Semibold` / `PingFangSC-Regular` for Chinese (CoreText cannot render CJK with Helvetica/Menlo), `Helvetica` family for ASCII.
  - Translate all 11 banner strings (title, subtitle, three column headers, display / stream profile labels, three-line footer).
- `src/main.c`
  - Translate all dynamic status / sender / display / mode / panel strings (`stream active`, `sender connected`, `waiting for sender`, etc.).
  - Fix `bonjour_update()` literal-string guard to recognize both `not detected` and `未检测到`.

## How to test

```sh
# Receiver (auto, follows LANG / LC_ALL)
./tbreceiver --windowed

# Force Chinese banners
TBR_LANG=zh ./tbreceiver --windowed

# Force English banners
TBR_LANG=en ./tbreceiver --windowed
```

For the sender, set system language to Simplified Chinese (or click the gear → Language → 中文).

## Verification

- ✅ Sender Swift type-check passes (`xcrun swiftc -typecheck`), private `CGVirtualDisplay*` API is provided by the bridging header as before.
- ✅ Sender full Xcode build succeeds (Xcode 26.5, macOS 26.5 SDK), `.app` runs and shows Chinese UI on a `zh-Hans-CN` system.
- ✅ Receiver compiles cleanly with `make` (Apple Silicon, brew ffmpeg / sdl2 / pkgconf).
- ✅ `i18n.h` runtime fallback verified across 5 scenarios (default, `TBR_LANG=zh`, `TBR_LANG=en` overriding `LANG=zh_CN`, `LANG=zh_CN`, `LANG=en_US`).
- ✅ No functional changes — existing toggles (`showsMenuBarIcon`, `largeCursor`) preserved, just relocated from the old in-panel `settingsCard` into the new gear sheet.

## Notes

- Chinese is opt-in by system locale; existing English / Italian / German behavior is unchanged for users who do not run in `zh-*`.
- The receiver gracefully falls back to English banners if the Chinese fonts (`PingFangSC-*`, ships with macOS) are absent.

<img width="2132" height="1592" alt="ScreenShot_2026-05-22_210730_804" src="https://github.com/user-attachments/assets/a978f0e9-4f17-4834-9823-188782ecc5a0" />
