### PR TITLE
Sender: capture watchdog + UI re-render storm mitigations

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/ReceiverBackedVirtualDisplaySession.swift
+++ b/TargetBridge-Sender/TBDisplaySender/ReceiverBackedVirtualDisplaySession.swift
@@ -18,14 +18,27 @@ struct TBVirtualDisplayIdentity {
         usesDedicatedArrangementIdentity: false
     )
 
-    static func extendedDesktop() -> TBVirtualDisplayIdentity {
-        let random = UInt32.random(in: 0x0100...0xFFFE)
+    static func extendedDesktop(for profile: TBMonitorDisplayProfile) -> TBVirtualDisplayIdentity {
+        // Deterministic identity per receiver so macOS retains window placement
+        // and the saved extended-desktop arrangement across reconnects.
+        let key = "\(profile.receiverName)|\(profile.panelWidth)x\(profile.panelHeight)"
+        let hash = djb2(key)
+        let productLow = (hash & 0x00FF) | 0x01
+        let serialLow = (hash & 0xFFFE) | 0x0100
         return TBVirtualDisplayIdentity(
-            productID: 0x6000 | (random & 0x00FF),
-            serialNumber: 0x2027_0000 | random,
+            productID: 0x6000 | productLow,
+            serialNumber: 0x2027_0000 | UInt32(serialLow),
             displayNamePrefix: "TB Extend",
             usesDedicatedArrangementIdentity: true
         )
+    }
+
+    private static func djb2(_ input: String) -> UInt32 {
+        var hash: UInt32 = 5381
+        for byte in input.utf8 {
+            hash = hash &* 33 &+ UInt32(byte)
+        }
+        return hash
     }
 }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260526205217"
+    static let buildNumber = "20260527204607"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260521211758"
+    static let buildNumber = "20260525204941"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "2.0"
-    static let buildNumber = "20260525204941"
+    static let buildNumber = "20260526205217"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -167,6 +167,8 @@ struct TBDisplaySenderContentView: View {
                 Toggle(TBDisplaySenderL10n.preventDisplaySleep(service.language), isOn: $service.preventDisplaySleep)
 
                 Toggle(TBDisplaySenderL10n.autoRestartOnWake(service.language), isOn: $service.autoRestartOnWake)
+
+                Toggle(TBDisplaySenderL10n.verboseDisplayLogging(service.language), isOn: $service.verboseDisplayLogging)
             }
         }
     }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -235,7 +235,11 @@ private struct TBDisplaySenderSessionCard: View {
                         }
                         .onChange(of: session.selectedReceiverID) { _, newValue in
                             guard let receiver = service.discoveredReceivers.first(where: { $0.id == newValue }) else { return }
-                            service.applyDiscoveredReceiver(receiver, to: session)
+                            // Defer the mutation past SwiftUI's current view-update phase to avoid
+                            // "Publishing changes from within view updates is not allowed".
+                            DispatchQueue.main.async {
+                                service.applyDiscoveredReceiver(receiver, to: session)
+                            }
                         }
                         .disabled(session.isConnected || session.isStreaming)
                     }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -163,6 +163,10 @@ struct TBDisplaySenderContentView: View {
 
                 Toggle(TBDisplaySenderL10n.largeCursor(service.language), isOn: $service.largeCursor)
                     .disabled(service.anyConnected)
+
+                Toggle(TBDisplaySenderL10n.preventDisplaySleep(service.language), isOn: $service.preventDisplaySleep)
+
+                Toggle(TBDisplaySenderL10n.autoRestartOnWake(service.language), isOn: $service.autoRestartOnWake)
             }
         }
     }
@@ -335,6 +339,12 @@ private struct TBDisplaySenderSessionCard: View {
                 }
                 .buttonStyle(.bordered)
                 .disabled(session.isConnected || session.isStreaming || session.isCableTesting || trimmedReceiverIP.isEmpty || session.localTBIP.isEmpty)
+
+                Button(TBDisplaySenderL10n.restartCaptureButton(service.language)) {
+                    session.restartCaptureNow()
+                }
+                .buttonStyle(.bordered)
+                .disabled(!session.canRestartCapture)
 
                 Button(TBDisplaySenderL10n.removeSessionButton(service.language)) {
                     service.removeSession(session)

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -480,6 +480,30 @@ enum TBDisplaySenderL10n {
         }
     }
 
+    static func preventDisplaySleep(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Impedisci screensaver e sospensione display durante lo streaming"
+        case .english: return "Prevent screensaver / display sleep while streaming"
+        case .german: return "Bildschirmschoner und Display-Ruhezustand beim Streamen verhindern"
+        }
+    }
+
+    static func autoRestartOnWake(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Riavvia automaticamente la cattura al risveglio"
+        case .english: return "Auto-restart capture after wake / unlock"
+        case .german: return "Aufnahme nach Aufwachen/Entsperren automatisch neu starten"
+        }
+    }
+
+    static func restartCaptureButton(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Riavvia cattura"
+        case .english: return "Restart capture"
+        case .german: return "Aufnahme neu starten"
+        }
+    }
+
     static func showMainWindow(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Mostra finestra principale"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -504,6 +504,14 @@ enum TBDisplaySenderL10n {
         }
     }
 
+    static func verboseDisplayLogging(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Diagnostica display in Console (verboso)"
+        case .english: return "Log virtual display events to Console (verbose)"
+        case .german: return "Virtuelle Display-Ereignisse in Console protokollieren (ausführlich)"
+        }
+    }
+
     static func showMainWindow(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Mostra finestra principale"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -20,7 +20,6 @@ final class TBDisplaySenderService: ObservableObject {
         didSet {
             language.persist()
             sessions.forEach { $0.language = language }
-            objectWillChange.send()
         }
     }
     @Published var showsMenuBarIcon = true
@@ -28,28 +27,24 @@ final class TBDisplaySenderService: ObservableObject {
         didSet {
             UserDefaults.standard.set(largeCursor, forKey: "fd.tbdisplaysender.largeCursor")
             sessions.forEach { $0.largeCursor = largeCursor }
-            objectWillChange.send()
         }
     }
     @Published var preventDisplaySleep: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep") {
         didSet {
             UserDefaults.standard.set(preventDisplaySleep, forKey: "fd.tbdisplaysender.preventDisplaySleep")
             sessions.forEach { $0.preventDisplaySleep = preventDisplaySleep }
-            objectWillChange.send()
         }
     }
     @Published var autoRestartOnWake: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake") {
         didSet {
             UserDefaults.standard.set(autoRestartOnWake, forKey: "fd.tbdisplaysender.autoRestartOnWake")
             sessions.forEach { $0.autoRestartOnWake = autoRestartOnWake }
-            objectWillChange.send()
         }
     }
     @Published var verboseDisplayLogging: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.verboseDisplayLogging") {
         didSet {
             UserDefaults.standard.set(verboseDisplayLogging, forKey: "fd.tbdisplaysender.verboseDisplayLogging")
             sessions.forEach { $0.verboseDisplayLogging = verboseDisplayLogging }
-            objectWillChange.send()
         }
     }
 
@@ -61,7 +56,6 @@ final class TBDisplaySenderService: ObservableObject {
         discoveryCancellable = receiverDiscovery.$receivers.sink { [weak self] receivers in
             guard let self else { return }
             discoveredReceivers = receivers
-            objectWillChange.send()
         }
         refreshBridgeInterfaces()
         addSession()
@@ -107,7 +101,6 @@ final class TBDisplaySenderService: ObservableObject {
         }
         attachSession(session)
         sessions.append(session)
-        objectWillChange.send()
     }
 
     func removeSession(_ session: TBDisplaySenderSession) {
@@ -116,7 +109,6 @@ final class TBDisplaySenderService: ObservableObject {
         sessions.removeAll { $0.id == session.id }
         sessionCancellables.removeValue(forKey: session.id)
         normalizeSessionInterfaces()
-        objectWillChange.send()
     }
 
     func stopAll() {
@@ -128,7 +120,6 @@ final class TBDisplaySenderService: ObservableObject {
         bridgeInterfaces = detectBridgeInterfaces()
         receiverDiscovery.refresh()
         normalizeSessionInterfaces()
-        objectWillChange.send()
     }
 
     func applyDiscoveredReceiver(_ receiver: TBDiscoveredReceiver, to session: TBDisplaySenderSession) {
@@ -136,7 +127,6 @@ final class TBDisplaySenderService: ObservableObject {
         if session.localTBIP.isEmpty {
             session.localTBIP = suggestedInterfaceForNewSession()?.ip ?? bridgeInterfaces.first?.ip ?? ""
         }
-        objectWillChange.send()
     }
 
     func sessionTitle(for session: TBDisplaySenderSession) -> String {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -31,6 +31,30 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
+    @Published var preventDisplaySleep: Bool = {
+        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.preventDisplaySleep") == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep")
+    }() {
+        didSet {
+            UserDefaults.standard.set(preventDisplaySleep, forKey: "fd.tbdisplaysender.preventDisplaySleep")
+            sessions.forEach { $0.preventDisplaySleep = preventDisplaySleep }
+            objectWillChange.send()
+        }
+    }
+    @Published var autoRestartOnWake: Bool = {
+        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.autoRestartOnWake") == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake")
+    }() {
+        didSet {
+            UserDefaults.standard.set(autoRestartOnWake, forKey: "fd.tbdisplaysender.autoRestartOnWake")
+            sessions.forEach { $0.autoRestartOnWake = autoRestartOnWake }
+            objectWillChange.send()
+        }
+    }
 
     private var sessionCancellables: [UUID: AnyCancellable] = [:]
     private let receiverDiscovery = TBReceiverDiscovery()
@@ -70,7 +94,12 @@ final class TBDisplaySenderService: ObservableObject {
     }
 
     func addSession() {
-        let session = TBDisplaySenderSession(language: language, largeCursor: largeCursor)
+        let session = TBDisplaySenderSession(
+            language: language,
+            largeCursor: largeCursor,
+            preventDisplaySleep: preventDisplaySleep,
+            autoRestartOnWake: autoRestartOnWake
+        )
         if let previous = sessions.last {
             session.capturePreset = previous.capturePreset
             session.captureSource = previous.captureSource

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -31,27 +31,24 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
-    @Published var preventDisplaySleep: Bool = {
-        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.preventDisplaySleep") == nil {
-            return true
-        }
-        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep")
-    }() {
+    @Published var preventDisplaySleep: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.preventDisplaySleep") {
         didSet {
             UserDefaults.standard.set(preventDisplaySleep, forKey: "fd.tbdisplaysender.preventDisplaySleep")
             sessions.forEach { $0.preventDisplaySleep = preventDisplaySleep }
             objectWillChange.send()
         }
     }
-    @Published var autoRestartOnWake: Bool = {
-        if UserDefaults.standard.object(forKey: "fd.tbdisplaysender.autoRestartOnWake") == nil {
-            return true
-        }
-        return UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake")
-    }() {
+    @Published var autoRestartOnWake: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.autoRestartOnWake") {
         didSet {
             UserDefaults.standard.set(autoRestartOnWake, forKey: "fd.tbdisplaysender.autoRestartOnWake")
             sessions.forEach { $0.autoRestartOnWake = autoRestartOnWake }
+            objectWillChange.send()
+        }
+    }
+    @Published var verboseDisplayLogging: Bool = UserDefaults.standard.bool(forKey: "fd.tbdisplaysender.verboseDisplayLogging") {
+        didSet {
+            UserDefaults.standard.set(verboseDisplayLogging, forKey: "fd.tbdisplaysender.verboseDisplayLogging")
+            sessions.forEach { $0.verboseDisplayLogging = verboseDisplayLogging }
             objectWillChange.send()
         }
     }
@@ -98,7 +95,8 @@ final class TBDisplaySenderService: ObservableObject {
             language: language,
             largeCursor: largeCursor,
             preventDisplaySleep: preventDisplaySleep,
-            autoRestartOnWake: autoRestartOnWake
+            autoRestartOnWake: autoRestartOnWake,
+            verboseDisplayLogging: verboseDisplayLogging
         )
         if let previous = sessions.last {
             session.capturePreset = previous.capturePreset

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -394,18 +394,33 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     let id = UUID()
 
-    init(language: TBDisplaySenderLanguage, largeCursor: Bool) {
+    init(
+        language: TBDisplaySenderLanguage,
+        largeCursor: Bool,
+        preventDisplaySleep: Bool = true,
+        autoRestartOnWake: Bool = true
+    ) {
         self.statusText = TBDisplaySenderStatusState.ready.text(language)
         self.receiverPanelText = TBDisplaySenderL10n.waitingReceiverProfile(language)
         self.virtualDisplayText = TBDisplaySenderL10n.virtualDisplayNotCreated(language)
         self.language = language
         self.largeCursor = largeCursor
+        self.preventDisplaySleep = preventDisplaySleep
+        self.autoRestartOnWake = autoRestartOnWake
         self.streamResolutionText = TBDisplaySenderL10n.streamSummary(
             preset: .standard1440p,
             source: .desktopMirror,
             language: language
         )
         super.init()
+        registerWakeObservers()
+    }
+
+    deinit {
+        for token in wakeObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(token)
+            DistributedNotificationCenter.default().removeObserver(token)
+        }
     }
 
     @Published var isConnected = false
@@ -432,6 +447,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
     @Published var largeCursor: Bool
+    @Published var preventDisplaySleep: Bool = true
+    @Published var autoRestartOnWake: Bool = true
     @Published var capturePreset: TBDisplayCapturePreset = .standard1440p {
         didSet {
             if !isStreaming {
@@ -477,6 +494,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var baselineDisplayIDs = Set<CGDirectDisplayID>()
     private var cursorDisplayID: CGDirectDisplayID = kCGNullDirectDisplay
     private var lastCursorPacket: TBMonitorCursor?
+    nonisolated(unsafe) private var wakeObservers: [NSObjectProtocol] = []
+    private var isRestartingCaptureAfterWake = false
 
     private final class CaptureDelegate: NSObject, SCStreamOutput, SCStreamDelegate {
         var onFrame: ((CMSampleBuffer) -> Void)?
@@ -1056,7 +1075,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             isStreaming = true
             if largeCursor { startCursorUpdates(displayID: display.displayID) }
             streamingActivity = ProcessInfo.processInfo.beginActivity(
-                options: [.userInitiated, .idleSystemSleepDisabled],
+                options: activityOptions(),
                 reason: "TargetBridge streaming active"
             )
             startFPSTimer()
@@ -1094,11 +1113,19 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         isStreaming = true
         if largeCursor { startCursorUpdates(displayID: displayID) }
         streamingActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.userInitiated, .idleSystemSleepDisabled],
+            options: activityOptions(),
             reason: "TargetBridge streaming active"
         )
         startFPSTimer()
         return true
+    }
+
+    private func activityOptions() -> ProcessInfo.ActivityOptions {
+        var options: ProcessInfo.ActivityOptions = [.userInitiated, .idleSystemSleepDisabled]
+        if preventDisplaySleep {
+            options.insert(.idleDisplaySleepDisabled)
+        }
+        return options
     }
 
     private func waitForCaptureDisplay() async throws -> SCDisplay {
@@ -1643,6 +1670,112 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         lastCursorPacket = cursor
         if let packet = TBMonitorProtocol.makeJSONPacket(type: .cursor, value: cursor) {
             send(packet)
+        }
+    }
+
+    private func registerWakeObservers() {
+        let handler: @Sendable (Notification) -> Void = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handleSystemWake()
+            }
+        }
+
+        wakeObservers.append(
+            NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.screensDidWakeNotification,
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+        wakeObservers.append(
+            DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("com.apple.screenIsUnlocked"),
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+        wakeObservers.append(
+            DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("com.apple.screensaver.didstop"),
+                object: nil,
+                queue: nil,
+                using: handler
+            )
+        )
+    }
+
+    private func handleSystemWake() {
+        guard autoRestartOnWake else { return }
+        scheduleCaptureRestart(reason: "system wake", delaySeconds: 1.0)
+    }
+
+    func restartCaptureNow() {
+        scheduleCaptureRestart(reason: "manual restart", delaySeconds: 0.0)
+    }
+
+    var canRestartCapture: Bool {
+        isStreaming && activeProfile != nil && !isRestartingCaptureAfterWake
+    }
+
+    private func scheduleCaptureRestart(reason: String, delaySeconds: Double) {
+        guard isStreaming, !isRestartingCaptureAfterWake, let profile = activeProfile else { return }
+        isRestartingCaptureAfterWake = true
+        NSLog("TargetBridge: \(reason) — soft restart of capture pipeline")
+        Task { @MainActor [weak self] in
+            if delaySeconds > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+            }
+            guard let self else { return }
+            guard self.isStreaming, self.activeProfile?.receiverName == profile.receiverName else {
+                self.isRestartingCaptureAfterWake = false
+                return
+            }
+            await self.softRestartCapture(for: profile)
+            self.isRestartingCaptureAfterWake = false
+        }
+    }
+
+    private func softRestartCapture(for profile: TBMonitorDisplayProfile) async {
+        // Tear down only the capture pipeline — keep the network connection and virtual display.
+        cursorTimer?.invalidate()
+        cursorTimer = nil
+        fpsTimer?.invalidate()
+        fpsTimer = nil
+        if let directDisplayStream {
+            directDisplayStream.stop()
+            self.directDisplayStream = nil
+        }
+        if let stream = scStream {
+            if let delegate = captureDelegate {
+                try? stream.removeStreamOutput(delegate, type: .screen)
+            }
+            stream.stopCapture(completionHandler: nil)
+            scStream = nil
+        }
+        captureDelegate = nil
+        if let activity = streamingActivity {
+            ProcessInfo.processInfo.endActivity(activity)
+            streamingActivity = nil
+        }
+        if let encoder = vtEncoder { VTCompressionSessionInvalidate(encoder) }
+        vtEncoder = nil
+        vtEncoderRef?.release()
+        vtEncoderRef = nil
+        isStreaming = false
+        displayStreamFrameSequence = 0
+        senderFPS = 0
+        sentSnapshot = sentFrames
+        pendingVideoPackets = 0
+        inFlightEncodeFrames = 0
+        cursorDisplayID = kCGNullDirectDisplay
+        lastCursorPacket = nil
+
+        let started = await startCapture(for: profile)
+        if !started {
+            NSLog("TargetBridge: soft restart after wake failed — falling back to full stop")
+            stop(resetStatusTo: .captureError("capture restart after wake failed"))
         }
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -238,12 +238,12 @@ enum TBDisplayCaptureSource: String, CaseIterable, Identifiable {
         }
     }
 
-    var virtualDisplayIdentity: TBVirtualDisplayIdentity {
+    func virtualDisplayIdentity(for profile: TBMonitorDisplayProfile) -> TBVirtualDisplayIdentity {
         switch self {
         case .desktopMirror:
             return .desktopMirror
         case .extendedDesktop:
-            return .extendedDesktop()
+            return .extendedDesktop(for: profile)
         }
     }
 }
@@ -397,8 +397,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     init(
         language: TBDisplaySenderLanguage,
         largeCursor: Bool,
-        preventDisplaySleep: Bool = true,
-        autoRestartOnWake: Bool = true
+        preventDisplaySleep: Bool = false,
+        autoRestartOnWake: Bool = false,
+        verboseDisplayLogging: Bool = false
     ) {
         self.statusText = TBDisplaySenderStatusState.ready.text(language)
         self.receiverPanelText = TBDisplaySenderL10n.waitingReceiverProfile(language)
@@ -407,6 +408,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         self.largeCursor = largeCursor
         self.preventDisplaySleep = preventDisplaySleep
         self.autoRestartOnWake = autoRestartOnWake
+        self.verboseDisplayLogging = verboseDisplayLogging
         self.streamResolutionText = TBDisplaySenderL10n.streamSummary(
             preset: .standard1440p,
             source: .desktopMirror,
@@ -414,12 +416,19 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         )
         super.init()
         registerWakeObservers()
+        registerDisplayReconfigurationCallback()
     }
 
     deinit {
         for token in wakeObservers {
             NSWorkspace.shared.notificationCenter.removeObserver(token)
             DistributedNotificationCenter.default().removeObserver(token)
+        }
+        if displayReconfigurationCallbackRegistered {
+            CGDisplayRemoveReconfigurationCallback(
+                Self.displayReconfigurationCallback,
+                Unmanaged.passUnretained(self).toOpaque()
+            )
         }
     }
 
@@ -447,8 +456,17 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
     @Published var largeCursor: Bool
-    @Published var preventDisplaySleep: Bool = true
-    @Published var autoRestartOnWake: Bool = true
+    @Published var preventDisplaySleep: Bool = false
+    @Published var autoRestartOnWake: Bool = false
+    @Published var verboseDisplayLogging: Bool = false {
+        didSet {
+            if verboseDisplayLogging {
+                startVerboseLoggingTimer()
+            } else {
+                stopVerboseLoggingTimer()
+            }
+        }
+    }
     @Published var capturePreset: TBDisplayCapturePreset = .standard1440p {
         didSet {
             if !isStreaming {
@@ -496,6 +514,18 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var lastCursorPacket: TBMonitorCursor?
     nonisolated(unsafe) private var wakeObservers: [NSObjectProtocol] = []
     private var isRestartingCaptureAfterWake = false
+    nonisolated(unsafe) private var displayReconfigurationCallbackRegistered = false
+    private var verboseLoggingTimer: Timer?
+
+    nonisolated(unsafe) private static let displayReconfigurationCallback: CGDisplayReconfigurationCallBack = { displayID, flags, userInfo in
+        guard let userInfo else { return }
+        let service = Unmanaged<TBDisplaySenderSession>.fromOpaque(userInfo).takeUnretainedValue()
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                service.handleDisplayReconfiguration(displayID: displayID, flags: flags)
+            }
+        }
+    }
 
     private final class CaptureDelegate: NSObject, SCStreamOutput, SCStreamDelegate {
         var onFrame: ((CMSampleBuffer) -> Void)?
@@ -976,7 +1006,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             guard self.session.create(
                 from: profile,
                 refreshRate: self.capturePreset.virtualDisplayRefreshRate,
-                identity: self.captureSource.virtualDisplayIdentity
+                identity: self.captureSource.virtualDisplayIdentity(for: profile)
             ) else {
                 self.setStatus(.virtualDisplayCreationFailed)
                 self.stop(resetStatusTo: nil)
@@ -1703,6 +1733,77 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 queue: nil,
                 using: handler
             )
+        )
+    }
+
+    private func registerDisplayReconfigurationCallback() {
+        guard !displayReconfigurationCallbackRegistered else { return }
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        let result = CGDisplayRegisterReconfigurationCallback(Self.displayReconfigurationCallback, context)
+        displayReconfigurationCallbackRegistered = (result == .success)
+        if verboseDisplayLogging {
+            startVerboseLoggingTimer()
+        }
+    }
+
+    private func handleDisplayReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+        let isOurs = session.displayID != kCGNullDirectDisplay && displayID == session.displayID
+        guard verboseDisplayLogging || isOurs else { return }
+        var parts: [String] = []
+        if flags.contains(.addFlag) { parts.append("add") }
+        if flags.contains(.removeFlag) { parts.append("remove") }
+        if flags.contains(.enabledFlag) { parts.append("enabled") }
+        if flags.contains(.disabledFlag) { parts.append("disabled") }
+        if flags.contains(.mirrorFlag) { parts.append("mirror") }
+        if flags.contains(.unMirrorFlag) { parts.append("unMirror") }
+        if flags.contains(.movedFlag) { parts.append("moved") }
+        if flags.contains(.setMainFlag) { parts.append("setMain") }
+        if flags.contains(.setModeFlag) { parts.append("setMode") }
+        if flags.contains(.beginConfigurationFlag) { parts.append("beginConfiguration") }
+        if flags.contains(.desktopShapeChangedFlag) { parts.append("desktopShapeChanged") }
+        let flagText = parts.isEmpty ? "none" : parts.joined(separator: "|")
+        NSLog(
+            "TargetBridge: display reconfiguration displayID=%u ours=%@ flags=%@ online=[%@]",
+            displayID,
+            isOurs ? "yes" : "no",
+            flagText,
+            onlineDisplayIDs().map(String.init).joined(separator: ",")
+        )
+        if isOurs, session.displayID != kCGNullDirectDisplay {
+            displayStateText = describeDisplayState(for: session.displayID)
+        }
+    }
+
+    private func startVerboseLoggingTimer() {
+        stopVerboseLoggingTimer()
+        guard verboseDisplayLogging else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.logStreamSnapshot()
+            }
+        }
+        verboseLoggingTimer = timer
+        logStreamSnapshot()
+    }
+
+    private func stopVerboseLoggingTimer() {
+        verboseLoggingTimer?.invalidate()
+        verboseLoggingTimer = nil
+    }
+
+    private func logStreamSnapshot() {
+        guard verboseDisplayLogging else { return }
+        let online = onlineDisplayIDs()
+        let virtualOnline = online.contains(session.displayID)
+        NSLog(
+            "TargetBridge: stream snapshot streaming=%@ fps=%d virtualID=%u online=%@ pendingPackets=%d inFlightEncode=%d ptsSeq=%lld",
+            isStreaming ? "yes" : "no",
+            senderFPS,
+            session.displayID,
+            virtualOnline ? "yes" : "no",
+            pendingVideoPackets,
+            inFlightEncodeFrames,
+            displayStreamFrameSequence
         )
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -516,6 +516,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var isRestartingCaptureAfterWake = false
     nonisolated(unsafe) private var displayReconfigurationCallbackRegistered = false
     private var verboseLoggingTimer: Timer?
+    private var lastCaptureFrameAt: Date = Date()
+    private var captureHealthWatchdog: Timer?
 
     nonisolated(unsafe) private static let displayReconfigurationCallback: CGDisplayReconfigurationCallBack = { displayID, flags, userInfo in
         guard let userInfo else { return }
@@ -793,6 +795,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         cursorTimer = nil
         fpsTimer?.invalidate()
         fpsTimer = nil
+        stopCaptureWatchdog()
         if let directDisplayStream {
             directDisplayStream.stop()
             self.directDisplayStream = nil
@@ -1109,6 +1112,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 reason: "TargetBridge streaming active"
             )
             startFPSTimer()
+            startCaptureWatchdog()
             return true
         } catch {
             if error.localizedDescription.hasPrefix("no virtual SCDisplay available") {
@@ -1147,6 +1151,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             reason: "TargetBridge streaming active"
         )
         startFPSTimer()
+        startCaptureWatchdog()
         return true
     }
 
@@ -1433,6 +1438,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     private func encode(_ sampleBuffer: CMSampleBuffer) {
+        lastCaptureFrameAt = Date()
         guard let encoder = vtEncoder,
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
@@ -1446,6 +1452,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     fileprivate func encodeDisplaySurface(_ surface: IOSurface, displayTime: UInt64) {
+        lastCaptureFrameAt = Date()
         guard let encoder = vtEncoder else { return }
         if capturePreset.dropsBeforeEncodeWhenBacklogged,
            (pendingVideoPackets >= capturePreset.maxPendingVideoPackets ||
@@ -1791,6 +1798,29 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         verboseLoggingTimer = nil
     }
 
+    private func startCaptureWatchdog() {
+        captureHealthWatchdog?.invalidate()
+        lastCaptureFrameAt = Date()
+        captureHealthWatchdog = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.checkCaptureHealth()
+            }
+        }
+    }
+
+    private func stopCaptureWatchdog() {
+        captureHealthWatchdog?.invalidate()
+        captureHealthWatchdog = nil
+    }
+
+    private func checkCaptureHealth() {
+        guard isStreaming, activeProfile != nil, !isRestartingCaptureAfterWake else { return }
+        let elapsed = Date().timeIntervalSince(lastCaptureFrameAt)
+        guard elapsed >= 8.0 else { return }
+        NSLog("TargetBridge: capture watchdog tripped — %.1fs since last frame, soft restart", elapsed)
+        scheduleCaptureRestart(reason: "watchdog (\(Int(elapsed))s without frames)", delaySeconds: 0.5)
+    }
+
     private func logStreamSnapshot() {
         guard verboseDisplayLogging else { return }
         let online = onlineDisplayIDs()
@@ -1844,6 +1874,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         cursorTimer = nil
         fpsTimer?.invalidate()
         fpsTimer = nil
+        stopCaptureWatchdog()
         if let directDisplayStream {
             directDisplayStream.stop()
             self.directDisplayStream = nil


### PR DESCRIPTION
## Summary

Addresses the long-duration stutter that has plagued long-running sender sessions. **Stacked on #69** — the watchdog reuses the `softRestartCapture(for:)` path introduced there. If #69 lands first, this PR can be rebased onto main with no conflicts; if this lands first, please merge or rebase #69 onto it.

## What we learned from a 23.5 h live capture

After collecting `sample`, `vmmap`, `nettop`, and 24 h of `log show` from a sender process that was stuck at 99.7% CPU (write-up in user's local `~/tb-diag-20260527-203102/FINDINGS.md`):

- **`replayd` (the daemon backing `SCStream` / `ScreenCaptureKit`) was issuing `RPDaemonProxy: connection INTERRUPTED` every ~30 minutes** — 14 times in the observed window. This is the sandbox-extension refresh cycle. The interruption does **not** reliably reach our `SCStreamDelegate didStopWithError` handler, so the existing pipeline kept running in a degraded state.
- Sample showed the main thread spinning in recursive `NSView _layoutSubtreeWithOldSize:` — a SwiftUI/AppKit runaway-layout loop, almost certainly amplified by the degraded capture state.
- The virtual display was still online — earlier hypotheses about display eviction were wrong.
- The `NWConnection` had accumulated 2.1 M retransmits before becoming unresponsive, but that was downstream of the wedged main thread, not the cause.
- At startup SwiftUI logged "Publishing changes from within view updates is not allowed" 16 times — a latent bug that is harmless under normal load but amplifies the failure mode once anything degrades.

## Changes

### 1. Capture watchdog (`TBDisplaySenderService.swift`)

- New `private var lastCaptureFrameAt: Date` is bumped at the top of both `encode(_ sampleBuffer:)` and `encodeDisplaySurface(_:displayTime:)`.
- New `captureHealthWatchdog: Timer` fires every 5 s on the main actor. If `isStreaming` is true, `activeProfile` is set, no restart is already in flight, and `Date().timeIntervalSince(lastCaptureFrameAt) >= 8.0`, the watchdog calls `scheduleCaptureRestart(reason: "watchdog (...)", delaySeconds: 0.5)`.
- The restart path is the **same `softRestartCapture(for:)` from #69** — capture pipeline, encoder, FPS / cursor timers, and the streaming activity are torn down; `NWConnection` and the virtual display are preserved.
- Started after `startFPSTimer()` in both `startCapture(for:)` and `startDirectDisplayStream(...)`. Torn down in `stop(resetStatusTo:)` and at the top of `softRestartCapture(for:)`.

Threshold rationale: 8 s is comfortably longer than any expected per-frame gap at 30 / 60 fps (33 / 16 ms) but short enough that the user only sees a brief blink before the rebuild completes.

### 2. Remove redundant `objectWillChange.send()` in `TBDisplaySenderManager.swift`

`@Published` already emits `objectWillChange` automatically. The didSet blocks, the `discoveryCancellable` sink, `addSession`, `removeSession`, `refreshBridgeInterfaces`, and `applyDiscoveredReceiver` all had a second explicit `objectWillChange.send()`. Removed those — each mutation now produces exactly one notification.

The bubble-up sink in `attachSession` (session → manager) is preserved; it is the only non-redundant explicit emit and is required so manager-bound views re-render when session state changes.

### 3. Defer the discovered-receiver picker mutation (`TBDisplaySenderContentView.swift`)

`.onChange(of: session.selectedReceiverID)` was calling `service.applyDiscoveredReceiver` synchronously from within the view-update phase, mutating `session.receiverIP` and `session.localTBIP` (both `@Published`) before SwiftUI had finished its current pass. Wrapping the mutation in `DispatchQueue.main.async { ... }` defers it to after the current view update completes and resolves the runtime warning.

## Test plan

- [ ] Build via Xcode (`TBDisplaySender` scheme) — verified locally, builds clean.
- [ ] Default behavior with the watchdog: stream for at least one full `replayd` interruption cycle (~30 min). Expect to see in `Console.app`:
      `TargetBridge: capture watchdog tripped — N.Ns since last frame, soft restart`
      `TargetBridge: watchdog (Ns without frames) — soft restart of capture pipeline`
      and the stream should recover automatically without the user noticing more than a brief blink.
- [ ] Confirm the receiver session remains connected across the watchdog-driven restart (`NWConnection` is preserved).
- [ ] At launch, observe `log show --predicate 'process == "TargetBridge"' --info --last 1m` — the `Publishing changes from within view updates` warnings should no longer appear.
- [ ] Toggle settings (Prevent display sleep, Auto-restart on wake, Verbose logging) repeatedly during streaming — UI remains responsive (no doubled notifications causing extra re-renders).
- [ ] Manually click the in-app "Restart capture" button — same soft-restart path as the watchdog, should behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)