### PR TITLE
feat(audio): add receiver volume control slider

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -31,7 +31,7 @@ LDFLAGS  += $(shell $(PKG) --libs libavcodec libavutil sdl2)
 
 UNAME_S  := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices
+LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices -framework CoreAudio
 endif
 
 C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/tb_i18n.c

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -25,6 +25,13 @@
 #include <dns_sd.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
+#include <CoreAudio/CoreAudio.h>
+
+/* kAudioObjectPropertyElementMain is the macOS 12+ SDK spelling; older SDKs
+ * only define kAudioObjectPropertyElementMaster (both are numerically 0). */
+#ifndef kAudioObjectPropertyElementMain
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
 
 #include <errno.h>
 #include <limits.h>
@@ -895,6 +902,53 @@ static void audio_callback(void *userdata, Uint8 *stream, int len) {
     }
 }
 
+/* Drive the receiver's master output volume knob (with the system volume HUD).
+ * level is clamped to 0.0..1.0. Sets the default output device's scalar volume,
+ * preferring the master element and falling back to per-channel when a device
+ * has no master volume control. Safe to call from the network/parser thread. */
+static void tb_set_system_volume(double level) {
+    if (level < 0.0) level = 0.0;
+    if (level > 1.0) level = 1.0;
+    Float32 vol = (Float32)level;
+
+    AudioObjectPropertyAddress dev_addr = {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    AudioDeviceID device = kAudioObjectUnknown;
+    UInt32 size = sizeof(device);
+    if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &dev_addr, 0, NULL,
+                                   &size, &device) != noErr ||
+        device == kAudioObjectUnknown) {
+        return;
+    }
+
+    AudioObjectPropertyAddress vol_addr = {
+        kAudioDevicePropertyVolumeScalar,
+        kAudioDevicePropertyScopeOutput,
+        kAudioObjectPropertyElementMain   /* element 0 = master */
+    };
+    Boolean settable = false;
+    if (AudioObjectHasProperty(device, &vol_addr) &&
+        AudioObjectIsPropertySettable(device, &vol_addr, &settable) == noErr &&
+        settable) {
+        AudioObjectSetPropertyData(device, &vol_addr, 0, NULL, sizeof(vol), &vol);
+        return;
+    }
+
+    /* No master element — set the left/right channels individually. */
+    for (UInt32 ch = 1; ch <= 2; ch++) {
+        vol_addr.mElement = ch;
+        settable = false;
+        if (AudioObjectHasProperty(device, &vol_addr) &&
+            AudioObjectIsPropertySettable(device, &vol_addr, &settable) == noErr &&
+            settable) {
+            AudioObjectSetPropertyData(device, &vol_addr, 0, NULL, sizeof(vol), &vol);
+        }
+    }
+}
+
 /* ---- Callbacks: parser → decoder ------------------------------------- */
 
 static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud) {
@@ -993,6 +1047,13 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
             char text[4096];
             extract_json_string_field(payload, len, "\"text\"", text, sizeof(text));
             tb_receiver_set_clipboard_text(text);
+        }
+        break;
+    case TB_PKT_VOLUME:
+        {
+            double level = 1.0;
+            (void)extract_json_double_field(payload, len, "\"level\"", &level);
+            tb_set_system_volume(level);
         }
         break;
     case TB_PKT_AUDIO_FRAME:

--- a/TargetBridge-Receiver/TBReceiverC/src/proto.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/proto.h
@@ -20,6 +20,7 @@
  * type 0x34 = input control mode update (JSON)
  * type 0x35 = brightness update (JSON)
  * type 0x36 = clipboard update (JSON)
+ * type 0x37 = volume update (JSON)
  *
  * Compatible with the new TBDisplaySender Swift app.
  */
@@ -44,6 +45,7 @@
 #define TB_PKT_INPUT_CONTROL    0x34
 #define TB_PKT_BRIGHTNESS       0x35
 #define TB_PKT_CLIPBOARD        0x36
+#define TB_PKT_VOLUME           0x37
 #define TB_PKT_TEST_DATA        0x40
 
 #define TB_HDR_BYTES        5   /* 4 length + 1 type */

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -196,6 +196,9 @@ private struct TBDisplaySenderSessionCard: View {
                 if session.isConnected {
                     brightnessCard
                 }
+                if session.isConnected && session.audioEnabled {
+                    volumeCard
+                }
                 monitorDetailsCard
             }
         }
@@ -318,6 +321,32 @@ private struct TBDisplaySenderSessionCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private var volumeCard: some View {
+        SurfaceSubcard {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionHeading(volumeTitle)
+                HStack(spacing: 12) {
+                    Image(systemName: "speaker.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.secondary)
+
+                    Slider(value: $session.volume, in: 0.0...1.0)
+                        .tint(.blue)
+
+                    Image(systemName: "speaker.wave.3.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.secondary)
+
+                    Text("\(Int((session.volume * 100).rounded()))%")
+                        .font(.system(.body, design: .monospaced))
+                        .frame(width: 44, alignment: .trailing)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     private var trimmedReceiverIP: String {
         session.receiverIP.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -418,6 +447,15 @@ private struct TBDisplaySenderSessionCard: View {
         case .english: return "Brightness"
         case .german: return "Helligkeit"
         case .chinese: return "亮度"
+        }
+    }
+
+    private var volumeTitle: String {
+        switch service.language {
+        case .italian: return "Volume"
+        case .english: return "Volume"
+        case .german: return "Lautstärke"
+        case .chinese: return "音量"
         }
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -250,6 +250,7 @@ final class TBDisplaySenderService: ObservableObject {
         var audioEnabled: Bool
         var brightness: Double
         var inputGestureMode: String
+        var volume: Double?
     }
 
     private var lastPersistedData: Data?
@@ -280,7 +281,8 @@ final class TBDisplaySenderService: ObservableObject {
                 captureSource: session.captureSource.rawValue,
                 audioEnabled: session.audioEnabled,
                 brightness: session.brightness,
-                inputGestureMode: session.inputGestureMode.rawValue
+                inputGestureMode: session.inputGestureMode.rawValue,
+                volume: session.volume
             )
         }
         guard let data = try? JSONEncoder().encode(configs) else { return }
@@ -339,6 +341,7 @@ final class TBDisplaySenderService: ObservableObject {
         session.localInterfaceIP = config.localInterfaceIP
         session.audioEnabled = config.audioEnabled && audioRelayAvailable
         session.brightness = config.brightness
+        session.volume = config.volume ?? 0.5
     }
 
     func refreshLocalInterfaces() {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -896,6 +896,11 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             sendBrightnessUpdate()
         }
     }
+    @Published var volume: Double = 1.0 {
+        didSet {
+            sendVolumeUpdate()
+        }
+    }
     var audioAddonAvailable = true
     var receiverSupportsHEVCDecodeHint: Bool?
     var receiverInputMonitoringTrustedHint: Bool?
@@ -1209,6 +1214,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                     self.sendHello()
                     self.sendInputControlModeUpdate()
                     self.sendBrightnessUpdate()
+                    self.sendVolumeUpdate()
                     self.receiveLoop(on: conn)
                 case .failed(let error):
                     self.setStatus(.connectionFailed(error.localizedDescription))
@@ -1520,6 +1526,14 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         send(packet)
     }
 
+    private func sendVolumeUpdate() {
+        guard let packet = TBMonitorProtocol.makeJSONPacket(
+            type: .volume,
+            value: TBMonitorVolume(level: volume)
+        ) else { return }
+        send(packet)
+    }
+
     func sendClipboardText(_ text: String) {
         guard let packet = TBMonitorProtocol.makeJSONPacket(
             type: .clipboard,
@@ -1817,6 +1831,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         sendHello()
         sendInputControlModeUpdate()
         sendBrightnessUpdate()
+        sendVolumeUpdate()
 
         Task { @MainActor in
             if self.isCableTestConnection {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -896,7 +896,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             sendBrightnessUpdate()
         }
     }
-    @Published var volume: Double = 1.0 {
+    @Published var volume: Double = 0.5 {
         didSet {
             sendVolumeUpdate()
         }

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -15,6 +15,7 @@ enum TBMonitorPacketType: UInt8 {
     case inputControlMode = 0x34
     case brightness = 0x35
     case clipboard = 0x36
+    case volume = 0x37
     case testData = 0x40
 }
 
@@ -84,6 +85,10 @@ struct TBMonitorInputControlMode: Codable {
 }
 
 struct TBMonitorBrightness: Codable {
+    var level: Double
+}
+
+struct TBMonitorVolume: Codable {
     var level: Double
 }
 


### PR DESCRIPTION
## Summary

Closes #95.

Adds a **volume slider** to the sender's session card — mirroring the existing brightness control — that drives the **receiver's master output volume**.

When audio is forwarded, the sender now shows a speaker slider. Dragging it sends a new `TB_PKT_VOLUME` (`0x37`) JSON packet (`{ "level": 0.0…1.0 }`). The receiver applies the level to the system master volume knob via CoreAudio.

## Changes

**Wire protocol** (`0x37`, JSON `{ level }`)
- `TBMonitorProtocol.swift` — `case volume = 0x37` + `TBMonitorVolume`
- `proto.h` — matching `TB_PKT_VOLUME` + doc

**Sender**
- `TBDisplaySenderService.swift` — `@Published var volume` with a `didSet` sender; pushed on connect-ready and on display-profile (same hooks as brightness)
- `TBDisplaySenderContentView.swift` — `volumeCard` slider (shown while connected **and** audio enabled) + localized title

**Receiver**
- `main.c` — `tb_set_system_volume()` sets the default output device's `kAudioDevicePropertyVolumeScalar` on the master element, falling back to per-channel when a device has no master volume control; `TB_PKT_VOLUME` handler calls it
- `Makefile` — link `-framework CoreAudio`

## Notes / discussion points

- **CoreAudio availability:** `AudioObjectSetPropertyData` exists since macOS 10.4; well below the project's 11.0 deployment floor. A compat `#define` maps `kAudioObjectPropertyElementMain` → `…Master` for pre-12 SDKs.
- **Global state:** this drives the receiver's *system* volume, so it affects all audio on that Mac and the change persists after the session ends. Happy to add snapshot-on-connect / restore-on-disconnect if preferred.
- **Volume HUD** flashes on each change while dragging. Can be suppressed or debounced if it's distracting.

## Testing

- Receiver builds via `make` (links CoreAudio cleanly).
- Sender builds via `xcodebuild` (`** BUILD SUCCEEDED **`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)