### PR TITLE
fix: Update timestamp of built TargetBridge.app bundle

### DIFF
--- a/TargetBridge-Sender/scripts/build_targetbridge_sender_app.sh
+++ b/TargetBridge-Sender/scripts/build_targetbridge_sender_app.sh
@@ -26,6 +26,7 @@ xcodebuild \
 mkdir -p "$DEST_DIR"
 rm -rf "$DEST_APP"
 ditto "$SOURCE_APP" "$DEST_APP"
+touch "$DEST_APP"
 
 echo "TargetBridge sender built: $DEST_APP"
 echo "Local DerivedData: $DERIVED_DATA_DIR"


### PR DESCRIPTION
During incremental builds, xcodebuild only updates files inside the bundle (under Contents/MacOS) without updating the modification timestamp (mtime) of the top-level .app directory in Xcode's DerivedData folder. When the build script copies the bundle via ditto, ditto preserves these timestamps exactly as they are in the source, resulting in Finder showing a stale build date (e.g. from days ago).

Adding a touch on the destination app bundle ensures the directory modification time is updated to the current build time, displaying the correct build date in Finder.