### PR TITLE
Fix virtual display capture in desktop mirror mode, fixes #52

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -1000,8 +1000,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         do {
             let preset = capturePreset
 
-            if captureSource == .extendedDesktop, session.displayID != kCGNullDirectDisplay {
-                if startDirectDisplayStream(displayID: session.displayID, preset: preset) {
+            if session.displayID != kCGNullDirectDisplay {
+                let captureDisplayID = (captureSource == .desktopMirror) ? CGMainDisplayID() : session.displayID
+                if startDirectDisplayStream(displayID: captureDisplayID, preset: preset) {
                     return true
                 }
             }
@@ -1102,8 +1103,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     private func waitForCaptureDisplay() async throws -> SCDisplay {
-        try await waitForVirtualDisplay(
-            matching: session.displayID,
+        let targetDisplayID = (captureSource == .desktopMirror) ? CGMainDisplayID() : session.displayID
+        return try await waitForVirtualDisplay(
+            matching: targetDisplayID,
             baselineDisplayIDs: baselineDisplayIDs
         )
     }


### PR DESCRIPTION
In duplicate/mirror desktop mode, the virtual display created by TargetBridge is configured to mirror the main display.

Because ScreenCaptureKit (`SCShareableContent`) does not include mirrored displays in its shareable display list, attempting to wait for and capture the virtual display ID resulted in a timeout and threw the 'no virtual SCDisplay available' error.

This PR resolves this by capturing the main display (`CGMainDisplayID()`) directly instead of the virtual mirror display when `captureSource` is `.desktopMirror`.