### PR TITLE
fix(sender): stop first-frame watchdog from tearing down healthy sessions

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -1850,6 +1850,13 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             )
             self.displayStateText = self.describeDisplayState(for: self.session.displayID)
 
+            // Reset the first-frame flag BEFORE capture starts. startCapture() is
+            // async and frames can begin flowing (firing handleFirstEncodedFrame,
+            // which sets sessionAckSent = true) during its suspension. Resetting
+            // afterward would clobber that true back to false, leaving the watchdog
+            // armed against a session that has already delivered frames — it then
+            // tears down a healthy stream ~4s in. See onFirstFrame wiring below.
+            self.sessionAckSent = false
             self.setStatus(.startingCapture(self.capturePreset.description, self.captureSource))
             let started = await self.startCapture(for: profile)
             guard started else {
@@ -1863,7 +1870,6 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 self.scheduleDesktopMirrorRecovery(for: self.session.displayID)
             }
 
-            self.sessionAckSent = false
             self.setStatus(.captureStartedWaitingFirstFrame)
             self.startFirstFrameWatchdog()
         }
@@ -2650,6 +2656,10 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     private func startFirstFrameWatchdog() {
+        // If the first encoded frame already arrived (handleFirstEncodedFrame ran
+        // while startCapture was still suspended), there is nothing to watch for —
+        // arming would only leave a no-op timer dangling for 4s.
+        guard !sessionAckSent else { return }
         firstFrameTimer?.invalidate()
         firstFrameTimer = Timer.scheduledTimer(withTimeInterval: 4, repeats: false) { [weak self] _ in
             guard let self else { return }


### PR DESCRIPTION
## Symptom

A display-mirroring session **connects, shows video briefly, then disconnects after ~3 seconds** — in both *duplicate* and *extend* modes. The on-screen status reported "Capture started but the first frame never arrived."

## Diagnosis (evidence-first)

Temporary plaintext instrumentation across the capture→encode→send pipeline showed the pipeline was **fully healthy** every session:

- `SCStream` delivered frames (`status=complete`)
- frames reached `encode()` and VideoToolbox produced encoded output (`hasBuf=1`)
- the session ack was sent
- **~99 frames were transmitted** before teardown

…yet `firstFrameWatchdog FIRED` with `sentFrames=99`. So the watchdog was killing a working stream — the "no first frame" status was a false alarm.

## Root cause

An async race on `sessionAckSent`:

1. `startCapture()` is `async`; frames begin flowing during its suspension.
2. The first encoded frame fires `onFirstFrame` → `handleFirstEncodedFrame()`, setting `sessionAckSent = true` and invalidating the timer.
3. But `sessionAckSent = false` ran **after** `startCapture()` returned, clobbering that `true` back to `false`.
4. The pipeline's own `ackSent` was already `true`, so `onFirstFrame` never fired again — nothing re-set the flag.
5. 4s later the watchdog saw `sessionAckSent == false`, declared "no first frame," and tore down the session.

## Fix

- Reset `sessionAckSent = false` **before** capture can produce a frame (so a frame arriving during `startCapture()` can't be clobbered).
- Guard `startFirstFrameWatchdog()` to not arm at all if the first frame already arrived.

Two small changes, behavior-only, with explanatory comments. All temporary diagnostic instrumentation was removed before this PR.

## Testing

Rebuilt, reinstalled, re-granted Screen Recording, and reproduced both *duplicate* and *extend*: sessions now **stay connected** with continuous frame flow and **zero watchdog fires** in the diagnostic log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)