### PR TITLE
Sender: GUI options for screensaver/wake handling, stable extended-display identity, diagnostic logging

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/ReceiverBackedVirtualDisplaySession.swift
+++ b/TargetBridge-Sender/TBDisplaySender/ReceiverBackedVirtualDisplaySession.swift
@@ -18,14 +18,27 @@ struct TBVirtualDisplayIdentity {
         usesDedicatedArrangementIdentity: false
     )
 
-    static func extendedDesktop() -> TBVirtualDisplayIdentity {
-        let random = UInt32.random(in: 0x0100...0xFFFE)
+    static func extendedDesktop(for profile: TBMonitorDisplayProfile) -> TBVirtualDisplayIdentity {
+        // Deterministic identity per receiver so macOS retains window placement
+        // and the saved extended-desktop arrangement across reconnects.
+        let key = "\(profile.receiverName)|\(profile.panelWidth)x\(profile.panelHeight)"
+        let hash = djb2(key)
+        let productLow = (hash & 0x00FF) | 0x01
+        let serialLow = (hash & 0xFFFE) | 0x0100
         return TBVirtualDisplayIdentity(
-            productID: 0x6000 | (random & 0x00FF),
-            serialNumber: 0x2027_0000 | random,
+            productID: 0x6000 | productLow,
+            serialNumber: 0x2027_0000 | UInt32(serialLow),
             displayNamePrefix: "TB Extend",
             usesDedicatedArrangementIdentity: true
         )
+    }
+
+    private static func djb2(_ input: String) -> UInt32 {
+        var hash: UInt32 = 5381
+        for byte in input.utf8 {
+            hash = hash &* 33 &+ UInt32(byte)
+        }
+        return hash
     }
 }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260521211758"
+    static let buildNumber = "20260525204941"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260525204941"
+    static let buildNumber = "20260526205217"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -167,6 +167,8 @@ struct TBDisplaySenderContentView: View {
                 Toggle(TBDisplaySenderL10n.preventDisplaySleep(service.language), isOn: $service.preventDisplaySleep)
 
                 Toggle(TBDisplaySenderL10n.autoRestartOnWake(service.language), isOn: $service.autoRestartOnWake)
+
+                Toggle(TBDisplaySenderL10n.verboseDisplayLogging(service.language), isOn: $service.verboseDisplayLogging)
             }
         }
     }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -163,6 +163,10 @@ struct TBDisplaySenderContentView: View {
 
                 Toggle(TBDisplaySenderL10n.largeCursor(service.language), isOn: $service.largeCursor)
                     .disabled(service.anyConnected)
+
+                Toggle(TBDisplaySenderL10n.preventDisplaySleep(service.language), isOn: $service.preventDisplaySleep)
+
+                Toggle(TBDisplaySenderL10n.autoRestartOnWake(service.language), isOn: $service.autoRestartOnWake)
             }
         }
     }
@@ -335,6 +339,12 @@ private struct TBDisplaySenderSessionCard: View {
                 }
                 .buttonStyle(.bordered)
                 .disabled(session.isConnected || session.isStreaming || session.isCableTesting || trimmedReceiverIP.isEmpty || session.localTBIP.isEmpty)
+
+                Button(TBDisplaySenderL10n.restartCaptureButton(service.language)) {
+                    session.restartCaptureNow()
+                }
+                .buttonStyle(.bordered)
+                .disabled(!session.canRestartCapture)
 
                 Button(TBDisplaySenderL10n.removeSessionButton(service.language)) {
                     service.removeSession(session)

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -480,6 +480,30 @@ enum TBDisplaySenderL10n {
         }
     }
 
+    static func preventDisplaySleep(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Impedisci screensaver e sospensione display durante lo streaming"
+        case .english: return "Prevent screensaver / display sleep while streaming"
+        case .german: return "Bildschirmschoner und Display-Ruhezustand beim Streamen verhindern"
+        }
+    }
+
+    static func autoRestartOnWake(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Riavvia automaticamente la cattura al risveglio"
+        case .english: return "Auto-restart capture after wake / unlock"
+        case .german: return "Aufnahme nach Aufwachen/Entsperren automatisch neu starten"
+        }
+    }
+
+    static func restartCaptureButton(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Riavvia cattura"
+        case .english: return "Restart capture"
+        case .german: return "Aufnahme neu starten"
+        }
+    }
+
     static func showMainWindow(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Mostra finestra principale"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -504,6 +504,14 @@ enum TBDisplaySenderL10n {
         }
     }
 
+    static func verboseDisplayLogging(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Diagnostica display in Console (verboso)"
+        case .english: return "Log virtual display events to Console (verbose)"
+        case .german: return "Virtuelle Display-Ereignisse in Console protokollieren (ausführlich)"
+        }
+    }
+
     static func showMainWindow(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Mostra finestra principale"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -31,6 +31,30 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
+    @Published var preventDisplaySleep: Bool = {
+        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.preventDisplaySleep") == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep")
+    }() {
+        didSet {
+            UserDefaults.standard.set(preventDisplaySleep, forKey: "fd.tbdisplaysender.preventDisplaySleep")
+            sessions.forEach { $0.preventDisplaySleep = preventDisplaySleep }
+            objectWillChange.send()
+        }
+    }
+    @Published var autoRestartOnWake: Bool = {
+        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.autoRestartOnWake") == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake")
+    }() {
+        didSet {
+            UserDefaults.standard.set(autoRestartOnWake, forKey: "fd.tbdisplaysender.autoRestartOnWake")
+            sessions.forEach { $0.autoRestartOnWake = autoRestartOnWake }
+            objectWillChange.send()
+        }
+    }
 
     private var sessionCancellables: [UUID: AnyCancellable] = [:]
     private let receiverDiscovery = TBReceiverDiscovery()
@@ -70,7 +94,12 @@ final class TBDisplaySenderService: ObservableObject {
     }
 
     func addSession() {
-        let session = TBDisplaySenderSession(language: language, largeCursor: largeCursor)
+        let session = TBDisplaySenderSession(
+            language: language,
+            largeCursor: largeCursor,
+            preventDisplaySleep: preventDisplaySleep,
+            autoRestartOnWake: autoRestartOnWake
+        )
         if let previous = sessions.last {
             session.capturePreset = previous.capturePreset
             session.captureSource = previous.captureSource

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -31,27 +31,24 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
-    @Published var preventDisplaySleep: Bool = {
-        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.preventDisplaySleep") == nil {
-            return true
-        }
-        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep")
-    }() {
+    @Published var preventDisplaySleep: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep") {
         didSet {
             UserDefaults.standard.set(preventDisplaySleep, forKey: "fd.tbdisplaysender.preventDisplaySleep")
             sessions.forEach { $0.preventDisplaySleep = preventDisplaySleep }
             objectWillChange.send()
         }
     }
-    @Published var autoRestartOnWake: Bool = {
-        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.autoRestartOnWake") == nil {
-            return true
-        }
-        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake")
-    }() {
+    @Published var autoRestartOnWake: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake") {
         didSet {
             UserDefaults.standard.set(autoRestartOnWake, forKey: "fd.tbdisplaysender.autoRestartOnWake")
             sessions.forEach { $0.autoRestartOnWake = autoRestartOnWake }
+            objectWillChange.send()
+        }
+    }
+    @Published var verboseDisplayLogging: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.verboseDisplayLogging") {
+        didSet {
+            UserDefaults.standard.set(verboseDisplayLogging, forKey: "fd.tbdisplaysender.verboseDisplayLogging")
+            sessions.forEach { $0.verboseDisplayLogging = verboseDisplayLogging }
             objectWillChange.send()
         }
     }
@@ -98,7 +95,8 @@ final class TBDisplaySenderService: ObservableObject {
             language: language,
             largeCursor: largeCursor,
             preventDisplaySleep: preventDisplaySleep,
-            autoRestartOnWake: autoRestartOnWake
+            autoRestartOnWake: autoRestartOnWake,
+            verboseDisplayLogging: verboseDisplayLogging
         )
         if let previous = sessions.last {
             session.capturePreset = previous.capturePreset

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -394,18 +394,33 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     let id = UUID()
 
-    init(language: TBDisplaySenderLanguage, largeCursor: Bool) {
+    init(
+        language: TBDisplaySenderLanguage,
+        largeCursor: Bool,
+        preventDisplaySleep: Bool = true,
+        autoRestartOnWake: Bool = true
+    ) {
         self.statusText = TBDisplaySenderStatusState.ready.text(language)
         self.receiverPanelText = TBDisplaySenderL10n.waitingReceiverProfile(language)
         self.virtualDisplayText = TBDisplaySenderL10n.virtualDisplayNotCreated(language)
         self.language = language
         self.largeCursor = largeCursor
+        self.preventDisplaySleep = preventDisplaySleep
+        self.autoRestartOnWake = autoRestartOnWake
         self.streamResolutionText = TBDisplaySenderL10n.streamSummary(
             preset: .standard1440p,
             source: .desktopMirror,
             language: language
         )
         super.init()
+        registerWakeObservers()
+    }
+
+    deinit {
+        for token in wakeObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+            DistributedNotificationCenter.default().removeObserver(token)
+        }
     }
 
     @Published var isConnected = false
@@ -432,6 +447,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
     @Published var largeCursor: Bool
+    @Published var preventDisplaySleep: Bool = true
+    @Published var autoRestartOnWake: Bool = true
     @Published var capturePreset: TBDisplayCapturePreset = .standard1440p {
         didSet {
             if !isStreaming {
@@ -477,6 +494,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var baselineDisplayIDs = Set<CGDirectDisplayID>()
     private var cursorDisplayID: CGDirectDisplayID = kCGNullDirectDisplay
     private var lastCursorPacket: TBMonitorCursor?
+    nonisolated(unsafe) private var wakeObservers: [NSObjectProtocol] = []
+    private var isRestartingCaptureAfterWake = false
 
     private final class CaptureDelegate: NSObject, SCStreamOutput, SCStreamDelegate {
         var onFrame: ((CMSampleBuffer) -> Void)?
@@ -1056,7 +1075,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             isStreaming = true
             if largeCursor { startCursorUpdates(displayID: display.displayID) }
             streamingActivity = ProcessInfo.processInfo.beginActivity(
-                options: [.userInitiated, .idleSystemSleepDisabled],
+                options: activityOptions(),
                 reason: "TargetBridge streaming active"
             )
             startFPSTimer()
@@ -1094,11 +1113,19 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         isStreaming = true
         if largeCursor { startCursorUpdates(displayID: displayID) }
         streamingActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.userInitiated, .idleSystemSleepDisabled],
+            options: activityOptions(),
             reason: "TargetBridge streaming active"
         )
         startFPSTimer()
         return true
+    }
+
+    private func activityOptions() -> ProcessInfo.ActivityOptions {
+        var options: ProcessInfo.ActivityOptions = [.userInitiated, .idleSystemSleepDisabled]
+        if preventDisplaySleep {
+            options.insert(.idleDisplaySleepDisabled)
+        }
+        return options
     }
 
     private func waitForCaptureDisplay() async throws -> SCDisplay {
@@ -1643,6 +1670,112 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         lastCursorPacket = cursor
         if let packet = TBMonitorProtocol.makeJSONPacket(type: .cursor, value: cursor) {
             send(packet)
+        }
+    }
+
+    private func registerWakeObservers() {
+        let handler: @Sendable (Notification) -> Void = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleSystemWake()
+            }
+        }
+
+        wakeObservers.append(
+            NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.screensDidWakeNotification,
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+        wakeObservers.append(
+            DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("com.apple.screenIsUnlocked"),
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+        wakeObservers.append(
+            DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("com.apple.screensaver.didstop"),
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+    }
+
+    private func handleSystemWake() {
+        guard autoRestartOnWake else { return }
+        scheduleCaptureRestart(reason: "system wake", delaySeconds: 1.0)
+    }
+
+    func restartCaptureNow() {
+        scheduleCaptureRestart(reason: "manual restart", delaySeconds: 0.0)
+    }
+
+    var canRestartCapture: Bool {
+        isStreaming && activeProfile != nil && !isRestartingCaptureAfterWake
+    }
+
+    private func scheduleCaptureRestart(reason: String, delaySeconds: Double) {
+        guard isStreaming, !isRestartingCaptureAfterWake, let profile = activeProfile else { return }
+        isRestartingCaptureAfterWake = true
+        NSLog("TargetBridge: \(reason) — soft restart of capture pipeline")
+        Task { @MainActor [weak self] in
+            if delaySeconds > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+            }
+            guard let self else { return }
+            guard self.isStreaming, self.activeProfile?.receiverName == profile.receiverName else {
+                self.isRestartingCaptureAfterWake = false
+                return
+            }
+            await self.softRestartCapture(for: profile)
+            self.isRestartingCaptureAfterWake = false
+        }
+    }
+
+    private func softRestartCapture(for profile: TBMonitorDisplayProfile) async {
+        // Tear down only the capture pipeline — keep the network connection and virtual display.
+        cursorTimer?.invalidate()
+        cursorTimer = nil
+        fpsTimer?.invalidate()
+        fpsTimer = nil
+        if let directDisplayStream {
+            directDisplayStream.stop()
+            self.directDisplayStream = nil
+        }
+        if let stream = scStream {
+            if let delegate = captureDelegate {
+                try? stream.removeStreamOutput(delegate, type: .screen)
+            }
+            stream.stopCapture(completionHandler: nil)
+            scStream = nil
+        }
+        captureDelegate = nil
+        if let activity = streamingActivity {
+            ProcessInfo.processInfo.endActivity(activity)
+            streamingActivity = nil
+        }
+        if let encoder = vtEncoder { VTCompressionSessionInvalidate(encoder) }
+        vtEncoder = nil
+        vtEncoderRef?.release()
+        vtEncoderRef = nil
+        isStreaming = false
+        displayStreamFrameSequence = 0
+        senderFPS = 0
+        sentSnapshot = sentFrames
+        pendingVideoPackets = 0
+        inFlightEncodeFrames = 0
+        cursorDisplayID = kCGNullDirectDisplay
+        lastCursorPacket = nil
+
+        let started = await startCapture(for: profile)
+        if !started {
+            NSLog("TargetBridge: soft restart after wake failed — falling back to full stop")
+            stop(resetStatusTo: .captureError("capture restart after wake failed"))
         }
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -238,12 +238,12 @@ enum TBDisplayCaptureSource: String, CaseIterable, Identifiable {
         }
     }
 
-    var virtualDisplayIdentity: TBVirtualDisplayIdentity {
+    func virtualDisplayIdentity(for profile: TBMonitorDisplayProfile) -> TBVirtualDisplayIdentity {
         switch self {
         case .desktopMirror:
             return .desktopMirror
         case .extendedDesktop:
-            return .extendedDesktop()
+            return .extendedDesktop(for: profile)
         }
     }
 }
@@ -397,8 +397,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     init(
         language: TBDisplaySenderLanguage,
         largeCursor: Bool,
-        preventDisplaySleep: Bool = true,
-        autoRestartOnWake: Bool = true
+        preventDisplaySleep: Bool = false,
+        autoRestartOnWake: Bool = false,
+        verboseDisplayLogging: Bool = false
     ) {
         self.statusText = TBDisplaySenderStatusState.ready.text(language)
         self.receiverPanelText = TBDisplaySenderL10n.waitingReceiverProfile(language)
@@ -407,6 +408,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         self.largeCursor = largeCursor
         self.preventDisplaySleep = preventDisplaySleep
         self.autoRestartOnWake = autoRestartOnWake
+        self.verboseDisplayLogging = verboseDisplayLogging
         self.streamResolutionText = TBDisplaySenderL10n.streamSummary(
             preset: .standard1440p,
             source: .desktopMirror,
@@ -414,12 +416,19 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         )
         super.init()
         registerWakeObservers()
+        registerDisplayReconfigurationCallback()
     }
 
     deinit {
         for token in wakeObservers {
             NSWorkspace.shared.notificationCenter.removeObserver(token)
             DistributedNotificationCenter.default().removeObserver(token)
+        }
+        if displayReconfigurationCallbackRegistered {
+            CGDisplayRemoveReconfigurationCallback(
+                Self.displayReconfigurationCallback,
+                Unmanaged.passUnretained(self).toOpaque()
+            )
         }
     }
 
@@ -447,8 +456,17 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
     @Published var largeCursor: Bool
-    @Published var preventDisplaySleep: Bool = true
-    @Published var autoRestartOnWake: Bool = true
+    @Published var preventDisplaySleep: Bool = false
+    @Published var autoRestartOnWake: Bool = false
+    @Published var verboseDisplayLogging: Bool = false {
+        didSet {
+            if verboseDisplayLogging {
+                startVerboseLoggingTimer()
+            } else {
+                stopVerboseLoggingTimer()
+            }
+        }
+    }
     @Published var capturePreset: TBDisplayCapturePreset = .standard1440p {
         didSet {
             if !isStreaming {
@@ -496,6 +514,18 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var lastCursorPacket: TBMonitorCursor?
     nonisolated(unsafe) private var wakeObservers: [NSObjectProtocol] = []
     private var isRestartingCaptureAfterWake = false
+    nonisolated(unsafe) private var displayReconfigurationCallbackRegistered = false
+    private var verboseLoggingTimer: Timer?
+
+    nonisolated(unsafe) private static let displayReconfigurationCallback: CGDisplayReconfigurationCallBack = { displayID, flags, userInfo in
+        guard let userInfo else { return }
+        let service = Unmanaged<TBDisplaySenderSession>.fromOpaque(userInfo).takeUnretainedValue()
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                service.handleDisplayReconfiguration(displayID: displayID, flags: flags)
+            }
+        }
+    }
 
     private final class CaptureDelegate: NSObject, SCStreamOutput, SCStreamDelegate {
         var onFrame: ((CMSampleBuffer) -> Void)?
@@ -976,7 +1006,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             guard self.session.create(
                 from: profile,
                 refreshRate: self.capturePreset.virtualDisplayRefreshRate,
-                identity: self.captureSource.virtualDisplayIdentity
+                identity: self.captureSource.virtualDisplayIdentity(for: profile)
             ) else {
                 self.setStatus(.virtualDisplayCreationFailed)
                 self.stop(resetStatusTo: nil)
@@ -1703,6 +1733,77 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 queue: nil,
                 using: handler
             )
+        )
+    }
+
+    private func registerDisplayReconfigurationCallback() {
+        guard !displayReconfigurationCallbackRegistered else { return }
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        let result = CGDisplayRegisterReconfigurationCallback(Self.displayReconfigurationCallback, context)
+        displayReconfigurationCallbackRegistered = (result == .success)
+        if verboseDisplayLogging {
+            startVerboseLoggingTimer()
+        }
+    }
+
+    private func handleDisplayReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+        let isOurs = session.displayID != kCGNullDirectDisplay && displayID == session.displayID
+        guard verboseDisplayLogging || isOurs else { return }
+        var parts: [String] = []
+        if flags.contains(.addFlag) { parts.append("add") }
+        if flags.contains(.removeFlag) { parts.append("remove") }
+        if flags.contains(.enabledFlag) { parts.append("enabled") }
+        if flags.contains(.disabledFlag) { parts.append("disabled") }
+        if flags.contains(.mirrorFlag) { parts.append("mirror") }
+        if flags.contains(.unMirrorFlag) { parts.append("unMirror") }
+        if flags.contains(.movedFlag) { parts.append("moved") }
+        if flags.contains(.setMainFlag) { parts.append("setMain") }
+        if flags.contains(.setModeFlag) { parts.append("setMode") }
+        if flags.contains(.beginConfigurationFlag) { parts.append("beginConfiguration") }
+        if flags.contains(.desktopShapeChangedFlag) { parts.append("desktopShapeChanged") }
+        let flagText = parts.isEmpty ? "none" : parts.joined(separator: "|")
+        NSLog(
+            "TargetBridge: display reconfiguration displayID=%u ours=%@ flags=%@ online=[%@]",
+            displayID,
+            isOurs ? "yes" : "no",
+            flagText,
+            onlineDisplayIDs().map(String.init).joined(separator: ",")
+        )
+        if isOurs, session.displayID != kCGNullDirectDisplay {
+            displayStateText = describeDisplayState(for: session.displayID)
+        }
+    }
+
+    private func startVerboseLoggingTimer() {
+        stopVerboseLoggingTimer()
+        guard verboseDisplayLogging else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.logStreamSnapshot()
+            }
+        }
+        verboseLoggingTimer = timer
+        logStreamSnapshot()
+    }
+
+    private func stopVerboseLoggingTimer() {
+        verboseLoggingTimer?.invalidate()
+        verboseLoggingTimer = nil
+    }
+
+    private func logStreamSnapshot() {
+        guard verboseDisplayLogging else { return }
+        let online = onlineDisplayIDs()
+        let virtualOnline = online.contains(session.displayID)
+        NSLog(
+            "TargetBridge: stream snapshot streaming=%@ fps=%d virtualID=%u online=%@ pendingPackets=%d inFlightEncode=%d ptsSeq=%lld",
+            isStreaming ? "yes" : "no",
+            senderFPS,
+            session.displayID,
+            virtualOnline ? "yes" : "no",
+            pendingVideoPackets,
+            inFlightEncodeFrames,
+            displayStreamFrameSequence
         )
     }
 


### PR DESCRIPTION
## Summary

Sender-side GUI options that address two separate observed issues — windows on the extended display being forgotten after each reconnect, and intermittent post-event stutter — plus diagnostic plumbing for a longer-duration stutter that is still being characterized.

After in-field testing of the original screensaver-focused commit, both screensaver-related toggles default to **off** in this update — they didn't fix the long-duration stutter reproduced by the user and the actual repro cause appears to be unrelated to display sleep. They remain available as options for setups where they help.

## Changes

**Stable extended-display identity** (`ReceiverBackedVirtualDisplaySession.swift`)
- The extended-desktop virtual display previously generated a random productID/serialNumber on every `extendedDesktop()` call. macOS keys window-placement memory on those fields, so every reconnect looked like a brand-new display and windows on it were not restored.
- Identity is now derived deterministically (djb2) from `profile.receiverName + panelWidth + panelHeight` — same fields the codebase already uses for the persisted extended-arrangement key. Same receiver → same virtual display identity across reconnects → window placement persists.
- `TBDisplayCaptureSource.virtualDisplayIdentity` now takes a `TBMonitorDisplayProfile`.

**Settings card toggles** (`TBDisplaySenderContentView.swift`, `TBDisplaySenderManager.swift`, `TBDisplaySenderService.swift`)
1. *Prevent screensaver / display sleep while streaming* — default **off**. When on, adds `.idleDisplaySleepDisabled` to `ProcessInfo.beginActivity` so the screensaver cannot engage during a session.
2. *Auto-restart capture after wake / unlock* — default **off**. When on, observes `screensDidWakeNotification`, `com.apple.screenIsUnlocked`, and `com.apple.screensaver.didstop`, and soft-restarts the capture pipeline (`SCStream`/`CGDisplayStream` + `VTCompressionSession` + capture timers + activity) while preserving the `NWConnection` and the virtual display. PTS sequence is reset to avoid receiver-side pacing desync.
3. *Log virtual display events to Console (verbose)* — default **off**. When on, registers `CGDisplayRegisterReconfigurationCallback` to log every add/remove/mirror/mode-change event affecting any display, and emits a 60 s stream snapshot to `NSLog` containing streaming state, FPS, virtual display online status, pending packet count, in-flight encode count, and PTS sequence. Intended for diagnosing the long-duration stutter from `Console.app` without leaving heavy logging on for ordinary users.

**Per-session button**
- *Restart capture* (enabled while streaming) — runs the same soft-restart path on demand. Notably this does **not** rebuild the virtual display or `NWConnection`; the long-duration stutter so far does not appear to be cleared by this and remains under investigation (see the verbose logging toggle).

UserDefaults keys: `fd.tbdisplaysender.preventDisplaySleep`, `fd.tbdisplaysender.autoRestartOnWake`, `fd.tbdisplaysender.verboseDisplayLogging`. Existing stored values are preserved across the default flip.

Localized in IT / EN / DE.

## Test plan

- [ ] Build via Xcode (`TBDisplaySender` scheme) — verified locally, builds clean.
- [ ] Default install (all three toggles off) behaves identically to current `main`.
- [ ] With extended-desktop capture mode and window placement set up on a receiver, disconnect → reconnect — windows return to the extended display rather than reflowing to the laptop. Test with at least two distinct receivers to confirm identities don't collide.
- [ ] Enable "Prevent screensaver / display sleep" + let the Mac idle past the screensaver timeout while streaming — screensaver should not engage.
- [ ] Enable "Auto-restart capture after wake" only + manually trigger a screensaver and dismiss it — soft-restart logs should fire (`TargetBridge: system wake — soft restart of capture pipeline`).
- [ ] Click "Restart capture" while streaming — capture briefly drops and reestablishes; `NWConnection` and virtual display remain.
- [ ] Enable "Log virtual display events to Console (verbose)" and stream — `Console.app` shows reconfiguration events and the 60 s snapshot lines.
- [ ] All three settings persist across app relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)