### PR TITLE
fix(sender): force dark color scheme on settings and about sheets

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAboutView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAboutView.swift
@@ -79,6 +79,9 @@ struct TBDisplaySenderAboutView: View {
         .padding(20)
         .frame(minWidth: 620, minHeight: 420)
         .background(appBackground)
+        // Fixed dark background → force dark scheme so semantic text colors stay
+        // light and don't render dark-on-dark in system Light mode.
+        .preferredColorScheme(.dark)
     }
 
     private var versionChip: some View {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderContentView.swift
@@ -751,6 +751,10 @@ private struct TBDisplaySenderSessionSettingsSheet: View {
             )
             .ignoresSafeArea()
         )
+        // The panel uses a fixed dark background, so force the dark color scheme:
+        // otherwise in system Light mode the semantic text colors (.primary /
+        // .secondary) resolve to dark variants and render dark-on-dark.
+        .preferredColorScheme(.dark)
     }
 
     private func settingsSection<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {


### PR DESCRIPTION
These sheets use a fixed dark gradient background, but their text uses semantic colors (.primary/.secondary). In system Light mode those resolve to dark and render dark-on-dark / unreadable.

Pin both sheets to .preferredColorScheme(.dark) so the text stays legible regardless of the system appearance. No change in Dark mode.