### PR TITLE
perf(input): hand-roll input-event encoding to drop per-event JSONEncoder

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -2783,10 +2783,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     func sendInputEvent(_ event: TBMonitorInputEvent) {
-        guard isConnected,
-              let packet = TBMonitorProtocol.makeJSONPacket(type: .inputEvent, value: event)
-        else { return }
-        send(packet)
+        guard isConnected else { return }
+        send(TBMonitorProtocol.makeInputEventPacket(event))
     }
 
     func updateInputControlMode() {

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -113,6 +113,24 @@ enum TBMonitorProtocol {
         return makePacket(type: type, payload: payload)
     }
 
+    /// Hand-rolled encoder for the input-event hot path. Mouse move/drag events
+    /// fire at display refresh rate (or faster with high-poll-rate mice), and a
+    /// fresh `JSONEncoder` per event is the busiest allocator in that path. This
+    /// emits the same JSON shape `JSONDecoder` reconstructs into a
+    /// `TBMonitorInputEvent` (omitted fields decode as nil), mirroring the
+    /// receiver's `snprintf`-based emitter. `kind` is always a fixed literal from
+    /// the event converter, so no string escaping is required.
+    static func makeInputEventPacket(_ event: TBMonitorInputEvent) -> Data {
+        var json = "{\"kind\":\"\(event.kind)\""
+        if let dx = event.dx { json += ",\"dx\":\(dx)" }
+        if let dy = event.dy { json += ",\"dy\":\(dy)" }
+        if let scrollX = event.scrollX { json += ",\"scrollX\":\(scrollX)" }
+        if let scrollY = event.scrollY { json += ",\"scrollY\":\(scrollY)" }
+        if let keyCode = event.keyCode { json += ",\"keyCode\":\(keyCode)" }
+        json += "}"
+        return makePacket(type: .inputEvent, payload: Data(json.utf8))
+    }
+
     static func decodeJSON<T: Decodable>(_ type: T.Type, from payload: Data) -> T? {
         let decoder = JSONDecoder()
         return try? decoder.decode(type, from: payload)


### PR DESCRIPTION
Mouse-move/drag events fire at display rate, and allocating a fresh JSONEncoder per event was the busiest allocator on the input relay path.

Emit the same JSON shape with a small hand-rolled encoder (mirrors the receiver's snprintf emitter). Wire format is unchanged, so it's fully compatible with existing receivers.