### PR TITLE
chore(sender): sync committed pbxproj MARKETING_VERSION with project.yml

### DIFF
--- a/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
+++ b/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.targetbridge.sender;
 				PRODUCT_NAME = TargetBridge;
 				SDKROOT = macosx;
@@ -318,7 +318,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 3.0;
+				MARKETING_VERSION = 3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.targetbridge.sender;
 				PRODUCT_NAME = TargetBridge;
 				SDKROOT = macosx;


### PR DESCRIPTION
## Problem

The committed `TargetBridge.xcodeproj/project.pbxproj` carries `MARKETING_VERSION = 3.0`, while `project.yml` specifies `3.0.1`. Because `scripts/build_targetbridge_sender_app.sh` runs `xcodegen generate` on every build, the pbxproj is rewritten to `3.0.1` each time, leaving the working tree dirty after a routine build.

## Fix

Regenerate the project with `xcodegen` (2.45.4) so the committed pbxproj matches `project.yml`. The only change is the two `MARKETING_VERSION` entries (Debug + Release configs); subsequent `xcodegen generate` runs are now no-ops, so builds no longer dirty the tree.

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)