### PR TITLE
Allow receiver display sleep when idle

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -457,7 +457,6 @@ struct tb_display *tb_disp_create(int fullscreen) {
         fprintf(stderr, "[disp] SDL_Init: %s\n", SDL_GetError());
         return NULL;
     }
-    SDL_DisableScreenSaver();
 
     struct tb_display *d = (struct tb_display *)calloc(1, sizeof(*d));
     if (!d) return NULL;

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -1607,6 +1607,7 @@ static void close_client(struct app *a) {
     a->close_requested = 0;
     a->have_video_frame = 0;
     snprintf(a->input_control_mode, sizeof(a->input_control_mode), "off");
+    SDL_EnableScreenSaver();
     tb_receiver_refresh_input_capture(a);
     tb_disp_set_connection_state(a->disp, 0);
     tb_disp_set_cursor(a->disp, 0, 0, 1, 1, 0, 0);
@@ -1795,6 +1796,7 @@ int main(int argc, char **argv) {
             if (c >= 0) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
+                SDL_DisableScreenSaver();
                 fprintf(stderr, "[main] client connected\n");
                 tb_parser_free(&a.parser);
                 tb_parser_init(&a.parser, on_packet, &a);


### PR DESCRIPTION
## Summary

Only prevent display sleep while an active TargetBridge session is connected.

Previously the Receiver called `SDL_DisableScreenSaver()` during application startup and only re-enabled it during application shutdown. As a result, the display would never sleep while the Receiver was running, even when idle.

This change:

- Removes `SDL_DisableScreenSaver()` from Receiver startup.
- Calls `SDL_DisableScreenSaver()` when a client connects.
- Calls `SDL_EnableScreenSaver()` when the client disconnects.
- Leaves the existing shutdown behaviour unchanged.

## Testing

Tested on a 2017 Intel 27" iMac running macOS Ventura 13.7.8.

Verified using:

```bash
pmset -g assertions
```

Results:

- Receiver running with no active connection → no `PreventUserIdleDisplaySleep` assertion.
- Sender connected → assertion present.
- Sender disconnected → assertion removed.
- Receiver quit → normal behaviour unchanged.

## Motivation

This fixes the issue where the Receiver prevented the display from sleeping whenever it was running, even if no Sender was connected.

Fixes #132 