### PR TITLE
Implement native Display P3 color space support

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -12,6 +12,12 @@
 #include <CoreText/CoreText.h>
 #include <SDL.h>
 
+#if defined(__APPLE__)
+#include <SDL_syswm.h>
+#include <objc/objc.h>
+#include <objc/message.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -300,6 +306,27 @@ struct tb_display *tb_disp_create(int fullscreen) {
     d->cursor_visible = 0;
     d->cursor_type = 0;
     d->last_video_frame_time = 0;
+
+#if defined(__APPLE__)
+    SDL_SysWMinfo wmInfo;
+    SDL_VERSION(&wmInfo.version);
+    if (SDL_GetWindowWMInfo(d->win, &wmInfo)) {
+        id nswin = (id)wmInfo.info.cocoa.window;
+        if (nswin) {
+            Class colorSpaceClass = objc_getClass("NSColorSpace");
+            SEL displayP3Sel = sel_registerName("displayP3ColorSpace");
+            typedef id (*msgSend_id_fn)(Class, SEL);
+            id p3ColorSpace = ((msgSend_id_fn)objc_msgSend)(colorSpaceClass, displayP3Sel);
+
+            if (p3ColorSpace) {
+                SEL setColorSpaceSel = sel_registerName("setColorSpace:");
+                typedef void (*msgSend_void_id_fn)(id, SEL, id);
+                ((msgSend_void_id_fn)objc_msgSend)(nswin, setColorSpaceSel, p3ColorSpace);
+                fprintf(stderr, "[disp] successfully set Cocoa window color space to Display P3\n");
+            }
+        }
+    }
+#endif
 
     tb_disp_refresh_window_mode(d);
     SDL_ShowWindow(d->win);

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260521211758"
+    static let buildNumber = "20260524080624"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -262,7 +262,8 @@ private final class TBDirectDisplayStreamCapture {
         let properties: NSDictionary = [
             CGDisplayStream.showCursor: showCursor,
             CGDisplayStream.queueDepth: preset.queueDepth,
-            CGDisplayStream.minimumFrameTime: 1.0 / Double(preset.expectedFrameRate)
+            CGDisplayStream.minimumFrameTime: 1.0 / Double(preset.expectedFrameRate),
+            CGDisplayStream.colorSpace: CGColorSpace(name: CGColorSpace.displayP3) as Any
         ]
 
         let serviceRefValue = UInt(bitPattern: serviceRef)
@@ -1020,6 +1021,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             configuration.showsCursor = !largeCursor
             configuration.scalesToFit = true
             configuration.captureResolution = preset.captureResolution
+            configuration.colorSpaceName = CGColorSpace.displayP3
 
             setupEncoder(
                 width: preset.width,
@@ -1368,6 +1370,11 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: NSNumber(value: preset.maxKeyFrameIntervalDuration))
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_MaxFrameDelayCount, value: NSNumber(value: preset.maxFrameDelayCount))
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AverageBitRate, value: NSNumber(value: averageBitRate))
+
+        // Tag video stream with native Display P3 color space metadata
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ColorPrimaries, value: kCVImageBufferColorPrimaries_P3_D65)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_TransferFunction, value: kCVImageBufferTransferFunction_ITU_R_709_2)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_YCbCrMatrix, value: kCVImageBufferYCbCrMatrix_ITU_R_709_2)
         if preset.prioritizeSpeed {
             VTSessionSetProperty(session, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         }


### PR DESCRIPTION
This adds native Display P3 wide-gamut support across TargetBridge.

### Sender (Swift)
- Configures SCStreamConfiguration to capture desktop frames in P3.
- Passes P3 CGColorSpace to CGDisplayStream properties for Direct Display Mode.
- Tags VTCompressionSession with Display P3 primaries, Rec. 709 transfer characteristics, and Rec. 709 YCbCr matrix VUI parameters.

### Receiver (C)
- Uses pure-C Objective-C runtime functions on macOS to assign the native [NSColorSpace displayP3ColorSpace] to the receiver's Cocoa NSWindow.

No CPU/GPU or network bandwidth overhead is introduced since it remains an 8-bit SDR profile.