### PR TITLE
Prefer GPU-backed receiver rendering

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -1,6 +1,7 @@
 /* display.c — SDL2 NV12 renderer.
  *
- * SDL2 on macOS uses Metal renderer by default (SDL_RENDERER_ACCELERATED).
+ * On macOS, prefer SDL's Metal renderer and fall back to OpenGL/default
+ * accelerated backends if needed.
  * SDL_PIXELFORMAT_NV12 + SDL_UpdateNVTexture lets us upload YUV planes
  * directly to GPU; the shader does YUV→RGB conversion on the GPU.
  */
@@ -232,10 +233,41 @@ static void tb_disp_refresh_window_mode(struct tb_display *d) {
     }
 }
 
-struct tb_display *tb_disp_create(int fullscreen) {
-    /* Force OpenGL renderer driver to avoid Metal's HDR/swapchain flickering on macOS Tahoe. */
-    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+static SDL_Renderer *tb_disp_try_renderer(SDL_Window *win, const char *driver) {
+    if (driver && driver[0] != '\0') {
+        SDL_SetHint(SDL_HINT_RENDER_DRIVER, driver);
+    } else {
+        SDL_SetHint(SDL_HINT_RENDER_DRIVER, "");
+    }
 
+    SDL_Renderer *ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
+    if (!ren) {
+        fprintf(stderr, "[disp] CreateRenderer(%s): %s\n",
+                driver && driver[0] != '\0' ? driver : "default",
+                SDL_GetError());
+    }
+    return ren;
+}
+
+static SDL_Renderer *tb_disp_create_accelerated_renderer(SDL_Window *win) {
+    const char *forced_driver = getenv("TB_RECEIVER_RENDER_DRIVER");
+    if (forced_driver && forced_driver[0] != '\0') {
+        fprintf(stderr, "[disp] renderer override = %s\n", forced_driver);
+        return tb_disp_try_renderer(win, forced_driver);
+    }
+
+#if defined(__APPLE__)
+    const char *macos_drivers[] = { "metal", "opengl", NULL };
+    for (int i = 0; macos_drivers[i] != NULL; i++) {
+        SDL_Renderer *ren = tb_disp_try_renderer(win, macos_drivers[i]);
+        if (ren) return ren;
+    }
+#endif
+
+    return tb_disp_try_renderer(win, NULL);
+}
+
+struct tb_display *tb_disp_create(int fullscreen) {
     /* Best-quality scaling (linear filter; Metal backend uses bilinear
      * regardless but this sets the hint correctly). "best" enables
      * anisotropic where supported. Must be set BEFORE renderer creation. */
@@ -263,7 +295,7 @@ struct tb_display *tb_disp_create(int fullscreen) {
     /* No VSYNC: lets us present as fast as decode produces frames.
      * On Intel iMac with Radeon Pro 570 + 5K display, VSYNC at 60Hz combined
      * with GPU→CPU NV12 transfer was stalling the pipeline to ~4 fps. */
-    d->ren = SDL_CreateRenderer(d->win, -1, SDL_RENDERER_ACCELERATED);
+    d->ren = tb_disp_create_accelerated_renderer(d->win);
     if (!d->ren) {
         fprintf(stderr, "[disp] CreateRenderer: %s\n", SDL_GetError());
         SDL_DestroyWindow(d->win); free(d); return NULL;

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -310,14 +310,16 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
 
 static int drain_socket(struct app *a) {
     uint8_t buf[1024 * 1024];
+    int saw_data = 0;
     for (;;) {
         ssize_t n = read(a->client_fd, buf, sizeof(buf));
         if (n > 0) {
+            saw_data = 1;
             if (tb_parser_feed(&a->parser, buf, (size_t)n) < 0) return -1;
         } else if (n == 0) {
             return -1;  /* peer closed */
         } else {
-            if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return saw_data;
             perror("[main] read");
             return -1;
         }
@@ -486,6 +488,7 @@ int main(int argc, char **argv) {
 
     while (!g_term && !tb_disp_poll_quit(a.disp)) {
         uint64_t t = now_ms();
+        int socket_activity = 0;
 
         if (t - a.last_ip_check_ms >= 1000) {
             char refreshed_ip[64] = {0};
@@ -511,8 +514,13 @@ int main(int argc, char **argv) {
                 send_receiver_info(&a);
             }
         } else {
-            if (drain_socket(&a) < 0) close_client(&a);
-            else if (a.close_requested) close_client(&a);
+            int drain_result = drain_socket(&a);
+            if (drain_result < 0) {
+                close_client(&a);
+            } else {
+                socket_activity = drain_result;
+                if (a.close_requested) close_client(&a);
+            }
         }
 
         if (a.client_fd < 0 || !a.have_video_frame) {
@@ -527,9 +535,9 @@ int main(int argc, char **argv) {
             if (df > 0) fprintf(stderr, "[main] %llu fps\n", (unsigned long long)df);
         }
 
-        /* Yield only while idle. During active video, keep draining and
-         * rendering without injecting an extra millisecond of latency. */
-        if (a.client_fd < 0 || !a.have_video_frame) {
+        /* Yield when idle or when an active nonblocking socket had no data.
+         * Without this, active video can busy-spin between frame packets. */
+        if (a.client_fd < 0 || !a.have_video_frame || socket_activity == 0) {
             SDL_Delay(1);
         }
     }


### PR DESCRIPTION
## Summary
- prefer SDL's Metal renderer on macOS, with OpenGL/default accelerated fallback
- allow TB_RECEIVER_RENDER_DRIVER to force a renderer for troubleshooting
- prevent the active receiver loop from busy-spinning when the nonblocking socket has no data

## Validation
- Built receiver bundle locally with PATH=/opt/homebrew/bin:/usr/local/bin:$PATH TargetBridge-Receiver/scripts/build_tbreceiver_c_app.sh
- Local bundle: build/TargetBridge Receiver.app

## Notes
- Local bundle was built on Apple Silicon and is arm64. Needs Intel iMac build/test before marking ready.