### PR TITLE
feat: remote screen brightness control from sender

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -11,6 +11,7 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <CoreText/CoreText.h>
 #include <SDL.h>
+#include <dlfcn.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -940,4 +941,39 @@ void tb_disp_render_status(struct tb_display *d,
     SDL_RenderClear(d->ren);
     if (d->status_tex) SDL_RenderCopy(d->ren, d->status_tex, NULL, NULL);
     SDL_RenderPresent(d->ren);
+}
+
+void tb_disp_set_brightness(struct tb_display *d, double level) {
+    (void)d;
+    if (level < 0.0) level = 0.0;
+    if (level > 1.0) level = 1.0;
+
+    void *lib = dlopen("/System/Library/PrivateFrameworks/DisplayServices.framework/Versions/A/DisplayServices", RTLD_LAZY);
+    if (!lib) {
+        fprintf(stderr, "[disp] failed to dlopen DisplayServices\n");
+        return;
+    }
+
+    typedef int (*SetBrightnessFunc)(CGDirectDisplayID display, float brightness);
+    SetBrightnessFunc set_brightness = (SetBrightnessFunc)dlsym(lib, "DisplayServicesSetBrightness");
+    if (!set_brightness) {
+        fprintf(stderr, "[disp] failed to find DisplayServicesSetBrightness symbol\n");
+        dlclose(lib);
+        return;
+    }
+
+    CGDirectDisplayID displays[16];
+    uint32_t count = 0;
+    if (CGGetActiveDisplayList(16, displays, &count) == kCGErrorSuccess) {
+        for (uint32_t i = 0; i < count; i++) {
+            set_brightness(displays[i], (float)level);
+        }
+        fprintf(stderr, "[disp] set brightness to %.2f on %u display(s)\n", level, count);
+    } else {
+        CGDirectDisplayID main_disp = CGMainDisplayID();
+        set_brightness(main_disp, (float)level);
+        fprintf(stderr, "[disp] set brightness to %.2f on main display\n", level);
+    }
+
+    dlclose(lib);
 }

--- a/TargetBridge-Receiver/TBReceiverC/src/display.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.h
@@ -38,6 +38,9 @@ void tb_disp_set_cursor(struct tb_display *d,
                         int visible,
                         int type);
 
+/* Adjust brightness dynamically on system displays. */
+void tb_disp_set_brightness(struct tb_display *d, double level);
+
 /* Returns 1 if user requested quit (ESC or window close). */
 int  tb_disp_poll_quit(struct tb_display *d);
 

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -208,6 +208,29 @@ static int extract_json_bool_field(const uint8_t *payload,
     return extract_json_int_field(payload, len, key, out_value);
 }
 
+static int extract_json_double_field(const uint8_t *payload,
+                                     size_t len,
+                                     const char *key,
+                                     double *out_value) {
+    if (!payload || !key || !out_value) return 0;
+
+    const char *text = (const char *)payload;
+    const char *pos = strstr(text, key);
+    if (!pos) return 0;
+
+    pos = strchr(pos, ':');
+    if (!pos) return 0;
+    pos++;
+    while ((size_t)(pos - text) < len && (*pos == ' ' || *pos == '\t')) pos++;
+    if ((size_t)(pos - text) >= len) return 0;
+
+    char *end = NULL;
+    double value = strtod(pos, &end);
+    if (end == pos) return 0;
+    *out_value = value;
+    return 1;
+}
+
 /* ---- Callbacks: decoder → display ------------------------------------ */
 
 static void on_frame(const uint8_t *y, int y_stride,
@@ -288,6 +311,13 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
             (void)extract_json_bool_field(payload, len, "\"visible\"", &visible);
             (void)extract_json_int_field(payload, len, "\"type\"", &type);
             tb_disp_set_cursor(a->disp, x, y, w, h, visible, type);
+        }
+        break;
+    case TB_PKT_BRIGHTNESS:
+        {
+            double level = 1.0;
+            (void)extract_json_double_field(payload, len, "\"level\"", &level);
+            tb_disp_set_brightness(a->disp, level);
         }
         break;
     case TB_PKT_HEARTBEAT:

--- a/TargetBridge-Receiver/TBReceiverC/src/proto.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/proto.h
@@ -33,6 +33,7 @@
 #define TB_PKT_HEARTBEAT        0x30
 #define TB_PKT_TEARDOWN         0x31
 #define TB_PKT_CURSOR           0x32
+#define TB_PKT_BRIGHTNESS       0x33
 #define TB_PKT_TEST_DATA        0x40
 
 #define TB_HDR_BYTES        5   /* 4 length + 1 type */

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260521211758"
+    static let buildNumber = "20260524153525"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -279,6 +279,30 @@ private struct TBDisplaySenderSessionCard: View {
                     .font(.footnote)
                 }
 
+                if session.isConnected {
+                    VStack(alignment: .leading, spacing: 10) {
+                        sectionHeading(TBDisplaySenderL10n.brightnessGroup(service.language))
+                        HStack(spacing: 12) {
+                            Image(systemName: "sun.min.fill")
+                                .font(.system(size: 16))
+                                .foregroundStyle(.secondary)
+
+                            Slider(value: $session.brightness, in: 0.0...1.0)
+                                .accentColor(.orange)
+
+                            Image(systemName: "sun.max.fill")
+                                .font(.system(size: 16))
+                                .foregroundStyle(.secondary)
+
+                            Text(String(format: "%.0f%%", session.brightness * 100))
+                                .font(.system(.body, design: .monospaced))
+                                .frame(width: 44, alignment: .trailing)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+
                 HStack(alignment: .top, spacing: 14) {
                     metricCard(
                         title: TBDisplaySenderL10n.cableTestGroup(service.language),

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -304,6 +304,14 @@ enum TBDisplaySenderL10n {
         }
     }
 
+    static func brightnessGroup(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Luminosità"
+        case .english: return "Brightness"
+        case .german: return "Helligkeit"
+        }
+    }
+
     static func streamResolutionGroup(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Risoluzione stream"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -410,6 +410,11 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     @Published var isConnected = false
     @Published var isStreaming = false
+    @Published var brightness: Double = 1.0 {
+        didSet {
+            sendBrightnessUpdate()
+        }
+    }
     @Published var statusText: String
     @Published var localTBIP = ""
     @Published var selectedReceiverID = ""
@@ -886,6 +891,15 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         send(packet)
     }
 
+    func sendBrightnessUpdate() {
+        guard isConnected else { return }
+        guard let packet = TBMonitorProtocol.makeJSONPacket(
+            type: .brightness,
+            value: TBMonitorBrightness(level: brightness)
+        ) else { return }
+        send(packet)
+    }
+
     private func receiveLoop(on connection: NWConnection) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 256 * 1024) { [weak self] data, _, isDone, error in
             Task { @MainActor [weak self] in
@@ -985,6 +999,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 self.stop(resetStatusTo: nil)
                 return
             }
+
+            self.sendBrightnessUpdate()
 
             if self.captureSource == .extendedDesktop {
                 self.scheduleExtendedDesktopRecovery(for: self.session.displayID)

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -9,7 +9,12 @@ enum TBMonitorPacketType: UInt8 {
     case heartbeat = 0x30
     case teardown = 0x31
     case cursor = 0x32
+    case brightness = 0x33
     case testData = 0x40
+}
+
+struct TBMonitorBrightness: Codable {
+    var level: Double
 }
 
 struct TBMonitorHelloReceiver: Codable {


### PR DESCRIPTION
This pull request adds support for controlling the target receiver's screen brightness directly from the sender app.

### Key Changes
* **Protocol update:** Added packet type `0x33` (`TB_PKT_BRIGHTNESS` / `.brightness`) to transmit brightness levels.
* **Receiver implementation (C):** Dynamically loads Apple's private `DisplayServices` framework at runtime via `dlopen` to control active screens' brightness smoothly.
* **Sender implementation (Swift/SwiftUI):** Displays an interactive orange Slider in each active session card with instant synchronization and localized strings for Italian, English, and German.