### PR TITLE
feat(sender): streaming audio controls — volume key relay and local auto-mute

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -327,6 +327,24 @@ enum TBDisplaySenderL10n {
         text("sender.toggle.show_menu_bar_icon", language)
     }
 
+    static func volumeKeysControlReceiver(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "I tasti volume controllano il ricevitore durante lo streaming"
+        case .english: return "Volume keys control the receiver while streaming"
+        case .german: return "Lautstärketasten steuern den Empfänger beim Streamen"
+        case .chinese: return "串流时音量键控制接收端"
+        }
+    }
+
+    static func volumeKeysAccessibilityHint(_ language: TBDisplaySenderLanguage) -> String {
+        switch language {
+        case .italian: return "Richiede l'autorizzazione Accessibilità (Impostazioni di Sistema → Privacy e Sicurezza → Accessibilità)."
+        case .english: return "Requires Accessibility permission (System Settings → Privacy & Security → Accessibility)."
+        case .german: return "Erfordert die Berechtigung Bedienungshilfen (Systemeinstellungen → Datenschutz & Sicherheit → Bedienungshilfen)."
+        case .chinese: return "需要辅助功能权限（系统设置 → 隐私与安全性 → 辅助功能）。"
+        }
+    }
+
     static func showSettings(_ language: TBDisplaySenderLanguage) -> String {
         switch language {
         case .italian: return "Mostra impostazioni"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -97,10 +97,21 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
+    @Published var volumeKeysControlReceiver: Bool = UserDefaults.standard.object(forKey: "fd.tbdisplaysender.volumeKeysControlReceiver") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(volumeKeysControlReceiver, forKey: "fd.tbdisplaysender.volumeKeysControlReceiver")
+            // A manual enable is the one place a permission prompt is expected.
+            refreshVolumeKeyRelay(promptForAccessibility: volumeKeysControlReceiver)
+            objectWillChange.send()
+        }
+    }
     private var sessionCancellables: [UUID: AnyCancellable] = [:]
     private let receiverDiscovery = TBReceiverDiscovery()
     private let addonStore = TBAddonStore.shared
     private let inputRelayController = TBInputRelayController()
+    private let volumeKeyRelayController = TBVolumeKeyRelayController()
+    private var preMuteVolumes: [UUID: Double] = [:]
+    private var activationObserver: NSObjectProtocol?
     private var discoveryCancellable: AnyCancellable?
     private var addonCancellable: AnyCancellable?
     private var clipboardTimer: Timer?
@@ -123,6 +134,81 @@ final class TBDisplaySenderService: ObservableObject {
         addonStore.refresh()
         restorePersistedSessions()
         startClipboardMonitoring()
+        refreshVolumeKeyRelay()
+        // Retry after the user grants Accessibility in System Settings and
+        // switches back — tap creation fails silently until trust is granted.
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshVolumeKeyRelay()
+        }
+    }
+
+    // MARK: - Volume key relay
+
+    /// True when the feature is enabled but the event tap could not be installed,
+    /// i.e. Accessibility trust is missing. Drives the settings hint.
+    var volumeKeyRelayNeedsAccessibility: Bool {
+        volumeKeysControlReceiver && !volumeKeyRelayController.isActive
+    }
+
+    /// Redirects the hardware volume keys to connected audio sessions. The tap
+    /// stays installed whenever the feature is on; per event, keys are consumed
+    /// only while at least one connected session streams audio, so local volume
+    /// behavior is untouched the rest of the time.
+    private func refreshVolumeKeyRelay(promptForAccessibility: Bool = false) {
+        guard volumeKeysControlReceiver else {
+            volumeKeyRelayController.stop()
+            return
+        }
+        guard !volumeKeyRelayController.isActive else { return }
+        let started = volumeKeyRelayController.start { [weak self] key, isKeyDown, fineStep in
+            guard let self else { return false }
+            return self.handleVolumeKey(key, isKeyDown: isKeyDown, fineStep: fineStep)
+        }
+        if !started {
+            NSLog("TargetBridge: volume key relay needs Accessibility permission; tap not installed")
+            if promptForAccessibility {
+                // Literal key: the kAXTrustedCheckOptionPrompt global trips Swift 6
+                // concurrency checking.
+                let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+                _ = AXIsProcessTrustedWithOptions(options)
+            }
+        } else {
+            // The permission hint in settings keys off tap state.
+            objectWillChange.send()
+        }
+    }
+
+    private func handleVolumeKey(_ key: TBVolumeKeyRelayController.Key, isKeyDown: Bool, fineStep: Bool) -> Bool {
+        let targets = sessions.filter { $0.isConnected && $0.audioEnabled }
+        guard !targets.isEmpty else { return false }
+        // Swallow the release of a claimed key too; only the press adjusts volume.
+        guard isKeyDown else { return true }
+
+        // macOS moves the hardware volume in 1/16 steps, 1/64 with shift+option.
+        let step = fineStep ? 1.0 / 64.0 : 1.0 / 16.0
+        for session in targets {
+            switch key {
+            case .up:
+                preMuteVolumes[session.id] = nil
+                session.volume = min(1.0, session.volume + step)
+            case .down:
+                preMuteVolumes[session.id] = nil
+                session.volume = max(0.0, session.volume - step)
+            case .mute:
+                if session.volume > 0 {
+                    preMuteVolumes[session.id] = session.volume
+                    session.volume = 0
+                } else {
+                    session.volume = preMuteVolumes[session.id] ?? 0.5
+                    preMuteVolumes[session.id] = nil
+                }
+            }
+        }
+        return true
     }
 
     var anyConnected: Bool {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -902,6 +902,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
     var audioAddonAvailable = true
+    private var holdsLocalMuteClaim = false
     var receiverSupportsHEVCDecodeHint: Bool?
     var receiverInputMonitoringTrustedHint: Bool?
     var receiverAccessibilityTrustedHint: Bool?
@@ -1417,6 +1418,10 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private func stop(resetStatusTo status: TBDisplaySenderStatusState?, persistArrangement: Bool = true) {
         if persistArrangement {
             persistExtendedDisplayArrangementIfNeeded()
+        }
+        if holdsLocalMuteClaim {
+            holdsLocalMuteClaim = false
+            TBLocalAudioMuteCoordinator.shared.release()
         }
         sendTeardown(reason: "sender_stop")
         connectTimeoutWorkItem?.cancel()
@@ -2105,6 +2110,13 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             guard started else {
                 self.stop(resetStatusTo: nil)
                 return
+            }
+
+            // Streamed audio also plays on the local speakers (SCK captures it
+            // upstream of the output device) — mute locally for the duration.
+            if self.audioEnabled {
+                TBLocalAudioMuteCoordinator.shared.claim()
+                self.holdsLocalMuteClaim = true
             }
 
             if self.captureSource == .extendedDesktop {

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderSettingsView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderSettingsView.swift
@@ -58,6 +58,13 @@ struct TBDisplaySenderSettingsView: View {
                     Toggle(TBDisplaySenderL10n.preventDisplaySleep(service.language), isOn: $service.preventDisplaySleep)
                     Toggle(TBDisplaySenderL10n.autoRestartOnWake(service.language), isOn: $service.autoRestartOnWake)
                     Toggle(TBDisplaySenderL10n.verboseDisplayLogging(service.language), isOn: $service.verboseDisplayLogging)
+                    Toggle(TBDisplaySenderL10n.volumeKeysControlReceiver(service.language), isOn: $service.volumeKeysControlReceiver)
+                    if service.volumeKeyRelayNeedsAccessibility {
+                        Text(TBDisplaySenderL10n.volumeKeysAccessibilityHint(service.language))
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 settingsSection(title: behaviorTitle) {

--- a/TargetBridge-Sender/TBDisplaySender/TBLocalAudioMute.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBLocalAudioMute.swift
@@ -1,0 +1,99 @@
+import CoreAudio
+import Foundation
+
+/// Mutes the local default output while audio streams to a receiver.
+///
+/// ScreenCaptureKit captures system audio upstream of the output device, so a
+/// stream plays on the local speakers and the receiver at once unless the Mac
+/// is muted. Sessions claim the mute when their capture starts and release it
+/// when they stop; the device is muted on the first claim and the original
+/// state restored when the last claim goes away. A device the app muted itself
+/// is the only thing it will unmute — if the user had already muted, or
+/// unmutes by hand mid-stream, their choice stands.
+final class TBLocalAudioMuteCoordinator: @unchecked Sendable {
+    static let shared = TBLocalAudioMuteCoordinator()
+
+    private let lock = NSLock()
+    private var activeClaims = 0
+    private var deviceToRestore: AudioDeviceID?
+
+    func claim() {
+        lock.lock()
+        defer { lock.unlock() }
+        activeClaims += 1
+        guard activeClaims == 1 else { return }
+
+        guard let device = Self.defaultOutputDevice(),
+              Self.isMuted(device) == false,
+              Self.setMuted(device, true)
+        else {
+            deviceToRestore = nil
+            return
+        }
+        deviceToRestore = device
+        NSLog("TargetBridge: muted local output while streaming audio")
+    }
+
+    func release() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard activeClaims > 0 else { return }
+        activeClaims -= 1
+        guard activeClaims == 0, let device = deviceToRestore else { return }
+        deviceToRestore = nil
+        // Restore only if still muted: respects a manual unmute mid-stream.
+        if Self.isMuted(device) == true, Self.setMuted(device, false) {
+            NSLog("TargetBridge: restored local output after streaming")
+        }
+    }
+
+    // MARK: - CoreAudio plumbing
+
+    private static func mutePropertyAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+    }
+
+    private static func defaultOutputDevice() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    private static func isMuted(_ device: AudioDeviceID) -> Bool? {
+        var address = mutePropertyAddress()
+        guard AudioObjectHasProperty(device, &address) else { return nil }
+        var muted: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(device, &address, 0, nil, &size, &muted) == noErr else {
+            return nil
+        }
+        return muted != 0
+    }
+
+    private static func setMuted(_ device: AudioDeviceID, _ muted: Bool) -> Bool {
+        var address = mutePropertyAddress()
+        var settable = DarwinBoolean(false)
+        guard AudioObjectHasProperty(device, &address),
+              AudioObjectIsPropertySettable(device, &address, &settable) == noErr,
+              settable.boolValue
+        else {
+            return false
+        }
+        var value: UInt32 = muted ? 1 : 0
+        let size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectSetPropertyData(device, &address, 0, nil, size, &value) == noErr
+    }
+}

--- a/TargetBridge-Sender/TBDisplaySender/TBVolumeKeyRelayController.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBVolumeKeyRelayController.swift
@@ -1,0 +1,118 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Consuming event tap for the hardware volume keys (sound up / sound down / mute).
+///
+/// While a session streams audio the sender Mac is typically muted — ScreenCaptureKit
+/// captures system audio upstream of the output device, so the local mute only
+/// silences the speakers. The physical volume keys would then just flash the local
+/// bezel over a muted device. This tap lets the service redirect them to the
+/// receiver's volume instead: the handler decides per event whether it was consumed;
+/// unclaimed events fall through to macOS untouched.
+@MainActor
+final class TBVolumeKeyRelayController {
+    enum Key {
+        case up
+        case down
+        case mute
+    }
+
+    /// Called for every volume-key press and release. Return true to consume the
+    /// event (macOS never sees it), false to let it through. Volume is only
+    /// adjusted on `isKeyDown`; releases are reported so the matching key-up can
+    /// be swallowed alongside its press.
+    typealias Handler = (_ key: Key, _ isKeyDown: Bool, _ fineStep: Bool) -> Bool
+
+    // NX_SYSDEFINED media-key event constants (IOKit/hidsystem/ev_keymap.h).
+    // CGEventType has no case for 14, so the raw value is compared directly.
+    private static let systemDefinedEventType: UInt32 = 14
+    private static let mediaKeySubtype: Int16 = 8
+    private static let soundUpKey = 0 // NX_KEYTYPE_SOUND_UP
+    private static let soundDownKey = 1 // NX_KEYTYPE_SOUND_DOWN
+    private static let muteKey = 7 // NX_KEYTYPE_MUTE
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var handler: Handler?
+
+    var isActive: Bool { eventTap != nil }
+
+    /// Installs the tap on the main run loop. Returns false when the tap cannot
+    /// be created, which in practice means Accessibility trust is missing — a
+    /// consuming session tap is refused without it.
+    @discardableResult
+    func start(handler: @escaping Handler) -> Bool {
+        stop()
+
+        let mask = CGEventMask(1) << CGEventMask(Self.systemDefinedEventType)
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: { _, type, cgEvent, refcon in
+                guard let refcon else { return Unmanaged.passUnretained(cgEvent) }
+                let controller = Unmanaged<TBVolumeKeyRelayController>.fromOpaque(refcon).takeUnretainedValue()
+                return controller.handle(type: type, cgEvent: cgEvent)
+            },
+            userInfo: refcon
+        ) else {
+            return false
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        eventTap = tap
+        runLoopSource = source
+        self.handler = handler
+        return true
+    }
+
+    func stop() {
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: false)
+        }
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        }
+        eventTap = nil
+        runLoopSource = nil
+        handler = nil
+    }
+
+    private func handle(type: CGEventType, cgEvent: CGEvent) -> Unmanaged<CGEvent>? {
+        // The system disables taps that stall or when secure input kicks in;
+        // re-enable and stay out of the way.
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return Unmanaged.passUnretained(cgEvent)
+        }
+
+        guard type.rawValue == Self.systemDefinedEventType,
+              let handler,
+              let event = NSEvent(cgEvent: cgEvent),
+              event.subtype.rawValue == Self.mediaKeySubtype
+        else {
+            return Unmanaged.passUnretained(cgEvent)
+        }
+
+        let data1 = event.data1
+        let key: Key
+        switch (data1 & 0xFFFF_0000) >> 16 {
+        case Self.soundUpKey: key = .up
+        case Self.soundDownKey: key = .down
+        case Self.muteKey: key = .mute
+        default:
+            return Unmanaged.passUnretained(cgEvent)
+        }
+
+        let isKeyDown = ((data1 & 0x0000_FF00) >> 8) == 0x0A
+        let fineStep = event.modifierFlags.contains(.shift) && event.modifierFlags.contains(.option)
+        return handler(key, isKeyDown, fineStep) ? nil : Unmanaged.passUnretained(cgEvent)
+    }
+}

--- a/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
+++ b/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		C1A77120267A12D9E355DCEA /* network-link.json in Resources */ = {isa = PBXBuildFile; fileRef = 6579B499CBC11196966318EA /* network-link.json */; };
 		C2CCAB017BC3CAB1DCFA5CCC /* TBMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA01317B43B46B1B323A7008 /* TBMonitorProtocol.swift */; };
 		CBA7C2F0FA57CC475E2307AF /* TBInputRelayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3DC447E3E8E522565E725B /* TBInputRelayController.swift */; };
+		A1C3E5B7D9F80B2C4D6E8F0A /* TBLocalAudioMute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D5F7A9C1E20D4E6F8A0B2C /* TBLocalAudioMute.swift */; };
+		D4E5F6A7B8C90A1B2C3D4E5F /* TBVolumeKeyRelayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A7B8C9D0E1A2B3C4D5E6F7 /* TBVolumeKeyRelayController.swift */; };
 		D5E6B5B7B49E740C92010C6F /* TBInputDebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80543A7A5A3B583C1543ABC7 /* TBInputDebugLog.swift */; };
 		E4967472D5CB13242FE2F288 /* TBDisplaySenderAboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374B5A5AA247C6922BD9AF72 /* TBDisplaySenderAboutView.swift */; };
 		E6A3663426721C75734F5BC5 /* zh.json in Resources */ = {isa = PBXBuildFile; fileRef = C9AA5BB4EE39D2C6FB37B90F /* zh.json */; };
@@ -76,6 +78,8 @@
 		6630386DB9C3D210849E6211 /* TBVirtualDisplayModeMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBVirtualDisplayModeMemory.swift; sourceTree = "<group>"; };
 		6AC1AF99431D4889F947CE1B /* TBDisplaySenderStatusItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderStatusItemController.swift; sourceTree = "<group>"; };
 		7E3DC447E3E8E522565E725B /* TBInputRelayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBInputRelayController.swift; sourceTree = "<group>"; };
+		B3D5F7A9C1E20D4E6F8A0B2C /* TBLocalAudioMute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBLocalAudioMute.swift; sourceTree = "<group>"; };
+		F6A7B8C9D0E1A2B3C4D5E6F7 /* TBVolumeKeyRelayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBVolumeKeyRelayController.swift; sourceTree = "<group>"; };
 		80543A7A5A3B583C1543ABC7 /* TBInputDebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBInputDebugLog.swift; sourceTree = "<group>"; };
 		9CEA5EB707F01E1708DA9170 /* TBDisplaySenderAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderAutomation.swift; sourceTree = "<group>"; };
 		9D063CAADA68CC48C54157FB /* TBDisplaySenderLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderLocalization.swift; sourceTree = "<group>"; };
@@ -125,6 +129,8 @@
 				4A72C42968FA2A6B2A0515B9 /* TBInputBinding.swift */,
 				20FE01BF2EA2F329442890AD /* TBInputBindingsView.swift */,
 				7E3DC447E3E8E522565E725B /* TBInputRelayController.swift */,
+				B3D5F7A9C1E20D4E6F8A0B2C /* TBLocalAudioMute.swift */,
+				F6A7B8C9D0E1A2B3C4D5E6F7 /* TBVolumeKeyRelayController.swift */,
 				06BABA1447D1E8DD50A6C2F0 /* TBReceiverDiscovery.swift */,
 				6630386DB9C3D210849E6211 /* TBVirtualDisplayModeMemory.swift */,
 			);
@@ -352,6 +358,8 @@
 				8D544352D7E2E226D551E46E /* TBInputBindingsView.swift in Sources */,
 				D5E6B5B7B49E740C92010C6F /* TBInputDebugLog.swift in Sources */,
 				CBA7C2F0FA57CC475E2307AF /* TBInputRelayController.swift in Sources */,
+				A1C3E5B7D9F80B2C4D6E8F0A /* TBLocalAudioMute.swift in Sources */,
+				D4E5F6A7B8C90A1B2C3D4E5F /* TBVolumeKeyRelayController.swift in Sources */,
 				8A729C68ECAC4642FA20A284 /* TBLocalizationStore.swift in Sources */,
 				C2CCAB017BC3CAB1DCFA5CCC /* TBMonitorProtocol.swift in Sources */,
 				06E4F7B33C77762A5E2CB616 /* TBReceiverDiscovery.swift in Sources */,


### PR DESCRIPTION
## Summary

ScreenCaptureKit captures system audio upstream of the output device, so streamed audio always doubled onto the sender's local speakers, and once the sender was muted by hand the hardware volume keys only flashed the local mute bezel — receiver volume was adjustable solely from the app's slider. This PR makes streaming audio behave like a real output device:

- **Local auto-mute.** The default output mutes when a session starts streaming with audio and restores when the last one stops (claim-counted across sessions). Only a mute the app applied itself is undone — a pre-existing manual mute, or a deliberate unmute mid-stream, is respected.
- **Volume keys drive the receiver.** A consuming `NX_SYSDEFINED` event tap redirects sound-up/down/mute to the connected sessions' stream volume — 1/16 steps, 1/64 with shift+option, mute toggles and restores the previous level — which the receiver applies to its system volume with its own HUD. Events pass through untouched whenever nothing is streaming audio, so normal local volume behavior is unaffected.

## Implementation notes

- The tap needs Accessibility trust: it is created lazily, retried when the app becomes active (covers granting permission in System Settings and switching back), and a settings hint appears while trust is missing. Manually enabling the toggle triggers the system prompt.
- New settings toggle "Volume keys control the receiver while streaming" (default on, persisted, localized en/it/de/zh).
- Auto-mute uses CoreAudio (`kAudioDevicePropertyMute` on the default output); devices without a settable mute control are left alone.

## Testing

- `xcodebuild test` (TBDisplaySender scheme): 68/68 pass.
- Mute coordinator exercised against real hardware: unmuted → claim → muted → release → restored.
- Verified end-to-end streaming to a 5K iMac receiver: sender mutes on stream start and restores on stop; volume keys step the receiver's volume with its HUD while local keys behave normally when not streaming.

Generated with [Claude Code](https://claude.com/claude-code)

Cheeky claude adding the watermark. 