### PR TITLE
feat(receiver): add mock sender and loopback smoke test for hardware-free testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         run: |
           brew install ffmpeg sdl2 dylibbundler
 
+      - name: Run Receiver Parser Tests
+        run: |
+          cd TargetBridge-Receiver/TBReceiverC
+          make test
+
       - name: Build Receiver App
         run: |
           cd TargetBridge-Receiver

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ xcuserdata/
 # C build outputs
 *.o
 tbreceiver
+
+# C test outputs
+test_net_parser
+*.dSYM/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ If you build from source, app outputs go into `build/` folder.
 - Audio transport internals: [docs/audio.md](docs/audio.md)
 - Hardware, cables, adapters, and Thunderbolt Bridge networking: [docs/Hardware.md](docs/Hardware.md)
 - Translation workflow: [docs/Translations.md](docs/Translations.md)
+- Testing without hardware (unit tests, mock sender, loopback smoke): [docs/Testing.md](docs/Testing.md)
 - Binary verification: [docs/verify-binaries.md](docs/verify-binaries.md)
 
 ## Licensing and brand

--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -51,6 +51,17 @@ $(BIN): $(OBJ)
 	$(CC) $(CFLAGS) -fobjc-arc -c -o $@ $<
 
 clean:
-	rm -f $(OBJ) $(BIN)
+	rm -f $(OBJ) $(BIN) $(TEST_BIN)
 
-.PHONY: all clean
+# Unit tests for the packet parser. net.c is pure POSIX, so this needs no
+# ffmpeg/SDL/pkgconf — it runs anywhere, including CI, with no hardware.
+TEST_CFLAGS = -O2 -g -Wall -Wextra -Wno-unused-parameter -std=c11
+TEST_BIN = test_net_parser
+
+$(TEST_BIN): tests/test_net_parser.c src/net.c src/net.h src/proto.h
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c -o $@
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+.PHONY: all clean test

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -47,6 +47,11 @@
 
 #define AUDIO_BUF_CAP (192000) // 1 second buffer of 48000Hz stereo 16-bit PCM
 
+/* Reap a connected sender that has gone completely silent. The sender
+ * heartbeats every 2s and streams frames continuously, so 10s of silence
+ * (5 missed heartbeats) means it died without a FIN. */
+#define TB_SENDER_IDLE_TIMEOUT_MS 10000
+
 struct app {
     struct tb_display *disp;
     struct tb_decoder *dec;
@@ -59,6 +64,7 @@ struct app {
     uint64_t last_fps_tick_ms;
     uint64_t last_fps_count;
     uint64_t last_ip_check_ms;
+    uint64_t last_recv_ms;      /* idle watchdog: last time the sender sent anything */
     int      close_requested;
     int      have_video_frame;
 
@@ -1135,6 +1141,12 @@ static void write_be32(uint8_t *dst, uint32_t value) {
 }
 
 static int send_all(int fd, const uint8_t *buf, size_t len) {
+    /* Bound the EAGAIN retry loop: this runs on the event-loop thread, so an
+     * unresponsive reader (half-open peer, saturated link) must not wedge
+     * rendering and quit handling forever. 2s of zero progress means the
+     * session is effectively dead; give up and let the caller/watchdog
+     * tear it down. */
+    const uint64_t deadline_ms = now_ms() + 2000;
     size_t off = 0;
     while (off < len) {
         ssize_t n = write(fd, buf + off, len - off);
@@ -1143,6 +1155,10 @@ static int send_all(int fd, const uint8_t *buf, size_t len) {
             continue;
         }
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            if (now_ms() >= deadline_ms) {
+                fprintf(stderr, "[net] send stalled for 2s; dropping write\n");
+                return -1;
+            }
             usleep(1000);
             continue;
         }
@@ -1802,6 +1818,7 @@ int main(int argc, char **argv) {
             if (c >= 0) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
+                a.last_recv_ms = t;
                 fprintf(stderr, "[main] client connected\n");
                 tb_parser_free(&a.parser);
                 tb_parser_init(&a.parser, on_packet, &a);
@@ -1814,7 +1831,20 @@ int main(int argc, char **argv) {
                 close_client(&a);
             } else {
                 socket_activity = drain_result;
-                if (a.close_requested) close_client(&a);
+                if (drain_result > 0) a.last_recv_ms = t;
+                if (a.close_requested) {
+                    close_client(&a);
+                } else if (t - a.last_recv_ms >= TB_SENDER_IDLE_TIMEOUT_MS) {
+                    /* The sender streams frames continuously and heartbeats
+                     * every 2s. Total silence means it died without a FIN
+                     * (crash, pulled cable, force sleep). Without this reap,
+                     * the dead fd is held forever and — because the receiver
+                     * is single-client — every future connect is locked out
+                     * until the app is restarted. */
+                    fprintf(stderr, "[main] no data from sender for %llu ms; closing stale session\n",
+                            (unsigned long long)(t - a.last_recv_ms));
+                    close_client(&a);
+                }
             }
         }
 

--- a/TargetBridge-Receiver/TBReceiverC/src/net.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/net.c
@@ -125,6 +125,17 @@ int tb_net_accept(int server_fd) {
     /* disable Nagle for low latency */
     int yes = 1;
     setsockopt(c, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes));
+    /* Detect half-open peers (sender crashed / cable pulled without a FIN):
+     * probe after 5s idle, every 5s, twice — the OS then errors the fd
+     * instead of leaving the session wedged. Complements the app-level
+     * idle watchdog in main.c. */
+    setsockopt(c, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+    int keep_idle = 5;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPALIVE, &keep_idle, sizeof(keep_idle));
+    int keep_intvl = 5;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPINTVL, &keep_intvl, sizeof(keep_intvl));
+    int keep_cnt = 2;
+    setsockopt(c, IPPROTO_TCP, TCP_KEEPCNT, &keep_cnt, sizeof(keep_cnt));
     return c;
 }
 

--- a/TargetBridge-Receiver/TBReceiverC/src/proto.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/proto.h
@@ -7,10 +7,12 @@
  * type 0x11 = display profile (JSON)
  * type 0x12 = create session ack (JSON)
  * type 0x13 = ui language update (JSON)
- * type 0x20 = H.264 parameter sets (SPS/PPS)
- *   payload = [1 byte count] then for each: [4 bytes BE uint32 size][size bytes]
+ * type 0x20 = parameter sets (H.264: SPS/PPS; HEVC: VPS/SPS/PPS)
+ *   payload = [1 byte codec marker: 1=H.264, 2=HEVC][1 byte count]
+ *             then for each set: [4 bytes BE uint32 size][size bytes]
+ *   (see build_extradata in decoder.c)
  *
- * type 0x21 = H.264 frame
+ * type 0x21 = video frame
  *   payload = AVCC-formatted NAL units, 4-byte BE length prefixes (no start codes)
  *
  * type 0x30 = heartbeat (JSON)

--- a/TargetBridge-Receiver/TBReceiverC/tests/mock_sender.py
+++ b/TargetBridge-Receiver/TBReceiverC/tests/mock_sender.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Mock TargetBridge sender — drives a receiver over plain TCP with no
+Thunderbolt hardware, no Apple Silicon, and no screen capture.
+
+Speaks the wire protocol from src/proto.h:
+    [4 bytes BE uint32 length][1 byte type][payload (length-1 bytes)]
+
+Modes (--mode):
+    handshake   connect, HELLO, heartbeat for --duration, TEARDOWN, close.
+    stream      handshake + generate H.264 with the ffmpeg CLI (testsrc2)
+                and stream it as PARAM_SETS + AVCC FRAMEs at ~30 fps.
+    hang        connect, HELLO, then go silent (no heartbeats) while keeping
+                the socket open — exercises the receiver's idle watchdog,
+                which should reap the session after ~10s.
+    badlen      connect, HELLO, then send a corrupt 0xFFFFFFFF length prefix —
+                the receiver's parser must reject it and disconnect.
+    drop        connect, HELLO, send half a packet, then close abruptly —
+                the receiver must return to "waiting for sender".
+
+Stdlib only. Example:
+    python3 tests/mock_sender.py --mode handshake --duration 3
+"""
+
+import argparse
+import json
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+# Packet types (src/proto.h)
+PKT_HELLO_RECEIVER = 0x10
+PKT_PARAM_SETS = 0x20
+PKT_FRAME = 0x21
+PKT_HEARTBEAT = 0x30
+PKT_TEARDOWN = 0x31
+
+
+def packet(ptype: int, payload: bytes) -> bytes:
+    return struct.pack(">I", 1 + len(payload)) + bytes([ptype]) + payload
+
+
+def json_packet(ptype: int, obj) -> bytes:
+    return packet(ptype, json.dumps(obj).encode("utf-8"))
+
+
+def hello_packet(name: str) -> bytes:
+    return json_packet(PKT_HELLO_RECEIVER, {
+        "senderName": name,
+        "uiLanguage": "en",
+        "capturePreset": "standard1440p",
+        "captureSource": "desktopMirror",
+        "captureWidth": 1280,
+        "captureHeight": 720,
+        "codec": "h264",
+    })
+
+
+def drain_receiver(sock: socket.socket, quiet: bool = False) -> None:
+    """Read whatever the receiver sent (DISPLAY_PROFILE etc.) so its writes
+    don't back up; log packet types for debugging."""
+    sock.setblocking(False)
+    try:
+        data = sock.recv(65536)
+        while data:
+            if len(data) >= 5:
+                (length,) = struct.unpack(">I", data[:4])
+                if not quiet:
+                    print(f"[mock] receiver sent type=0x{data[4]:02x} len={length}")
+                data = data[4 + length:]
+            else:
+                break
+    except (BlockingIOError, socket.error):
+        pass
+    finally:
+        sock.setblocking(True)
+
+
+# ---- H.264 generation & AVCC conversion (stream mode) ----------------------
+
+def generate_h264(duration_s: int, fps: int = 30) -> bytes:
+    """Render a test pattern to Annex-B H.264 using the ffmpeg CLI."""
+    with tempfile.NamedTemporaryFile(suffix=".h264", delete=False) as tmp:
+        path = tmp.name
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-f", "lavfi", "-i", f"testsrc2=size=1280x720:rate={fps}:duration={duration_s}",
+        "-c:v", "libx264", "-profile:v", "baseline", "-pix_fmt", "yuv420p",
+        "-g", str(fps), "-f", "h264", path,
+    ]
+    subprocess.run(cmd, check=True)
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def split_annexb(data: bytes):
+    """Split an Annex-B stream into raw NAL units (start codes removed)."""
+    nals, i, n = [], 0, len(data)
+    while i < n:
+        if data[i:i + 4] == b"\x00\x00\x00\x01":
+            start = i + 4
+        elif data[i:i + 3] == b"\x00\x00\x01":
+            start = i + 3
+        else:
+            i += 1
+            continue
+        j = start
+        while j < n:
+            if data[j:j + 4] == b"\x00\x00\x00\x01" or data[j:j + 3] == b"\x00\x00\x01":
+                break
+            j += 1
+        nals.append(data[start:j])
+        i = j
+    return nals
+
+
+def stream_video(sock: socket.socket, duration_s: int) -> None:
+    fps = 30
+    nals = split_annexb(generate_h264(duration_s, fps))
+
+    sps = next(n for n in nals if n and (n[0] & 0x1F) == 7)
+    pps = next(n for n in nals if n and (n[0] & 0x1F) == 8)
+
+    # PARAM_SETS payload: [1B codec (1=H264)][1B count] then [4B BE size][bytes] per set.
+    params = bytes([1, 2])
+    for ps in (sps, pps):
+        params += struct.pack(">I", len(ps)) + ps
+    sock.sendall(packet(PKT_PARAM_SETS, params))
+    print(f"[mock] sent param sets (SPS {len(sps)}B, PPS {len(pps)}B)")
+
+    # Group slices into frames: a frame is one slice NAL (types 1/5) here
+    # (baseline testsrc2 output, one slice per picture).
+    frame_interval = 1.0 / fps
+    heartbeat_due = time.monotonic()
+    seq = 0
+    frames_sent = 0
+    for nal in nals:
+        ntype = nal[0] & 0x1F if nal else 0
+        if ntype not in (1, 5):
+            continue
+        # FRAME payload: AVCC — 4-byte BE length-prefixed NAL units.
+        sock.sendall(packet(PKT_FRAME, struct.pack(">I", len(nal)) + nal))
+        frames_sent += 1
+        now = time.monotonic()
+        if now >= heartbeat_due:
+            sock.sendall(json_packet(PKT_HEARTBEAT, {"sequence": seq}))
+            seq += 1
+            heartbeat_due = now + 2.0
+        drain_receiver(sock, quiet=True)
+        time.sleep(frame_interval)
+    print(f"[mock] streamed {frames_sent} frames")
+
+
+# ---- modes ------------------------------------------------------------------
+
+def run(args) -> int:
+    sock = socket.create_connection((args.host, args.port), timeout=5)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    print(f"[mock] connected to {args.host}:{args.port}")
+    time.sleep(0.2)
+    drain_receiver(sock)
+
+    sock.sendall(hello_packet(args.name))
+    print("[mock] sent HELLO")
+
+    try:
+        if args.mode == "handshake":
+            deadline = time.monotonic() + args.duration
+            seq = 0
+            while time.monotonic() < deadline:
+                sock.sendall(json_packet(PKT_HEARTBEAT, {"sequence": seq}))
+                seq += 1
+                drain_receiver(sock)
+                time.sleep(2.0)
+            sock.sendall(json_packet(PKT_TEARDOWN, {"reason": "mock done"}))
+            print("[mock] sent TEARDOWN")
+
+        elif args.mode == "stream":
+            stream_video(sock, args.duration)
+            sock.sendall(json_packet(PKT_TEARDOWN, {"reason": "mock stream done"}))
+
+        elif args.mode == "hang":
+            print(f"[mock] going silent for {args.duration}s (socket stays open, no heartbeats)")
+            time.sleep(args.duration)
+            # If the receiver's idle watchdog works, it already closed us.
+            try:
+                sock.sendall(json_packet(PKT_HEARTBEAT, {"sequence": 0}))
+                sock.sendall(json_packet(PKT_HEARTBEAT, {"sequence": 1}))
+                print("[mock] receiver still accepted writes after silence")
+            except (BrokenPipeError, ConnectionResetError):
+                print("[mock] receiver closed the stale session (watchdog OK)")
+
+        elif args.mode == "badlen":
+            sock.sendall(struct.pack(">I", 0xFFFFFFFF) + b"\x21")
+            print("[mock] sent corrupt 0xFFFFFFFF length prefix")
+            sock.settimeout(5)
+            try:
+                data = sock.recv(4096)
+                while data:
+                    data = sock.recv(4096)
+                print("[mock] receiver disconnected us (parser rejected corrupt length)")
+            except socket.timeout:
+                print("[mock] ERROR: receiver did not disconnect within 5s")
+                return 1
+
+        elif args.mode == "drop":
+            # Announce a 1000-byte packet but send only half, then vanish.
+            sock.sendall(struct.pack(">I", 1001) + b"\x21" + b"\x00" * 500)
+            print("[mock] sent partial frame; closing abruptly")
+
+    finally:
+        sock.close()
+    print("[mock] done")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=54321)
+    ap.add_argument("--mode", choices=["handshake", "stream", "hang", "badlen", "drop"], default="handshake")
+    ap.add_argument("--duration", type=int, default=5, help="seconds (mode-specific)")
+    ap.add_argument("--name", default="MockSender")
+    return run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
+++ b/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
@@ -1,0 +1,230 @@
+/* test_net_parser.c — hardware-free unit tests for the streaming packet
+ * parser in net.c (the framing layer every receiver session depends on).
+ *
+ * Build & run:  make test
+ *
+ * Only needs net.c + POSIX — no ffmpeg, no SDL, no Thunderbolt. */
+
+#include "../src/net.h"
+#include "../src/proto.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+#define CHECK(cond, msg) do {                                              \
+    g_checks++;                                                            \
+    if (!(cond)) {                                                         \
+        g_failures++;                                                      \
+        fprintf(stderr, "FAIL %s:%d — %s\n", __FILE__, __LINE__, (msg));   \
+    }                                                                      \
+} while (0)
+
+/* ---- callback capture ------------------------------------------------- */
+
+#define MAX_CAPTURED 16
+
+struct captured_packet {
+    uint8_t type;
+    size_t  len;
+    uint8_t payload[1024];
+    int     had_nul_sentinel;   /* payload[len] was '\0' during the callback */
+};
+
+static struct captured_packet g_captured[MAX_CAPTURED];
+static int g_captured_count = 0;
+
+static void capture_cb(uint8_t type, const uint8_t *payload, size_t len, void *ud) {
+    (void)ud;
+    if (g_captured_count >= MAX_CAPTURED) return;
+    struct captured_packet *c = &g_captured[g_captured_count++];
+    c->type = type;
+    c->len = len;
+    if (len <= sizeof(c->payload)) memcpy(c->payload, payload, len);
+    /* net.c promises a NUL one byte past the payload so string functions in
+     * the callback cannot run off the end. */
+    c->had_nul_sentinel = (payload[len] == '\0');
+}
+
+static void reset_capture(void) {
+    memset(g_captured, 0, sizeof(g_captured));
+    g_captured_count = 0;
+}
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static void put_be32(uint8_t *dst, uint32_t v) {
+    dst[0] = (uint8_t)(v >> 24);
+    dst[1] = (uint8_t)(v >> 16);
+    dst[2] = (uint8_t)(v >> 8);
+    dst[3] = (uint8_t)v;
+}
+
+/* Builds [4B BE len][1B type][payload] into buf; returns total size. */
+static size_t build_packet(uint8_t *buf, uint8_t type, const void *payload, size_t plen) {
+    put_be32(buf, (uint32_t)(1 + plen));
+    buf[4] = type;
+    if (plen) memcpy(buf + 5, payload, plen);
+    return 5 + plen;
+}
+
+/* ---- tests ------------------------------------------------------------- */
+
+static void test_single_packet_whole_feed(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t pkt[64];
+    size_t n = build_packet(pkt, TB_PKT_HELLO_RECEIVER, "hi", 2);
+
+    CHECK(tb_parser_feed(&p, pkt, n) == 0, "feed should succeed");
+    CHECK(g_captured_count == 1, "exactly one packet");
+    CHECK(g_captured[0].type == TB_PKT_HELLO_RECEIVER, "type preserved");
+    CHECK(g_captured[0].len == 2, "payload length preserved");
+    CHECK(memcmp(g_captured[0].payload, "hi", 2) == 0, "payload bytes preserved");
+    CHECK(g_captured[0].had_nul_sentinel, "NUL sentinel past payload");
+
+    tb_parser_free(&p);
+}
+
+static void test_byte_by_byte_feed(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t pkt[64];
+    size_t n = build_packet(pkt, TB_PKT_HEARTBEAT, "\x01\x02\x03", 3);
+
+    for (size_t i = 0; i < n; i++) {
+        CHECK(tb_parser_feed(&p, pkt + i, 1) == 0, "fragmented feed should succeed");
+        if (i < n - 1) {
+            CHECK(g_captured_count == 0, "must not fire before final byte");
+        }
+    }
+    CHECK(g_captured_count == 1, "fires exactly once at final byte");
+    CHECK(g_captured[0].len == 3, "payload length preserved across fragments");
+
+    tb_parser_free(&p);
+}
+
+static void test_two_contiguous_packets(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t buf[128];
+    size_t n1 = build_packet(buf, TB_PKT_HELLO_RECEIVER, "first", 5);
+    size_t n2 = build_packet(buf + n1, TB_PKT_HEARTBEAT, "second!", 7);
+
+    CHECK(tb_parser_feed(&p, buf, n1 + n2) == 0, "feed should succeed");
+    CHECK(g_captured_count == 2, "both packets fire");
+    CHECK(g_captured[0].type == TB_PKT_HELLO_RECEIVER, "first type");
+    CHECK(memcmp(g_captured[0].payload, "first", 5) == 0, "first payload");
+    /* The NUL sentinel for packet 1 lands on packet 2's length byte; the
+     * save/restore in net.c must leave packet 2 intact. */
+    CHECK(g_captured[1].type == TB_PKT_HEARTBEAT, "second type intact after sentinel restore");
+    CHECK(g_captured[1].len == 7, "second length intact");
+    CHECK(memcmp(g_captured[1].payload, "second!", 7) == 0, "second payload intact");
+
+    tb_parser_free(&p);
+}
+
+static void test_split_across_feeds_with_remainder(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t buf[128];
+    size_t n1 = build_packet(buf, TB_PKT_PARAM_SETS, "abcd", 4);
+    size_t n2 = build_packet(buf + n1, TB_PKT_FRAME, "efghij", 6);
+
+    /* Feed 1.5 packets, then the rest. */
+    size_t first_chunk = n1 + 3;
+    CHECK(tb_parser_feed(&p, buf, first_chunk) == 0, "first chunk ok");
+    CHECK(g_captured_count == 1, "only complete packet fires");
+    CHECK(tb_parser_feed(&p, buf + first_chunk, n1 + n2 - first_chunk) == 0, "second chunk ok");
+    CHECK(g_captured_count == 2, "remainder completes second packet");
+    CHECK(g_captured[1].type == TB_PKT_FRAME, "second packet type");
+    CHECK(memcmp(g_captured[1].payload, "efghij", 6) == 0, "second packet payload");
+
+    tb_parser_free(&p);
+}
+
+static void test_zero_length_is_fatal(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t bad[5] = {0x00, 0x00, 0x00, 0x00, 0x30};
+    CHECK(tb_parser_feed(&p, bad, sizeof(bad)) == -1, "pkt_len=0 must be rejected");
+    CHECK(g_captured_count == 0, "no callback for corrupt framing");
+
+    tb_parser_free(&p);
+}
+
+static void test_oversized_length_is_fatal(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    uint8_t bad[5];
+    put_be32(bad, 64u * 1024 * 1024 + 1);  /* one past the 64 MiB sanity cap */
+    bad[4] = 0x21;
+    CHECK(tb_parser_feed(&p, bad, sizeof(bad)) == -1, "oversized pkt_len must be rejected");
+
+    uint8_t worst[5] = {0xFF, 0xFF, 0xFF, 0xFF, 0x21};
+    struct tb_parser p2;
+    tb_parser_init(&p2, capture_cb, NULL);
+    CHECK(tb_parser_feed(&p2, worst, sizeof(worst)) == -1, "0xFFFFFFFF pkt_len must be rejected");
+
+    tb_parser_free(&p);
+    tb_parser_free(&p2);
+}
+
+static void test_large_payload_roundtrip(void) {
+    struct tb_parser p;
+    tb_parser_init(&p, capture_cb, NULL);
+    reset_capture();
+
+    size_t plen = 1024 * 1024;  /* 1 MiB, exercises parser_reserve growth */
+    uint8_t *pkt = malloc(5 + plen);
+    CHECK(pkt != NULL, "alloc");
+    if (!pkt) return;
+    put_be32(pkt, (uint32_t)(1 + plen));
+    pkt[4] = TB_PKT_FRAME;
+    for (size_t i = 0; i < plen; i++) pkt[5 + i] = (uint8_t)(i * 31);
+
+    /* Feed in 64 KiB slices like a real socket drain. */
+    size_t off = 0, total = 5 + plen;
+    while (off < total) {
+        size_t chunk = total - off > 65536 ? 65536 : total - off;
+        CHECK(tb_parser_feed(&p, pkt + off, chunk) == 0, "chunked feed ok");
+        off += chunk;
+    }
+    CHECK(g_captured_count == 1, "large packet fires once");
+    CHECK(g_captured[0].len == plen, "large payload length preserved");
+
+    free(pkt);
+    tb_parser_free(&p);
+}
+
+int main(void) {
+    test_single_packet_whole_feed();
+    test_byte_by_byte_feed();
+    test_two_contiguous_packets();
+    test_split_across_feeds_with_remainder();
+    test_zero_length_is_fatal();
+    test_oversized_length_is_fatal();
+    test_large_payload_roundtrip();
+
+    if (g_failures == 0) {
+        printf("net parser tests: %d checks passed\n", g_checks);
+        return 0;
+    }
+    fprintf(stderr, "net parser tests: %d/%d checks FAILED\n", g_failures, g_checks);
+    return 1;
+}

--- a/TargetBridge-Receiver/scripts/loopback_smoke.sh
+++ b/TargetBridge-Receiver/scripts/loopback_smoke.sh
@@ -1,0 +1,95 @@
+#!/bin/zsh
+# loopback_smoke.sh — end-to-end receiver smoke test on one Mac, no
+# Thunderbolt hardware and no real sender.
+#
+# Builds the receiver, runs it windowed, then drives it over 127.0.0.1 with
+# tests/mock_sender.py through four phases:
+#   1. handshake     -> receiver logs the sender hello
+#   2. badlen        -> parser rejects a corrupt length and disconnects
+#   3. hang          -> idle watchdog reaps a silent sender (~10s)
+#   4. stream        -> real H.264 decode (skipped without ffmpeg CLI or
+#                       with --no-stream)
+#
+# Needs a GUI session (SDL window) and the receiver build deps
+# (brew install ffmpeg sdl2 pkgconf). Exits non-zero on any failed phase.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC="$ROOT/TBReceiverC"
+LOG="$(mktemp -t tb_smoke_receiver.err)"
+MOCK="$SRC/tests/mock_sender.py"
+NO_STREAM=0
+[[ "${1:-}" == "--no-stream" ]] && NO_STREAM=1
+
+FAILURES=0
+RECEIVER_PID=""
+
+phase() { print -P "%B== $1 ==%b"; }
+pass()  { print -P "%F{green}PASS%f  $1"; }
+fail()  { print -P "%F{red}FAIL%f  $1"; FAILURES=$((FAILURES + 1)); }
+
+expect_log() {
+    local needle="$1" what="$2" tries=0
+    while (( tries < 20 )); do
+        if grep -qF "$needle" "$LOG"; then pass "$what"; return 0; fi
+        sleep 0.5; tries=$((tries + 1))
+    done
+    fail "$what (missing log line: $needle)"
+    return 1
+}
+
+cleanup() {
+    [[ -n "$RECEIVER_PID" ]] && kill "$RECEIVER_PID" 2>/dev/null
+    wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+phase "Build receiver"
+if ! make -C "$SRC" >/dev/null; then
+    print "receiver build failed"; exit 1
+fi
+pass "build"
+
+phase "Launch receiver (windowed, log -> $LOG)"
+TB_LANG=en "$SRC/tbreceiver" --windowed 2>"$LOG" &
+RECEIVER_PID=$!
+sleep 2
+if ! kill -0 "$RECEIVER_PID" 2>/dev/null; then
+    print "receiver exited early:"; tail -5 "$LOG"; exit 1
+fi
+pass "receiver running (pid $RECEIVER_PID)"
+
+phase "Phase 1: handshake"
+python3 "$MOCK" --mode handshake --duration 3 || fail "mock handshake exited non-zero"
+expect_log "[main] hello from sender" "receiver saw HELLO"
+expect_log "[main] teardown requested by sender" "receiver honored TEARDOWN"
+sleep 1
+
+phase "Phase 2: corrupt length"
+python3 "$MOCK" --mode badlen || fail "mock badlen exited non-zero"
+expect_log "bad pkt_len=4294967295" "parser rejected corrupt length"
+expect_log "[main] client disconnected" "receiver dropped the corrupt session"
+sleep 1
+
+phase "Phase 3: silent sender (idle watchdog)"
+python3 "$MOCK" --mode hang --duration 14 || fail "mock hang exited non-zero"
+expect_log "closing stale session" "idle watchdog reaped silent sender"
+sleep 1
+
+phase "Phase 4: H.264 stream"
+if (( NO_STREAM )) || ! command -v ffmpeg >/dev/null; then
+    print "skipped (no ffmpeg or --no-stream)"
+else
+    python3 "$MOCK" --mode stream --duration 4 || fail "mock stream exited non-zero"
+    expect_log "param sets changed, opening decoder" "decoder accepted param sets"
+fi
+
+print ""
+if (( FAILURES == 0 )); then
+    print -P "%F{green}loopback smoke: all phases passed%f"
+    exit 0
+fi
+print -P "%F{red}loopback smoke: $FAILURES failure(s)%f — log: $LOG"
+exit 1

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,97 @@
+# Testing TargetBridge Without Hardware
+
+Everything on this page runs on one Mac with **no Thunderbolt cable, no
+second machine, and no Apple Silicon requirement** (except where noted).
+CI runs the first two suites on every push/PR.
+
+## 1. Sender unit tests (Swift)
+
+Covers the wire protocol (framing, corrupt-length rejection, unknown-type
+skipping, input-event encoder parity with `JSONDecoder`), the discovered-
+receiver model (which IP is dialed per transport), connection diagnostics
+(link-local interface scoping, failure-detail composition), and the
+automation parsers behind `targetbridge://` URLs and `--connect` launch args.
+
+```bash
+cd TargetBridge-Sender
+xcodegen generate     # only needed after changing project.yml or adding files
+xcodebuild test -project TargetBridge.xcodeproj -scheme TBDisplaySender -destination 'platform=macOS'
+```
+
+Test sources live in `TargetBridge-Sender/TBDisplaySenderTests/`.
+
+## 2. Receiver parser tests (C)
+
+Unit tests for the streaming packet parser in `net.c` — fragmented and
+contiguous feeds, the NUL-sentinel guarantee, corrupt/oversized length
+rejection, and multi-megabyte payloads fed in socket-sized chunks.
+Pure POSIX: needs **no ffmpeg, SDL, or pkgconf**.
+
+```bash
+cd TargetBridge-Receiver/TBReceiverC
+make test
+```
+
+Test sources live in `TargetBridge-Receiver/TBReceiverC/tests/`.
+
+## 3. Mock sender (protocol-level fault injection)
+
+`TargetBridge-Receiver/TBReceiverC/tests/mock_sender.py` (stdlib-only
+Python 3) speaks the full wire protocol against a running receiver:
+
+| Mode        | What it exercises                                              |
+|-------------|----------------------------------------------------------------|
+| `handshake` | HELLO / heartbeat / TEARDOWN lifecycle                          |
+| `stream`    | PARAM_SETS + AVCC H.264 frames (generated via the ffmpeg CLI)   |
+| `hang`      | idle watchdog: silent sender is reaped after ~10s               |
+| `badlen`    | parser rejects a corrupt `0xFFFFFFFF` length and disconnects    |
+| `drop`      | abrupt mid-packet disconnect returns receiver to waiting        |
+
+```bash
+# terminal 1
+cd TargetBridge-Receiver/TBReceiverC && make && ./tbreceiver --windowed
+
+# terminal 2
+python3 TargetBridge-Receiver/TBReceiverC/tests/mock_sender.py --mode stream --duration 5
+```
+
+## 4. Loopback smoke test (one command)
+
+Builds the receiver, launches it windowed, and drives all mock-sender
+phases with pass/fail assertions on the receiver's log:
+
+```bash
+TargetBridge-Receiver/scripts/loopback_smoke.sh            # full run
+TargetBridge-Receiver/scripts/loopback_smoke.sh --no-stream  # skip the H.264 phase
+```
+
+Needs a GUI session (an SDL window opens briefly) and the receiver build
+deps (`brew install ffmpeg sdl2 pkgconf`), so it is a local dev tool rather
+than a CI job.
+
+## 5. Real sender ↔ receiver on one Mac (no cable)
+
+The receiver binds `0.0.0.0:54321` and accepts any peer, so an Apple
+Silicon Mac can stream to a receiver running on itself over the LAN
+interface (the sender refuses `127.0.0.1`, so use the machine's own LAN IP
+for both ends):
+
+```bash
+open build/TargetBridge.app   # sender: pick the LAN interface, enter the Mac's own LAN IP
+./tbreceiver --windowed       # receiver on the same Mac
+```
+
+This exercises the true capture → encode → decode → render path minus the
+Thunderbolt link itself.
+
+## Debugging a live connection
+
+The sender logs its connection lifecycle (dial target, interface, waiting/
+failed states, timeouts) to unified logging:
+
+```bash
+log stream --predicate 'subsystem == "com.targetbridge.sender"'
+```
+
+The receiver logs to stderr; under the LaunchAgent that lands in
+`~/Library/Logs/TargetBridgeReceiver.launchd.err.log`.


### PR DESCRIPTION
> **Stacked on #128** — includes its commits; review the last commit only. (The `hang` phase asserts #128's idle watchdog.)

## Motivation

Exercising the receiver previously required two Macs, a Thunderbolt cable, and an Apple Silicon sender — so failure paths (silent sender death, corrupt framing, mid-packet disconnects) were effectively untestable. This adds a protocol-level harness that needs none of that: everything runs against `127.0.0.1` on one machine, including CI-less local smoke coverage of the full decode pipeline.

## What's in it

- **`TBReceiverC/tests/mock_sender.py`** (stdlib-only Python 3) speaks the full wire protocol. Modes:
  - `handshake` — HELLO / heartbeat / TEARDOWN lifecycle
  - `stream` — PARAM_SETS + AVCC H.264 frames generated with the ffmpeg CLI (`testsrc2`)
  - `hang` — silent sender; the idle watchdog must reap it (~10s)
  - `badlen` — corrupt `0xFFFFFFFF` length prefix; parser must reject + disconnect
  - `drop` — abrupt mid-packet disconnect; receiver must return to waiting
- **`scripts/loopback_smoke.sh`** — builds the receiver, runs it windowed, drives all phases, asserts on the receiver's log, exits non-zero on failure.
- **`docs/Testing.md`** — documents every hardware-free test path (sender unit tests, receiver parser tests, mock sender, smoke script, same-Mac sender↔receiver) and how to stream the sender's connection log. Linked from the README.
- **`proto.h`**: corrects the stale `0x20` comment — the payload starts with a 1-byte codec marker (1=H.264, 2=HEVC) before the set count, as parsed by `build_extradata` in `decoder.c`.

## How tested

Full local run, all phases green: handshake acknowledged, corrupt length rejected + session dropped, silent sender reaped by the watchdog at ~10s, and **120 H.264 frames decoded and rendered** — the complete framing → decode → render pipeline with no Thunderbolt hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)