### PR TITLE
fix(receiver): only relay input while the shared display Space is active

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -8,6 +8,7 @@
 
 #include "display.h"
 #include "tb_i18n.h"
+#include "tb_gesture_bridge.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
@@ -1263,6 +1264,22 @@ void tb_disp_set_input_intercept_active(struct tb_display *d, int active) {
     if (!d) return;
     d->input_intercept_active = active ? 1 : 0;
     tb_disp_refresh_window_mode(d);
+}
+
+int tb_disp_window_on_active_space(struct tb_display *d) {
+    /* Whether the receiver's display window is on the Space the user is
+     * currently viewing. The receiverMaster global event tap fires for events
+     * on every Space, but the user only intends to drive the sender while
+     * looking at this (fullscreen) window. When they switch to another Space on
+     * the receiver, this window is no longer on the active Space and the caller
+     * stops forwarding so local work doesn't leak to the sender's cursor.
+     *
+     * Keyboard focus is not a reliable signal here: a fullscreen window can stay
+     * key across a Space switch when the receiver app remains active on the new
+     * (empty) Space. -[NSWindow isOnActiveSpace] is a direct, purely spatial
+     * query to the window server, so it stays correct in that case. */
+    if (!d || !d->win) return 1;
+    return tb_window_on_active_space(d->win);
 }
 
 void tb_disp_render_status(struct tb_display *d,

--- a/TargetBridge-Receiver/TBReceiverC/src/display.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.h
@@ -61,6 +61,11 @@ void               tb_disp_set_connection_state(struct tb_display *d, int connec
 void               tb_disp_set_input_capture_active(struct tb_display *d, int active);
 void               tb_disp_set_input_intercept_active(struct tb_display *d, int active);
 
+/* Whether the receiver display window is on the active macOS Space. Used to
+ * gate receiverMaster global-tap forwarding so input on other receiver Spaces
+ * does not leak to the sender. */
+int                tb_disp_window_on_active_space(struct tb_display *d);
+
 /* Resize/recreate texture when frame dimensions change. */
 int  tb_disp_ensure_texture(struct tb_display *d, int w, int h);
 

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -1260,6 +1260,13 @@ static CGEventRef tb_receiver_input_tap_callback(CGEventTapProxy proxy,
 
     if (strcmp(a->input_control_mode, "receiverMaster") != 0) return event;
 
+    /* Only drive the sender while the user is actually on the shared display
+     * window's Space. The global tap also sees events from other receiver
+     * Spaces; forwarding those would make the sender's cursor jump while the
+     * user is doing local work on the receiver. When the window is on a
+     * different Space, pass the event through untouched and forward nothing. */
+    if (!tb_disp_window_on_active_space(a->disp)) return event;
+
     int should_consume = 0;
 
     switch (type) {

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
@@ -6,4 +6,8 @@ typedef void (*tb_gesture_space_switch_callback)(int direction, void *context);
 void tb_gesture_bridge_install(tb_gesture_space_switch_callback callback, void *context);
 void tb_gesture_bridge_set_active(int active);
 
+/* Returns 1 if the given SDL_Window's Cocoa window is on the active macOS
+ * Space (or can't be determined), 0 if it is on a different Space. */
+int tb_window_on_active_space(void *sdl_window);
+
 #endif

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
@@ -1,6 +1,49 @@
 #import "tb_gesture_bridge.h"
 
 #import <AppKit/AppKit.h>
+#include <stdio.h>
+
+int tb_window_on_active_space(void *sdl_window) {
+    /* Whether the receiver's content window is on the Space the user is
+     * currently viewing. Used to gate receiverMaster forwarding so local work
+     * on another (receiver-only) Space doesn't move the sender's cursor.
+     *
+     * We deliberately avoid SDL_GetWindowWMInfo here: it is version-gated and
+     * fails when the app is compiled against newer SDL headers than the bundled
+     * runtime (as happens on the Intel build), which would silently fail open.
+     * Instead we find our largest visible window via NSApp and query the window
+     * server directly with -[NSWindow isOnActiveSpace]. That is purely spatial,
+     * so — unlike keyboard focus — it stays correct even when the receiver app
+     * remains the active application on another Space. */
+    (void)sdl_window;
+
+    NSWindow *content = nil;
+    CGFloat best_area = 0.0;
+    NSArray<NSWindow *> *windows = [NSApp windows];
+    for (NSWindow *w in windows) {
+        if (!w.isVisible) continue;
+        NSSize s = w.frame.size;
+        CGFloat area = s.width * s.height;
+        if (area < 200.0 * 200.0) continue;   /* skip tiny status/aux windows */
+        if (area > best_area) { best_area = area; content = w; }
+    }
+
+    /* Fail open (forward) only when we genuinely can't find a content window. */
+    int on_active = content ? (content.isOnActiveSpace ? 1 : 0) : 1;
+
+    /* Log on decision flips only, to keep the input hot path quiet. */
+    static int last = -1;
+    if (on_active != last) {
+        last = on_active;
+        fprintf(stderr,
+                "[input] forward-gate on_active_space=%d (window=%s area=%.0f "
+                "collectionBehavior=0x%lx windows=%lu)\n",
+                on_active, content ? "found" : "none", best_area,
+                content ? (unsigned long)content.collectionBehavior : 0UL,
+                (unsigned long)windows.count);
+    }
+    return on_active;
+}
 
 static tb_gesture_space_switch_callback g_callback = NULL;
 static void *g_context = NULL;


### PR DESCRIPTION
In receiverMaster, the global event tap forwarded every event regardless of which macOS Space was frontmost, so moving the mouse/keyboard on a receiver-only Space still drove the sender.

Gate forwarding on -[NSWindow isOnActiveSpace] of the receiver's content window (queried via NSApp, so it's purely spatial and independent of keyboard focus). When the shared window isn't on the active Space, events pass through locally and nothing is forwarded.

Test: in receiverMaster, switch to another Space on the receiver → sender cursor no longer moves; switch back → control resumes.