### PR TITLE
fix(receiver): only show connecting splash for a real session (stop idle flap)

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -67,6 +67,10 @@ struct app {
     uint64_t last_recv_ms;      /* idle watchdog: last time the sender sent anything */
     int      close_requested;
     int      have_video_frame;
+    /* A real streaming session has begun (the sender sent a session packet, not
+     * just a transient probe like a UI-language push). Gates the fullscreen
+     * "connecting" splash so a bare/short-lived connection doesn't flash it. */
+    int      session_active;
 
     char     ip_text[64];
     char     tb_ip_text[64];
@@ -1009,19 +1013,23 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
 
             tb_set_receiver_mode_requested(a->mode_text, sizeof(a->mode_text), capture_w, capture_h, source, preset, codec);
         }
+        a->session_active = 1;
         fprintf(stderr, "[main] hello from sender\n");
         tb_copy_i18n(a->status_text, sizeof(a->status_text), "receiver.status.sender_connected_profile_sent");
         break;
     case TB_PKT_CREATE_SESSION_ACK:
+        a->session_active = 1;
         fprintf(stderr, "[main] sender session ack: %.*s\n", (int)len, (const char *)payload);
         tb_copy_i18n(a->status_text, sizeof(a->status_text), "receiver.status.session_accepted_waiting_frames");
         break;
     case TB_PKT_PARAM_SETS:
+        a->session_active = 1;
         /* tb_dec_set_param_sets is now a no-op if the sets are unchanged,
          * so we don't spam a log line per keyframe. */
         tb_dec_set_param_sets(a->dec, payload, len);
         break;
     case TB_PKT_FRAME:
+        a->session_active = 1;
         tb_dec_feed_frame(a->dec, payload, len);
         break;
     case TB_PKT_CURSOR:
@@ -1627,6 +1635,7 @@ static void send_receiver_info(struct app *a) {
 static void close_client(struct app *a) {
     if (a->client_fd >= 0) close(a->client_fd);
     a->client_fd = -1;
+    a->session_active = 0;
     a->close_requested = 0;
     a->have_video_frame = 0;
     snprintf(a->input_control_mode, sizeof(a->input_control_mode), "off");
@@ -1819,6 +1828,7 @@ int main(int argc, char **argv) {
             if (c >= 0) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
+                a.session_active = 0;
                 a.last_recv_ms = t;
                 SDL_DisableScreenSaver();
                 fprintf(stderr, "[main] client connected\n");
@@ -1855,7 +1865,10 @@ int main(int argc, char **argv) {
             tb_receiver_poll_permissions(&a);
         }
 
-        if (a.client_fd < 0) {
+        if (a.client_fd < 0 || !a.session_active) {
+            /* No client, or a connection that hasn't started a real streaming
+             * session (e.g. a transient UI-language push during discovery):
+             * stay on the windowed waiting screen, don't flash fullscreen. */
             tb_disp_render_status(a.disp, a.display_host, a.status_text, a.sender_text, a.panel_text, a.mode_text, a.language_text, a.permissions_text);
         } else if (!a.have_video_frame) {
             tb_disp_render_connecting(a.disp);


### PR DESCRIPTION
## Problem

With a sender app merely **open (not streaming)**, an idle receiver repeatedly flashes its fullscreen "connecting" splash and drops back — for ~2–3 s on sender launch, and more on multi-interface setups. Verified on a 2020 5K iMac.

## Cause

The receiver enters the fullscreen/"connecting" state on **any** accepted TCP connection. But the sender opens short-lived connections to discovered receivers during Bonjour discovery just to push the UI-language packet. On a multi-interface setup discovery churns while resolving each address, firing several of these transient connections — and the receiver treats each as a session start → fullscreen flash → close → repeat.

## Fix

Gate the fullscreen "connecting" state on a **real session** having started: set a `session_active` flag when a session packet arrives (`helloReceiver`, param sets, session ack, or a frame — all sent on a real connect, none by a language push), and stay on the windowed waiting screen otherwise. A transient language-only connection is now ignored; a genuine connect shows the splash exactly as before.

Receiver-only; no protocol change.

## Testing

- Receiver compiles clean (arm64 + x86_64).
- Verified on hardware (2020 5K iMac): sender open & idle → **no more flapping**; start casting → splash + video as before; 5K@60 raw passthrough still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
