### PR TITLE
fix(receiver): reap silent senders and bound relay writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         run: |
           brew install ffmpeg sdl2 dylibbundler
 
+      - name: Run Receiver Parser Tests
+        run: |
+          cd TargetBridge-Receiver/TBReceiverC
+          make test
+
       - name: Build Receiver App
         run: |
           cd TargetBridge-Receiver

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ xcuserdata/
 # C build outputs
 *.o
 tbreceiver
+
+# C test outputs
+test_net_parser
+*.dSYM/

--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -51,6 +51,17 @@ $(BIN): $(OBJ)
 	$(CC) $(CFLAGS) -fobjc-arc -c -o $@ $<
 
 clean:
-	rm -f $(OBJ) $(BIN)
+	rm -f $(OBJ) $(BIN) $(TEST_BIN)
 
-.PHONY: all clean
+# Unit tests for the packet parser. net.c is pure POSIX, so this needs no
+# ffmpeg/SDL/pkgconf — it runs anywhere, including CI, with no hardware.
+TEST_CFLAGS = -O2 -g -Wall -Wextra -Wno-unused-parameter -std=c11
+TEST_BIN = test_net_parser
+
+$(TEST_BIN): tests/test_net_parser.c src/net.c src/net.h src/proto.h
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c -o $@
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+.PHONY: all clean test

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -47,6 +47,11 @@
 
 #define AUDIO_BUF_CAP (192000) // 1 second buffer of 48000Hz stereo 16-bit PCM
 
+/* Reap a connected sender that has gone completely silent. The sender
+ * heartbeats every 2s and streams frames continuously, so 10s of silence
+ * (5 missed heartbeats) means it died without a FIN. */
+#define TB_SENDER_IDLE_TIMEOUT_MS 10000
+
 struct app {
     struct tb_display *disp;
     struct tb_decoder *dec;
@@ -59,6 +64,7 @@ struct app {
     uint64_t last_fps_tick_ms;
     uint64_t last_fps_count;
     uint64_t last_ip_check_ms;
+    uint64_t last_recv_ms;      /* idle watchdog: last time the sender sent anything */
     int      close_requested;
     int      have_video_frame;
 
@@ -1135,6 +1141,12 @@ static void write_be32(uint8_t *dst, uint32_t value) {
 }
 
 static int send_all(int fd, const uint8_t *buf, size_t len) {
+    /* Bound the EAGAIN retry loop: this runs on the event-loop thread, so an
+     * unresponsive reader (half-open peer, saturated link) must not wedge
+     * rendering and quit handling forever. 2s of zero progress means the
+     * session is effectively dead; give up and let the caller/watchdog
+     * tear it down. */
+    const uint64_t deadline_ms = now_ms() + 2000;
     size_t off = 0;
     while (off < len) {
         ssize_t n = write(fd, buf + off, len - off);
@@ -1143,6 +1155,10 @@ static int send_all(int fd, const uint8_t *buf, size_t len) {
             continue;
         }
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            if (now_ms() >= deadline_ms) {
+                fprintf(stderr, "[net] send stalled for 2s; dropping write\n");
+                return -1;
+            }
             usleep(1000);
             continue;
         }
@@ -1802,6 +1818,7 @@ int main(int argc, char **argv) {
             if (c >= 0) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
+                a.last_recv_ms = t;
                 fprintf(stderr, "[main] client connected\n");
                 tb_parser_free(&a.parser);
                 tb_parser_init(&a.parser, on_packet, &a);
@@ -1814,7 +1831,20 @@ int main(int argc, char **argv) {
                 close_client(&a);
             } else {
                 socket_activity = drain_result;
-                if (a.close_requested) close_client(&a);
+                if (drain_result > 0) a.last_recv_ms = t;
+                if (a.close_requested) {
+                    close_client(&a);
+                } else if (t - a.last_recv_ms >= TB_SENDER_IDLE_TIMEOUT_MS) {
+                    /* The sender streams frames continuously and heartbeats
+                     * every 2s. Total silence means it died without a FIN
+                     * (crash, pulled cable, force sleep). Without this reap,
+                     * the dead fd is held forever and — because the receiver
+                     * is single-client — every future connect is locked out
+                     * until the app is restarted. */
+                    fprintf(stderr, "[main] no data from sender for %llu ms; closing stale session\n",
+                            (unsigned long long)(t - a.last_recv_ms));
+                    close_client(&a);
+                }
             }
         }
 

--- a/TargetBridge-Receiver/TBReceiverC/src/net.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/net.c
@@ -125,6 +125,17 @@ int tb_net_accept(int server_fd) {
     /* disable Nagle for low latency */
     int yes = 1;
     setsockopt(c, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes));
+    /* Detect half-open peers (sender crashed / cable pulled without a FIN):
+     * probe after 5s idle, every 5s, twice — the OS then errors the fd
+     * instead of leaving the session wedged. Complements the app-level
+     * idle watchdog in main.c. */
+    setsockopt(c, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+    int keep_idle = 5;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPALIVE, &keep_idle, sizeof(keep_idle));
+    int keep_intvl = 5;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPINTVL, &keep_intvl, sizeof(keep_intvl));
+    int keep_cnt = 2;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPCNT, &keep_cnt, sizeof(keep_cnt));
     return c;
 }
 

--- a/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
+++ b/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
@@ -1,0 +1,230 @@
+/* test_net_parser.c — hardware-free unit tests for the streaming packet
+ * parser in net.c (the framing layer every receiver session depends on).
+ *
+ * Build & run:  make test
+ *
+ * Only needs net.c + POSIX — no ffmpeg, no SDL, no Thunderbolt. */
+
+#include "../src/net.h"
+#include "../src/proto.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, msg) do {                                              \
+    g_checks++;                                                            \
+    if (!(cond)) {                                                         \
+        g_failures++;                                                      \
+        fprintf(stderr, "FAIL %s:%d — %s\n", __FILE__, __LINE__, (msg));   \
+    }                                                                      \
+} while (0)
+
+/* ---- callback capture ------------------------------------------------- */
+
+#define MAX_CAPTURED 16
+
+struct captured_packet {
+    uint8_t type;
+    size_t  len;
+    uint8_t payload[1024];
+    int     had_nul_sentinel;   /* payload[len] was '\0' during the callback */
+};
+
+static struct captured_packet g_captured[MAX_CAPTURED];
+static int g_captured_count = 0;
+
+static void capture_cb(uint8_t type, const uint8_t *payload, size_t len, void *ud) {
+    (void)ud;
+    if (g_captured_count >= MAX_CAPTURED) return;
+    struct captured_packet *c = &g_captured[g_captured_count++];
+    c->type = type;
+    c->len = len;
+    if (len <= sizeof(c->payload)) memcpy(c->payload, payload, len);
+    /* net.c promises a NUL one byte past the payload so string functions in
+     * the callback cannot run off the end. */
+    c->had_nul_sentinel = (payload[len] == '\0');
+}
+
+static void reset_capture(void) {
+    memset(g_captured, 0, sizeof(g_captured));
+    g_captured_count = 0;
+}
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static void put_be32(uint8_t *dst, uint32_t v) {
+    dst[0] = (uint8_t)(v >> 24);
+    dst[1] = (uint8_t)(v >> 16);
+    dst[2] = (uint8_t)(v >> 8);
+    dst[3] = (uint8_t)v;
+}
+
+/* Builds [4B BE len][1B type][payload] into buf; returns total size. */
+static size_t build_packet(uint8_t *buf, uint8_t type, const void *payload, size_t plen) {
+    put_be32(buf, (uint32_t)(1 + plen));
+    buf[4] = type;
+    if (plen) memcpy(buf + 5, payload, plen);
+    return 5 + plen;
+}
+
+/* ---- tests ------------------------------------------------------------- */
+
+static void test_single_packet_whole_feed(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t pkt[64];
+    size_t n = build_packet(pkt, TB_PKT_HELLO_RECEIVER, "hi", 2);
+
+    CHECK(tb_parser_feed(&p, pkt, n) == 0, "feed should succeed");
+    CHECK(g_captured_count == 1, "exactly one packet");
+    CHECK(g_captured[0].type == TB_PKT_HELLO_RECEIVER, "type preserved");
+    CHECK(g_captured[0].len == 2, "payload length preserved");
+    CHECK(memcmp(g_captured[0].payload, "hi", 2) == 0, "payload bytes preserved");
+    CHECK(g_captured[0].had_nul_sentinel, "NUL sentinel past payload");
+
+    tb_parser_free(&p);
+}
+
+static void test_byte_by_byte_feed(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t pkt[64];
+    size_t n = build_packet(pkt, TB_PKT_HEARTBEAT, "\x01\x02\x03", 3);
+
+    for (size_t i = 0; i < n; i++) {
+        CHECK(tb_parser_feed(&p, pkt + i, 1) == 0, "fragmented feed should succeed");
+        if (i < n - 1) {
+            CHECK(g_captured_count == 0, "must not fire before final byte");
+        }
+    }
+    CHECK(g_captured_count == 1, "fires exactly once at final byte");
+    CHECK(g_captured[0].len == 3, "payload length preserved across fragments");
+
+    tb_parser_free(&p);
+}
+
+static void test_two_contiguous_packets(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t buf[128];
+    size_t n1 = build_packet(buf, TB_PKT_HELLO_RECEIVER, "first", 5);
+    size_t n2 = build_packet(buf + n1, TB_PKT_HEARTBEAT, "second!", 7);
+
+    CHECK(tb_parser_feed(&p, buf, n1 + n2) == 0, "feed should succeed");
+    CHECK(g_captured_count == 2, "both packets fire");
+    CHECK(g_captured[0].type == TB_PKT_HELLO_RECEIVER, "first type");
+    CHECK(memcmp(g_captured[0].payload, "first", 5) == 0, "first payload");
+    /* The NUL sentinel for packet 1 lands on packet 2's length byte; the
+     * save/restore in net.c must leave packet 2 intact. */
+    CHECK(g_captured[1].type == TB_PKT_HEARTBEAT, "second type intact after sentinel restore");
+    CHECK(g_captured[1].len == 7, "second length intact");
+    CHECK(memcmp(g_captured[1].payload, "second!", 7) == 0, "second payload intact");
+
+    tb_parser_free(&p);
+}
+
+static void test_split_across_feeds_with_remainder(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t buf[128];
+    size_t n1 = build_packet(buf, TB_PKT_PARAM_SETS, "abcd", 4);
+    size_t n2 = build_packet(buf + n1, TB_PKT_FRAME, "efghij", 6);
+
+    /* Feed 1.5 packets, then the rest. */
+    size_t first_chunk = n1 + 3;
+    CHECK(tb_parser_feed(&p, buf, first_chunk) == 0, "first chunk ok");
+    CHECK(g_captured_count == 1, "only complete packet fires");
+    CHECK(tb_parser_feed(&p, buf + first_chunk, n1 + n2 - first_chunk) == 0, "second chunk ok");
+    CHECK(g_captured_count == 2, "remainder completes second packet");
+    CHECK(g_captured[1].type == TB_PKT_FRAME, "second packet type");
+    CHECK(memcmp(g_captured[1].payload, "efghij", 6) == 0, "second packet payload");
+
+    tb_parser_free(&p);
+}
+
+static void test_zero_length_is_fatal(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t bad[5] = {0x00, 0x00, 0x00, 0x00, 0x30};
+    CHECK(tb_parser_feed(&p, bad, sizeof(bad)) == -1, "pkt_len=0 must be rejected");
+    CHECK(g_captured_count == 0, "no callback for corrupt framing");
+
+    tb_parser_free(&p);
+}
+
+static void test_oversized_length_is_fatal(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t bad[5];
+    put_be32(bad, 64u * 1024 * 1024 + 1);  /* one past the 64 MiB sanity cap */
+    bad[4] = 0x21;
+    CHECK(tb_parser_feed(&p, bad, sizeof(bad)) == -1, "oversized pkt_len must be rejected");
+
+    uint8_t worst[5] = {0xFF, 0xFF, 0xFF, 0xFF, 0x21};
+    struct tb_parser p2;
+    tb_parser_init(&p2, capture_cb, NULL);
+    CHECK(tb_parser_feed(&p2, worst, sizeof(worst)) == -1, "0xFFFFFFFF pkt_len must be rejected");
+
+    tb_parser_free(&p);
+    tb_parser_free(&p2);
+}
+
+static void test_large_payload_roundtrip(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    size_t plen = 1024 * 1024;  /* 1 MiB, exercises parser_reserve growth */
+    uint8_t *pkt = malloc(5 + plen);
+    CHECK(pkt != NULL, "alloc");
+    if (!pkt) return;
+    put_be32(pkt, (uint32_t)(1 + plen));
+    pkt[4] = TB_PKT_FRAME;
+    for (size_t i = 0; i < plen; i++) pkt[5 + i] = (uint8_t)(i * 31);
+
+    /* Feed in 64 KiB slices like a real socket drain. */
+    size_t off = 0, total = 5 + plen;
+    while (off < total) {
+        size_t chunk = total - off > 65536 ? 65536 : total - off;
+        CHECK(tb_parser_feed(&p, pkt + off, chunk) == 0, "chunked feed ok");
+        off += chunk;
+    }
+    CHECK(g_captured_count == 1, "large packet fires once");
+    CHECK(g_captured[0].len == plen, "large payload length preserved");
+
+    free(pkt);
+    tb_parser_free(&p);
+}
+
+int main(void) {
+    test_single_packet_whole_feed();
+    test_byte_by_byte_feed();
+    test_two_contiguous_packets();
+    test_split_across_feeds_with_remainder();
+    test_zero_length_is_fatal();
+    test_oversized_length_is_fatal();
+    test_large_payload_roundtrip();
+
+    if (g_failures == 0) {
+        printf("net parser tests: %d checks passed\n", g_checks);
+        return 0;
+    }
+    fprintf(stderr, "net parser tests: %d/%d checks FAILED\n", g_failures, g_checks);
+    return 1;
+}


### PR DESCRIPTION
## Motivation

When the sender dies without a TCP FIN — app crash, Thunderbolt cable pulled, hard sleep — the receiver never notices: heartbeats are received but ignored, the non-blocking read returns EAGAIN forever, and the receiver keeps showing the last frame while holding the dead fd. Because the receiver is single-client with `listen` backlog 1, **every subsequent connect attempt is locked out until the app is restarted**. Separately, `send_all()` retries EAGAIN with no bound on the event-loop thread, so an unresponsive reader freezes rendering and quit handling.

## What's in it

- **Idle watchdog**: tracks when the sender last sent anything; after 10s of silence (5 missed heartbeats — the sender heartbeats every 2s and streams frames continuously) the session is closed and the receiver returns to *waiting for sender*.
- **TCP keepalive** on the accepted socket (5s idle / 5s interval / 2 probes) so the OS also detects half-open peers for the receiver's own writes (input relay, clipboard).
- **Bounded `send_all()`**: gives up after 2s of zero progress instead of spinning forever on the UI thread.
- **Parser test harness** (`make test` in `TBReceiverC`): pure POSIX, no ffmpeg/SDL/pkgconf — whole/fragmented/contiguous feeds, the NUL-sentinel guarantee (incl. save/restore across contiguous packets), zero/oversized/`0xFFFFFFFF` length rejection, and a 1 MiB payload fed in socket-sized chunks. **60 checks.** Wired into CI for both receiver architectures.

## How tested

- `make test` — 60/60 checks green.
- Full receiver build unchanged (`make`).
- The idle watchdog is verified end-to-end (a scripted sender that goes silent gets reaped at ~10s) by the loopback harness in the follow-up PR stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)