### PR TITLE
fix(sender): stop receiver fullscreen flap when sender is idle

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -48,7 +48,9 @@ final class TBDisplaySenderService: ObservableObject {
         didSet {
             language.persist()
             sessions.forEach { $0.language = language }
-            pushLanguageUpdateToDiscoveredReceivers()
+            // Language actually changed: re-sync every discovered receiver.
+            languageSyncedReceiverIDs.removeAll()
+            syncLanguageToNewlyDiscoveredReceivers()
             objectWillChange.send()
         }
     }
@@ -102,6 +104,11 @@ final class TBDisplaySenderService: ObservableObject {
     private let addonStore = TBAddonStore.shared
     private let inputRelayController = TBInputRelayController()
     private var discoveryCancellable: AnyCancellable?
+    // Receivers we've already pushed the current UI language to. Bonjour re-emits
+    // the discovered set repeatedly, so without this we'd reopen a TCP connection
+    // to every receiver on each tick — which makes an idle receiver flash its
+    // fullscreen "connecting" splash even though nothing is streaming.
+    private var languageSyncedReceiverIDs: Set<String> = []
     private var addonCancellable: AnyCancellable?
     private var clipboardTimer: Timer?
     private var lastClipboardChangeCount: Int = NSPasteboard.general.changeCount
@@ -110,7 +117,7 @@ final class TBDisplaySenderService: ObservableObject {
         discoveryCancellable = receiverDiscovery.$receivers.sink { [weak self] receivers in
             guard let self else { return }
             discoveredReceivers = receivers
-            pushLanguageUpdateToDiscoveredReceivers()
+            syncLanguageToNewlyDiscoveredReceivers()
             objectWillChange.send()
         }
         addonCancellable = addonStore.$addons.sink { [weak self] addons in
@@ -623,15 +630,24 @@ final class TBDisplaySenderService: ObservableObject {
         }
     }
 
-    private func pushLanguageUpdateToDiscoveredReceivers() {
-        let receivers = discoveredReceivers
+    /// Pushes the UI language only to receivers we haven't synced yet, so a stable
+    /// Bonjour discovery stream (the same set re-emitted on every tick) doesn't
+    /// reopen a connection to each receiver — the transient connections made an
+    /// idle receiver toggle into its fullscreen "connecting" splash and back.
+    private func syncLanguageToNewlyDiscoveredReceivers() {
+        // Forget receivers that went away so they re-sync if they reappear.
+        languageSyncedReceiverIDs.formIntersection(Set(discoveredReceivers.map(\.id)))
+        let newReceivers = discoveredReceivers.filter { !languageSyncedReceiverIDs.contains($0.id) }
+        guard !newReceivers.isEmpty else { return }
+
         let languageCode = language.fileStem
-        for receiver in receivers {
+        for receiver in newReceivers {
             let candidateIPs = [receiver.preferredIP, receiver.thunderboltIP, receiver.networkIP]
             var sentTo = Set<String>()
             for ip in candidateIPs where !ip.isEmpty && sentTo.insert(ip).inserted {
                 sendLanguageUpdate(to: ip, languageCode: languageCode)
             }
+            languageSyncedReceiverIDs.insert(receiver.id)
         }
     }
 


### PR DESCRIPTION
## Problem

With a sender app merely **open (not streaming)**, an idle receiver repeatedly toggles into its fullscreen "connecting" splash and back. It's distracting and makes the receiver look like it's receiving when nothing is being sent.

## Cause

`TBDisplaySenderManager` pushed the UI language to discovered receivers on **every** Bonjour discovery emission (`receiverDiscovery.$receivers.sink`). Bonjour re-emits the discovered set repeatedly (TXT refreshes, re-resolves), so the sender kept opening a throwaway TCP connection to each receiver just to send one `uiLanguage` packet. The receiver treats any accepted connection as a session start → fullscreen + "connecting" splash → the sender closes it → back to idle. Repeated pushes = the toggle.

## Fix

Track which receivers already received the current language (`languageSyncedReceiverIDs`) and push only to **newly-discovered** receivers; re-sync all only when the language actually changes. A stable discovery stream no longer reopens connections, so an idle receiver stays put.

Contained in `TBDisplaySenderManager.swift`; sender-only, no protocol change.

## Testing

- `xcodebuild test` (TBDisplaySender): **72/72 pass**.
- Behavioral: with the sender open and idle, the receiver no longer flaps fullscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
