### PR TITLE
fix(input): let relayed cursor cross onto adjacent displays

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -1622,16 +1622,38 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         CGEvent(source: nil)?.location
     }
 
+    // Bounds of every active display, in the Quartz global coordinate space
+    // (top-left origin) — matching CGEvent locations and CGWarpMouseCursorPosition.
+    // NSScreen.frame uses AppKit's bottom-left origin and must not be mixed in here.
+    private func activeDisplayBounds() -> [CGRect] {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return [] }
+        return ids.prefix(Int(count)).map { CGDisplayBounds($0) }
+    }
+
     private func screenFrame(containing point: CGPoint) -> CGRect? {
-        NSScreen.screens.first(where: { $0.frame.contains(point) })?.frame
+        activeDisplayBounds().first(where: { $0.contains(point) })
     }
 
     private func clampedMouseTarget(from current: CGPoint, dx: Int, dy: Int) -> CGPoint {
         let rawTarget = CGPoint(x: current.x + CGFloat(dx), y: current.y + CGFloat(dy))
-        guard let frame = screenFrame(containing: current) ?? NSScreen.screens.first?.frame else {
+        let displays = activeDisplayBounds()
+        guard !displays.isEmpty else { return rawTarget }
+
+        // If the target lands on any display, allow it unchanged. This lets the
+        // relayed cursor cross from one screen onto an adjacent one (e.g. the
+        // receiver-backed virtual extended display), matching how the pointer
+        // behaves with the local touchpad. Clamping to a single screen's bounds
+        // previously trapped the pointer on the sender's main display (issue #97).
+        if displays.contains(where: { $0.contains(rawTarget) }) {
             return rawTarget
         }
 
+        // Off every display: keep the pointer on the display it is currently on so
+        // the injected cursor can never get lost in a gap between displays.
+        let frame = displays.first(where: { $0.contains(current) }) ?? displays[0]
         let minX = frame.minX
         let maxX = frame.maxX - 1
         let minY = frame.minY


### PR DESCRIPTION
## Problem

Fixes #97.

In Input-Dockstation **receiver-master** mode (e.g. iMac touchpad controlling a MacBook sender), the relayed pointer could not leave the sender's main screen to enter an adjacent virtual/extended display. Moving with the sender's *own* touchpad worked, since that path doesn't go through the relay.

## Root cause

Received mouse-move deltas are re-injected on the sender by `postLocalMouseMove`, which runs each target through `clampedMouseTarget`. That function clamped the target to the bounds of the **single display the cursor was currently on**, trapping the pointer on the sender's main display.

There was also a latent coordinate-system mismatch: the cursor location is in Quartz coordinates (top-left origin), but `screenFrame(containing:)` matched against `NSScreen.frame` (AppKit, bottom-left origin) — only correct by coincidence on the main display.

## Fix

- `clampedMouseTarget` now returns the target unchanged whenever it lands on **any** active display, allowing the pointer to cross onto adjacent screens — matching native multi-display behavior. It only clamps (to the current display) when the target would fall off every display, so the injected cursor can't get lost in a gap.
- Display lookups now use `CGDisplayBounds` (Quartz top-left origin), consistent with the cursor location.

## Testing

- `xcodebuild` of `TBDisplaySender` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)