### PR TITLE
Add raw NV12 passthrough streaming mode (opt-in, for weak/older receivers)

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -885,6 +885,40 @@ static void on_frame(const uint8_t *y, int y_stride,
     a->frames++;
 }
 
+/* Raw passthrough: render received NV12 planes directly, bypassing the decoder.
+ * Payload: [1: format=1(NV12)][BE32 w][BE32 h][BE32 yStride][BE32 uvStride]
+ *          [Y plane: yStride*h][CbCr plane: uvStride*(h/2)] */
+static void handle_raw_frame(struct app *a, const uint8_t *p, size_t len) {
+    if (len < 17) return;
+    if (p[0] != 1) return; /* only NV12 is supported */
+    uint32_t w  = ((uint32_t)p[1]  << 24) | ((uint32_t)p[2]  << 16) | ((uint32_t)p[3]  << 8) | (uint32_t)p[4];
+    uint32_t h  = ((uint32_t)p[5]  << 24) | ((uint32_t)p[6]  << 16) | ((uint32_t)p[7]  << 8) | (uint32_t)p[8];
+    uint32_t ys = ((uint32_t)p[9]  << 24) | ((uint32_t)p[10] << 16) | ((uint32_t)p[11] << 8) | (uint32_t)p[12];
+    uint32_t us = ((uint32_t)p[13] << 24) | ((uint32_t)p[14] << 16) | ((uint32_t)p[15] << 8) | (uint32_t)p[16];
+    if (w == 0 || h == 0 || ys < w || us < w) return;
+    size_t y_size  = (size_t)ys * h;
+    size_t uv_size = (size_t)us * (h / 2);
+    if (len < (size_t)17 + y_size + uv_size) return;
+    const uint8_t *y  = p + 17;
+    const uint8_t *uv = y + y_size;
+
+    a->have_video_frame = 1;
+    tb_copy_i18n(a->status_text, sizeof(a->status_text), "receiver.status.stream_active");
+    {
+        char width_text[16];
+        char height_text[16];
+        struct tb_i18n_pair pairs[] = {
+            { "width", width_text },
+            { "height", height_text }
+        };
+        snprintf(width_text, sizeof(width_text), "%u", w);
+        snprintf(height_text, sizeof(height_text), "%u", h);
+        tb_format_i18n(a->mode_text, sizeof(a->mode_text), "receiver.mode.receiving", pairs, 2);
+    }
+    tb_disp_render_nv12(a->disp, y, (int)ys, uv, (int)us, (int)w, (int)h);
+    a->frames++;
+}
+
 static void ring_read(struct app *a, Uint8 *dst, int len) {
     int first = AUDIO_BUF_CAP - a->audio_buf_tail;
     if (first >= len) {
@@ -1023,6 +1057,9 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
         break;
     case TB_PKT_FRAME:
         tb_dec_feed_frame(a->dec, payload, len);
+        break;
+    case TB_PKT_RAW_FRAME:
+        handle_raw_frame(a, payload, len);
         break;
     case TB_PKT_CURSOR:
         {

--- a/TargetBridge-Receiver/TBReceiverC/src/proto.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/proto.h
@@ -15,6 +15,12 @@
  * type 0x21 = video frame
  *   payload = AVCC-formatted NAL units, 4-byte BE length prefixes (no start codes)
  *
+ * type 0x22 = raw video frame (uncompressed NV12, "raw passthrough" mode)
+ *   payload = [1 byte format: 1=NV12][4 BE uint32 width][4 BE uint32 height]
+ *             [4 BE uint32 yStride][4 BE uint32 uvStride]
+ *             [Y plane: yStride*height][CbCr plane: uvStride*(height/2)]
+ *   (see handle_raw_frame in main.c; sender-side sendRawFrame)
+ *
  * type 0x30 = heartbeat (JSON)
  * type 0x31 = teardown (JSON)
  * type 0x32 = cursor position (JSON)
@@ -39,6 +45,7 @@
 #define TB_PKT_UI_LANGUAGE      0x13
 #define TB_PKT_PARAM_SETS       0x20
 #define TB_PKT_FRAME            0x21
+#define TB_PKT_RAW_FRAME        0x22  /* uncompressed NV12 planes (raw passthrough) */
 #define TB_PKT_AUDIO_FRAME      0x23
 #define TB_PKT_HEARTBEAT        0x30
 #define TB_PKT_TEARDOWN         0x31

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -504,9 +504,24 @@ private final class TBVideoPipeline: @unchecked Sendable {
 
     // MARK: - Encode paths (on `queue`)
 
+    /// Opt-in raw passthrough (`RAW=1`): ScreenCaptureKit already captures NV12,
+    /// so we can forward the planes uncompressed and skip the encoder entirely.
+    /// This removes all decode cost on the receiver — useful when the receiver is
+    /// an older Intel Mac whose HEVC decoder struggles at high resolutions — at
+    /// the price of much higher bandwidth (~10.6 Gb/s for 5K@60 4:2:0), which a
+    /// direct Thunderbolt Bridge link comfortably sustains.
+    private var rawEnabled: Bool {
+        guard let v = ProcessInfo.processInfo.environment["RAW"] else { return false }
+        return v == "1" || v.lowercased() == "true"
+    }
+
     /// SCStream capture path. Must be dispatched onto `queue` by the caller.
     func encode(_ sampleBuffer: CMSampleBuffer) {
         markCaptureFrame()
+        if rawEnabled {
+            sendRawFrame(sampleBuffer)
+            return
+        }
         guard running, let encoder = vtEncoder,
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
@@ -620,6 +635,66 @@ private final class TBVideoPipeline: @unchecked Sendable {
             }))
             lock.lock(); _sentFrames += 1; lock.unlock()
         }
+    }
+
+    /// Raw passthrough: package the two NV12 planes of the captured pixel buffer
+    /// and send them uncompressed. The receiver blits them directly (no decode).
+    /// Payload: [1: format=1(NV12)][BE32 w][BE32 h][BE32 yStride][BE32 uvStride]
+    ///          [Y plane: yStride*h][CbCr plane: uvStride*(h/2)]
+    private func sendRawFrame(_ sampleBuffer: CMSampleBuffer) {
+        guard running,
+              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+        else { return }
+        // Backpressure: never pile frames on top of a network that can't keep up.
+        if pendingVideoPackets >= preset.maxPendingVideoPackets { return }
+        guard CVPixelBufferGetPlaneCount(pixelBuffer) >= 2 else { return }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+        guard let yBase = CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0),
+              let uvBase = CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1)
+        else { return }
+        let width = CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)
+        let height = CVPixelBufferGetHeightOfPlane(pixelBuffer, 0)
+        let yStride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0)
+        let uvStride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1)
+        let uvHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer, 1)
+        let ySize = yStride * height
+        let uvSize = uvStride * uvHeight
+
+        // Send the session ack on the first frame, mirroring the encoded path.
+        if !ackSent {
+            ackSent = true
+            let ack = TBMonitorCreateSessionAck(
+                accepted: true,
+                displayName: displayName,
+                displayID: displayID
+            )
+            if let packet = TBMonitorProtocol.makeJSONPacket(type: .createSessionAck, value: ack) {
+                connection.send(content: packet, completion: .contentProcessed({ _ in }))
+            }
+            onFirstFrame()
+        }
+
+        var payload = Data(capacity: 17 + ySize + uvSize)
+        payload.append(1) // format: NV12
+        TBMonitorProtocol.appendBE32(&payload, UInt32(width))
+        TBMonitorProtocol.appendBE32(&payload, UInt32(height))
+        TBMonitorProtocol.appendBE32(&payload, UInt32(yStride))
+        TBMonitorProtocol.appendBE32(&payload, UInt32(uvStride))
+        payload.append(UnsafeBufferPointer(start: yBase.assumingMemoryBound(to: UInt8.self), count: ySize))
+        payload.append(UnsafeBufferPointer(start: uvBase.assumingMemoryBound(to: UInt8.self), count: uvSize))
+
+        let packet = TBMonitorProtocol.makePacket(type: .rawFrame, payload: payload)
+        pendingVideoPackets += 1
+        connection.send(content: packet, completion: .contentProcessed({ [weak self] _ in
+            guard let self else { return }
+            self.queue.async {
+                self.pendingVideoPackets = max(0, self.pendingVideoPackets - 1)
+            }
+        }))
+        lock.lock(); _sentFrames += 1; lock.unlock()
     }
 
     private func buildParamSetsPacket(from format: CMVideoFormatDescription, codecType: CMVideoCodecType) -> Data? {

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -7,6 +7,7 @@ enum TBMonitorPacketType: UInt8 {
     case uiLanguage = 0x13
     case paramSets = 0x20
     case frame = 0x21
+    case rawFrame = 0x22   // Uncompressed NV12 planes (raw passthrough mode)
     case audioFrame = 0x23
     case heartbeat = 0x30
     case teardown = 0x31


### PR DESCRIPTION
### Disclosure

Full transparency: **I did not write this code.** I had the idea (send frames
uncompressed so an old receiver doesn't have to decode) and tested it end-to-end
on my own hardware; the implementation was written with **Claude (Anthropic's
AI)**. I'm opening this PR so the project and its users benefit — take, adapt or
rewrite it however you see fit. No credit needed.

Offered freely, no strings attached. My only hope is that a capability like this
stays available to everyone in the free/open build rather than being gated behind
a paywall — so anyone with an ageing Mac can give it a second life. 🙂

### What

Adds an **opt-in raw passthrough mode** (`RAW=1`) that streams uncompressed
**NV12** planes instead of HEVC. The receiver renders them directly via its
existing SDL NV12 path, **with no decoding at all**.

### Why

ScreenCaptureKit already delivers frames as NV12 (`kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`),
which is then HEVC-encoded on the sender and decoded on the receiver. On an
**older Intel receiver** the HEVC *decode* is the real bottleneck at high
resolution/refresh — e.g. a 2017 5K iMac can't sustain 5K@60 HEVC decode: the
decoder saturates, latency climbs and the fans spin up.

Since the sender is Apple Silicon and the link is a direct Thunderbolt Bridge,
it's cheaper to just send the pixels raw and let the receiver blit them:

- **Receiver decode cost → zero** (GPU YUV→RGB blit only).
- **Latency drops** to essentially capture → wire → present.
- Bandwidth cost is high but fine on Thunderbolt: 5K@60 4:2:0 ≈ **10.6 Gb/s**;
  measured link throughput between the two Macs was **~17 Gb/s** (iperf3).

Real-world result on a MacBook Pro M5 → 2017 5K iMac (Ventura): smooth 5K@60,
near-zero latency, iMac decoder idle.

### How

New wire packet type **`0x22` (`TB_PKT_RAW_FRAME`)**:

```
[1 byte format: 1=NV12]
[4 BE uint32 width][4 BE uint32 height]
[4 BE uint32 yStride][4 BE uint32 uvStride]
[Y plane: yStride*height]
[CbCr plane: uvStride*(height/2)]
```

- **Sender** (`TBDisplaySenderService.swift`, `TBMonitorProtocol.swift`):
  when `RAW=1`, `encode()` routes the captured buffer to `sendRawFrame()`,
  which packages the two NV12 planes and sends them. Same first-frame session
  ack and `pendingVideoPackets` backpressure as the encoded path. The encoder
  is never involved.
- **Receiver** (`proto.h`, `main.c`): `handle_raw_frame()` validates and parses
  the planes, then calls the **existing** `tb_disp_render_nv12()` — the same
  function the HEVC decoder feeds. So the SDL side is unchanged; the decoder is
  simply skipped for `0x22` packets.

### Opt-in / compatibility

Entirely gated behind the `RAW=1` environment variable. With `RAW` unset the
behaviour is byte-for-byte the encoded path as before. A patched receiver
handles both `0x21` (HEVC) and `0x22` (raw) transparently; an unpatched
receiver simply logs `unknown pkt type=0x22` and ignores raw frames.

### Testing

- Sender built with Xcode; receiver built with the repo's
  `build_tbreceiver_c_app.sh` on the Intel iMac.
- Verified end-to-end over Thunderbolt Bridge at `native5k` and `crisp2160p60`.

### Notes / possible follow-ups

- Could expose the mode in the UI instead of an env var.
- Could add 4:2:2 for higher chroma fidelity where bandwidth allows.

---