### PR TITLE
Preserve mouse click count in receiver-master mode

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -1240,12 +1240,14 @@ unsigned int tb_disp_poll_actions(struct tb_display *d) {
                 if (ev.button.button == SDL_BUTTON_LEFT) input_event.kind = TB_INPUT_EVENT_LEFT_DOWN;
                 else if (ev.button.button == SDL_BUTTON_RIGHT) input_event.kind = TB_INPUT_EVENT_RIGHT_DOWN;
                 else input_event.kind = TB_INPUT_EVENT_OTHER_DOWN;
+                input_event.click_count = ev.button.clicks;
                 tb_disp_queue_input_event(d, &input_event);
                 break;
             case SDL_MOUSEBUTTONUP:
                 if (ev.button.button == SDL_BUTTON_LEFT) input_event.kind = TB_INPUT_EVENT_LEFT_UP;
                 else if (ev.button.button == SDL_BUTTON_RIGHT) input_event.kind = TB_INPUT_EVENT_RIGHT_UP;
                 else input_event.kind = TB_INPUT_EVENT_OTHER_UP;
+                input_event.click_count = ev.button.clicks;
                 tb_disp_queue_input_event(d, &input_event);
                 break;
             case SDL_KEYDOWN:

--- a/TargetBridge-Receiver/TBReceiverC/src/display.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.h
@@ -53,6 +53,7 @@ struct tb_input_event {
     int scroll_x;
     int scroll_y;
     uint16_t key_code;
+    int click_count;
 };
 
 struct tb_display *tb_disp_create(int fullscreen);

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -1265,6 +1265,41 @@ static void tb_receiver_send_input_event(struct app *a,
     (void)send_all(a->client_fd, pkt, 5 + (size_t)len);
 }
 
+static void tb_receiver_send_input_button_event(struct app *a,
+                                                const char *kind,
+                                                int click_count) {
+    if (!a || a->client_fd < 0) return;
+    if (strcmp(a->input_control_mode, "receiverMaster") != 0) return;
+
+    if (click_count < 1) click_count = 1;
+    if (click_count > 3) click_count = 3;
+
+    char json[128];
+    int len = snprintf(json, sizeof(json),
+                       "{\"kind\":\"%s\",\"clickCount\":%d}",
+                       kind ? kind : "",
+                       click_count);
+    if (len <= 0 || (size_t)len >= sizeof(json)) return;
+
+    uint8_t pkt[4 + 1 + sizeof(json)];
+    write_be32(pkt, (uint32_t)(1 + len));
+    pkt[4] = TB_PKT_INPUT_EVENT;
+    memcpy(pkt + 5, json, (size_t)len);
+    a->input_events_sent += 1;
+    if (tb_should_log_input_event(a->input_events_sent)) {
+        tb_receiver_input_log("[input][receiver->sender] send #%llu kind=%s dx=%d dy=%d sx=%d sy=%d key=%u mode=%s",
+                              (unsigned long long)a->input_events_sent,
+                              kind ? kind : "?",
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              a->input_control_mode);
+    }
+    (void)send_all(a->client_fd, pkt, 5 + (size_t)len);
+}
+
 static void tb_receiver_send_target_switch(struct app *a, int direction) {
     tb_receiver_send_input_event(a,
                                  direction < 0 ? "switchPrevTarget" : "switchNextTarget",
@@ -1375,27 +1410,45 @@ static CGEventRef tb_receiver_input_tap_callback(CGEventTapProxy proxy,
         break;
     }
     case kCGEventLeftMouseDown:
-        tb_receiver_send_input_event(a, "leftDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "leftDown",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventLeftMouseUp:
-        tb_receiver_send_input_event(a, "leftUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "leftUp",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventRightMouseDown:
-        tb_receiver_send_input_event(a, "rightDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "rightDown",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventRightMouseUp:
-        tb_receiver_send_input_event(a, "rightUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "rightUp",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventOtherMouseDown:
-        tb_receiver_send_input_event(a, "otherDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "otherDown",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventOtherMouseUp:
-        tb_receiver_send_input_event(a, "otherUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        tb_receiver_send_input_button_event(
+            a,
+            "otherUp",
+            (int)CGEventGetIntegerValueField(event, kCGMouseEventClickState));
         should_consume = a->input_tap_consumes_events;
         break;
     case kCGEventScrollWheel: {
@@ -1947,22 +2000,22 @@ int main(int argc, char **argv) {
                     tb_receiver_send_input_event(&a, "scroll", 0, 0, 0, 0, 1, input_event.scroll_x, 1, input_event.scroll_y, 0, 0);
                     break;
                 case TB_INPUT_EVENT_LEFT_DOWN:
-                    tb_receiver_send_input_event(&a, "leftDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "leftDown", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_LEFT_UP:
-                    tb_receiver_send_input_event(&a, "leftUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "leftUp", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_RIGHT_DOWN:
-                    tb_receiver_send_input_event(&a, "rightDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "rightDown", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_RIGHT_UP:
-                    tb_receiver_send_input_event(&a, "rightUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "rightUp", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_OTHER_DOWN:
-                    tb_receiver_send_input_event(&a, "otherDown", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "otherDown", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_OTHER_UP:
-                    tb_receiver_send_input_event(&a, "otherUp", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                    tb_receiver_send_input_button_event(&a, "otherUp", input_event.click_count);
                     break;
                 case TB_INPUT_EVENT_KEY_DOWN:
                     tb_receiver_send_input_event(&a, "keyDown", 0, 0, 0, 0, 0, 0, 0, 0, 1, input_event.key_code);

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -1799,7 +1799,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                         releaseInjectedModifiersIfNeeded()
                         onRemoteDeactivateInputRequest?()
                     } else {
-                        applyIncomingInputEvent(event)
+                        applyIncomingInputEvent(event, payload: payload)
                     }
                 }
             case .heartbeat:
@@ -1906,11 +1906,13 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
 
-    private func postLocalMouseButton(type: CGEventType, button: CGMouseButton) {
+    private func postLocalMouseButton(type: CGEventType, button: CGMouseButton, clickCount: Int? = nil) {
         logLocalInputInjectionStateIfNeeded(context: "mouseButton")
         guard let current = injectedRemoteMouseLocation ?? currentLocalMouseLocation() else { return }
         guard let event = CGEvent(mouseEventSource: localInputEventSource(), mouseType: type, mouseCursorPosition: current, mouseButton: button) else { return }
-        if button == .left {
+        if let clickCount {
+            event.setIntegerValueField(.mouseEventClickState, value: Int64(min(max(clickCount, 1), 3)))
+        } else if button == .left {
             let clickState: Int
             if type == .leftMouseDown {
                 clickState = injectedLeftClickTracker.registerClick(
@@ -2022,7 +2024,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         controlUp.post(tap: .cghidEventTap)
     }
 
-    private func applyIncomingInputEvent(_ event: TBMonitorInputEvent) {
+    private func applyIncomingInputEvent(_ event: TBMonitorInputEvent, payload: Data) {
         TBInputDebugLog.log("sender applying incoming event kind=\(event.kind)")
         switch event.kind {
         case "move":
@@ -2034,17 +2036,23 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         case "otherDrag":
             postLocalMouseMove(dx: event.dx ?? 0, dy: event.dy ?? 0, type: .otherMouseDragged, button: .center)
         case "leftDown":
-            postLocalMouseButton(type: .leftMouseDown, button: .left)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .leftMouseDown, button: .left, clickCount: buttonEvent?.clickCount)
         case "leftUp":
-            postLocalMouseButton(type: .leftMouseUp, button: .left)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .leftMouseUp, button: .left, clickCount: buttonEvent?.clickCount)
         case "rightDown":
-            postLocalMouseButton(type: .rightMouseDown, button: .right)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .rightMouseDown, button: .right, clickCount: buttonEvent?.clickCount)
         case "rightUp":
-            postLocalMouseButton(type: .rightMouseUp, button: .right)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .rightMouseUp, button: .right, clickCount: buttonEvent?.clickCount)
         case "otherDown":
-            postLocalMouseButton(type: .otherMouseDown, button: .center)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .otherMouseDown, button: .center, clickCount: buttonEvent?.clickCount)
         case "otherUp":
-            postLocalMouseButton(type: .otherMouseUp, button: .center)
+            let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+            postLocalMouseButton(type: .otherMouseUp, button: .center, clickCount: buttonEvent?.clickCount)
         case "scroll":
             postLocalScroll(scrollX: event.scrollX ?? 0, scrollY: event.scrollY ?? 0)
         case "keyDown":

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBMonitorProtocolTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBMonitorProtocolTests.swift
@@ -207,6 +207,40 @@ final class TBMonitorProtocolTests: XCTestCase {
         XCTAssertEqual(TBMonitorProtocol.decodeJSON(TBMonitorHeartbeat.self, from: payload)?.sequence, 42)
     }
 
+    func testInputButtonEventRoundTripPreservesClickCount() throws {
+        let buttonEvent = TBMonitorInputButtonEvent(kind: "leftDown", clickCount: 2)
+        guard var buffer = TBMonitorProtocol.makeJSONPacket(type: .inputEvent, value: buttonEvent),
+              let (type, payload) = try TBMonitorProtocol.drainPacket(from: &buffer)
+        else {
+            XCTFail("button event did not encode and drain")
+            return
+        }
+
+        XCTAssertEqual(type, .inputEvent)
+        XCTAssertEqual(TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)?.kind, "leftDown")
+        XCTAssertEqual(TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)?.clickCount, 2)
+    }
+
+    func testInputButtonEventWithoutClickCountRemainsCompatible() {
+        let payload = Data(#"{"kind":"leftDown"}"#.utf8)
+
+        let buttonEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputButtonEvent.self, from: payload)
+        XCTAssertEqual(buttonEvent?.kind, "leftDown")
+        XCTAssertNil(buttonEvent?.clickCount)
+    }
+
+    func testGenericInputEventIgnoresButtonOnlyMetadata() {
+        let payload = Data(#"{"kind":"leftDown","clickCount":2}"#.utf8)
+
+        let genericEvent = TBMonitorProtocol.decodeJSON(TBMonitorInputEvent.self, from: payload)
+        XCTAssertEqual(genericEvent?.kind, "leftDown")
+        XCTAssertNil(genericEvent?.dx)
+        XCTAssertNil(genericEvent?.dy)
+        XCTAssertNil(genericEvent?.scrollX)
+        XCTAssertNil(genericEvent?.scrollY)
+        XCTAssertNil(genericEvent?.keyCode)
+    }
+
     // MARK: - Hand-rolled input-event encoder parity
     //
     // `makeInputEventPacket` documents this invariant: "emits the same JSON shape

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -82,6 +82,11 @@ struct TBMonitorInputEvent: Codable {
     var keyCode: UInt16?
 }
 
+struct TBMonitorInputButtonEvent: Codable {
+    var kind: String
+    var clickCount: Int?
+}
+
 struct TBMonitorInputControlMode: Codable {
     var mode: String
 }


### PR DESCRIPTION
## Context

In receiver-master mode, a mouse attached to the Receiver controls the Sender. Single clicks, dragging, scrolling, and movement worked, but double-clicks were not recognised: applications received two separate single clicks. Finder was one reproducible example.

The Receiver discarded the native Core Graphics/SDL click count. v3.3.0 tried to reconstruct it on the Sender from timing and pointer distance, but that heuristic still failed on a direct Thunderbolt connection between an Intel iMac Receiver and a MacBook Sender.

## Change

- forward the native click count in a button-only Receiver -> Sender payload
- set `.mouseEventClickState` on the injected Sender event
- retain the v3.3.0 tracker when an older Receiver omits the metadata

Move, drag, scroll, keyboard, and sender-master paths are unchanged.

## Validation

- double-click recognition now works on the real receiver-master setup, verified in Finder
- ordinary clicking, dragging, scrolling, and movement remain operational
- 83 Sender tests and 60 Receiver parser checks pass
- all ARM64 and x86_64 CI builds pass

Fixes #136
