### PR TITLE
fix(sender): stop the status menu from orphaning a click-eating window

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
@@ -69,6 +69,15 @@ final class TBDisplaySenderStatusItemController: NSObject {
         item.button?.image = NSImage(systemSymbolName: "display.2", accessibilityDescription: "TargetBridge")
         item.button?.imagePosition = .imageOnly
         item.button?.toolTip = TBDisplaySenderL10n.topBarToolTip(service.language)
+
+        // Assign one menu instance for the lifetime of the status item and
+        // repopulate it lazily in `menuNeedsUpdate(_:)`. Swapping `item.menu`
+        // out from under an open/tracking menu leaves macOS holding an
+        // orphaned, invisible menu window that swallows clicks at the menu's
+        // location — the "dead zone" below the menu bar icon.
+        let menu = NSMenu()
+        menu.delegate = self
+        item.menu = menu
         statusItem = item
     }
 
@@ -81,11 +90,10 @@ final class TBDisplaySenderStatusItemController: NSObject {
     private func refreshStatusItem() {
         guard let item = statusItem else { return }
         item.button?.toolTip = TBDisplaySenderL10n.topBarToolTip(service.language)
-        item.menu = makeMenu()
     }
 
-    private func makeMenu() -> NSMenu {
-        let menu = NSMenu()
+    private func rebuildMenuItems(in menu: NSMenu) {
+        menu.removeAllItems()
 
         let titleItem = NSMenuItem(title: "TargetBridge", action: nil, keyEquivalent: "")
         titleItem.isEnabled = false
@@ -148,35 +156,59 @@ final class TBDisplaySenderStatusItemController: NSObject {
         let quitItem = NSMenuItem(title: TBDisplaySenderL10n.quitApp(service.language), action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
+    }
 
-        return menu
+    // Menu-item handlers run while the menu is still dismissing. Doing work
+    // synchronously here (activating the app, ordering windows front, mutating
+    // observed session state) interrupts the menu window's fade-out: its alpha
+    // animates to 0 but the window is never closed, leaving an invisible
+    // menu-layer window that swallows clicks at the menu's footprint. Deferring
+    // to the next runloop tick lets the menu fully tear down first.
+    private func runAfterMenuDismissal(_ action: @escaping () -> Void) {
+        DispatchQueue.main.async(execute: action)
     }
 
     @objc
     private func showMainWindow() {
-        NSApp.activate(ignoringOtherApps: true)
-        for window in NSApp.windows {
-            window.makeKeyAndOrderFront(nil)
+        runAfterMenuDismissal {
+            NSApp.activate(ignoringOtherApps: true)
+            for window in NSApp.windows {
+                window.makeKeyAndOrderFront(nil)
+            }
         }
     }
 
     @objc
     private func addSession() {
-        service.addSession()
+        runAfterMenuDismissal { [service] in
+            service.addSession()
+        }
     }
 
     @objc
     private func stopAll() {
-        service.stopAll()
+        runAfterMenuDismissal { [service] in
+            service.stopAll()
+        }
     }
 
     @objc
     private func hideStatusItem() {
-        service.showsMenuBarIcon = false
+        runAfterMenuDismissal { [service] in
+            service.showsMenuBarIcon = false
+        }
     }
 
     @objc
     private func quitApp() {
-        NSApp.terminate(nil)
+        runAfterMenuDismissal {
+            NSApp.terminate(nil)
+        }
+    }
+}
+
+extension TBDisplaySenderStatusItemController: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        rebuildMenuItems(in: menu)
     }
 }


### PR DESCRIPTION
## Problem

Opening the menu bar icon's menu and then **selecting an item** left a persistent "dead zone" below the icon — a rectangle where the cursor was visible but hover/clicks never landed (links wouldn't highlight, menu bar unclickable). It cleared only by quitting the app, and reproduced reliably after clicking an option (not on plain open/close).

A system window dump while the dead zone was present revealed the culprit:

```
owner=TargetBridge  layer=101 (menu/popup)  alpha=0.00  w=974 h=272
```

A TargetBridge-owned, invisible, menu-layer window sitting at the menu's exact footprint — the menu's backing window had faded out but was never closed, so it kept swallowing clicks.

## Cause

Each `@objc` menu-item handler ran **synchronously while the menu was still dismissing**. Activating the app, ordering windows front (`showMainWindow`), or mutating observed session state (`addSession`/`stopAll`) mid-dismissal interrupted the menu window's fade-out: alpha reached 0 but the window was never removed.

A secondary contributor: the controller reassigned `item.menu = makeMenu()` on every `service.objectWillChange` (which fires constantly during a session), so the menu object could be swapped while open/tracking.

## Fix

- Assign one `NSMenu` for the status item's lifetime; repopulate items lazily via `NSMenuDelegate.menuNeedsUpdate(_:)` instead of swapping the menu object.
- Defer each menu-item handler to the next runloop tick so the menu fully tears down before the action runs.

## Testing

Built locally (`xcodebuild … TBDisplaySender`). Verified on-device: opened the menu and exercised **Show main window**, **Add session**, and **Stop all** repeatedly during an active session — no dead zone appears, and the orphaned layer-101 alpha-0 window no longer shows in the window dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)