### PR TITLE
Night Shift and True Tone toggles for the receiver's display

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -35,7 +35,7 @@ LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoun
 endif
 
 C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/tb_i18n.c
-OBJC_SRC = src/tb_gesture_bridge.m
+OBJC_SRC = src/tb_gesture_bridge.m src/tb_display_tweaks.m
 OBJ = $(C_SRC:.c=.o) $(OBJC_SRC:.m=.o)
 BIN = tbreceiver
 

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -18,6 +18,7 @@
 #include "display.h"
 #include "proto.h"
 #include "tb_gesture_bridge.h"
+#include "tb_display_tweaks.h"
 #include "tb_i18n.h"
 
 #include <SDL.h>
@@ -64,6 +65,13 @@ struct app {
     uint64_t last_fps_tick_ms;
     uint64_t last_fps_count;
     uint64_t last_ip_check_ms;
+    /* Last display-tweak state reported to the sender, so changes made on this
+     * Mac (Control Center, System Settings) propagate back and the sender's
+     * toggles stay truthful. -1 = nothing sent yet. */
+    int      reported_night_shift;
+    int      reported_true_tone;
+    uint64_t last_tweak_poll_ms;
+
     uint64_t last_recv_ms;      /* idle watchdog: last time the sender sent anything */
     int      close_requested;
     int      have_video_frame;
@@ -191,6 +199,7 @@ static void tb_receiver_set_clipboard_text(const char *text);
 static int tb_receiver_get_clipboard_text(char *dest, size_t size);
 static void tb_receiver_send_clipboard_if_changed(struct app *a);
 static void write_be32(uint8_t *dst, uint32_t value);
+static void tb_receiver_send_display_tweaks_if_changed(struct app *a);
 
 static int tb_receiver_is_valid_language_pref(const char *language_pref) {
     return language_pref &&
@@ -1105,6 +1114,19 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
             tb_disp_set_brightness(a->disp, level);
         }
         break;
+    case TB_PKT_DISPLAY_TWEAKS:
+        {
+            /* Absent fields are left alone rather than defaulted, so the sender
+             * can change one without disturbing the other. */
+            int night = 0, tone = 0;
+            if (extract_json_bool_field(payload, len, "\"nightShift\"", &night)) {
+                tb_night_shift_set(night);
+            }
+            if (extract_json_bool_field(payload, len, "\"trueTone\"", &tone)) {
+                tb_true_tone_set(tone);
+            }
+        }
+        break;
     case TB_PKT_CLIPBOARD:
         {
             char text[4096];
@@ -1615,6 +1637,33 @@ static void tb_receiver_refresh_input_capture(struct app *a) {
     }
 }
 
+
+/* Report Night Shift / True Tone back to the sender when they change, so its
+ * menu reflects the panel's real state rather than only what it last asked for. */
+static void tb_receiver_send_display_tweaks_if_changed(struct app *a) {
+    if (a->client_fd < 0) return;
+
+    const int night = tb_night_shift_supported() ? tb_night_shift_enabled() : 0;
+    const int tone  = tb_true_tone_supported() ? tb_true_tone_enabled() : 0;
+    if (night == a->reported_night_shift && tone == a->reported_true_tone) return;
+
+    a->reported_night_shift = night;
+    a->reported_true_tone = tone;
+
+    char json[192];
+    int len = snprintf(json, sizeof(json),
+                       "{\"nightShift\":%s,\"trueTone\":%s}",
+                       night ? "true" : "false",
+                       tone ? "true" : "false");
+    if (len <= 0 || (size_t)len >= sizeof(json)) return;
+
+    uint8_t pkt[4 + 1 + sizeof(json)];
+    write_be32(pkt, (uint32_t)(1 + len));
+    pkt[4] = TB_PKT_DISPLAY_TWEAKS;
+    memcpy(pkt + 5, json, (size_t)len);
+    (void)send_all(a->client_fd, pkt, 5 + (size_t)len);
+}
+
 static void send_receiver_info(struct app *a) {
     struct tb_display_info info;
     if (tb_disp_get_info(a->disp, &info) < 0) return;
@@ -1644,14 +1693,15 @@ static void send_receiver_info(struct app *a) {
     }
     escaped_name[out] = '\0';
 
-    char json[768];
+    char json[1024];
     int json_len = snprintf(
         json,
         sizeof(json),
         "{\"receiverName\":\"%s\",\"panelWidth\":%u,\"panelHeight\":%u,"
         "\"modeWidth\":%u,\"modeHeight\":%u,\"refreshRate\":60,"
         "\"hiDPI\":true,\"captureWidth\":%u,\"captureHeight\":%u,"
-        "\"supportsHEVCDecode\":%s,\"supportsRawNV12\":true,\"inputMonitoringTrusted\":%s,\"accessibilityTrusted\":%s}",
+        "\"supportsHEVCDecode\":%s,\"supportsRawNV12\":true,\"inputMonitoringTrusted\":%s,\"accessibilityTrusted\":%s,"
+        "\"supportsNightShift\":%s,\"supportsTrueTone\":%s}",
         escaped_name,
         panel_w,
         panel_h,
@@ -1661,8 +1711,9 @@ static void send_receiver_info(struct app *a) {
         capture_h,
         tb_dec_supports_hevc_hwdecode() ? "true" : "false",
         tb_receiver_input_monitoring_trusted() ? "true" : "false",
-        tb_receiver_accessibility_trusted() ? "true" : "false"
-    );
+        tb_receiver_accessibility_trusted() ? "true" : "false",
+        tb_night_shift_supported() ? "true" : "false",
+        tb_true_tone_supported() ? "true" : "false");
     if (json_len <= 0 || (size_t)json_len >= sizeof(json)) return;
 
     const size_t packet_len = 4 + 1 + (size_t)json_len;
@@ -1878,6 +1929,8 @@ int main(int argc, char **argv) {
                 a.client_fd = c;
                 a.have_video_frame = 0;
                 a.session_active = 0;
+                a.reported_night_shift = -1;   /* force one report per session */
+                a.reported_true_tone = -1;
                 a.last_recv_ms = t;
                 SDL_DisableScreenSaver();
                 fprintf(stderr, "[main] client connected\n");
@@ -1912,6 +1965,12 @@ int main(int argc, char **argv) {
         if (t - a.last_permissions_poll_ms >= 250) {
             a.last_permissions_poll_ms = t;
             tb_receiver_poll_permissions(&a);
+        }
+
+        /* Cheap enough to poll: two private-framework getters, twice a second. */
+        if (t - a.last_tweak_poll_ms >= 500) {
+            a.last_tweak_poll_ms = t;
+            tb_receiver_send_display_tweaks_if_changed(&a);
         }
 
         if (a.client_fd < 0 || !a.session_active) {

--- a/TargetBridge-Receiver/TBReceiverC/src/proto.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/proto.h
@@ -55,6 +55,10 @@
 #define TB_PKT_BRIGHTNESS       0x35
 #define TB_PKT_CLIPBOARD        0x36
 #define TB_PKT_VOLUME           0x37
+/* Display tweaks on the receiver's panel: JSON {"nightShift":bool,"trueTone":bool}.
+ * Both are private CoreBrightness features, so the receiver reports whether it
+ * can honour them in its display profile. */
+#define TB_PKT_DISPLAY_TWEAKS   0x38
 #define TB_PKT_TEST_DATA        0x40
 
 #define TB_HDR_BYTES        5   /* 4 length + 1 type */

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_display_tweaks.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_display_tweaks.h
@@ -1,0 +1,28 @@
+/* tb_display_tweaks.h — Night Shift / True Tone on the receiver's own panel.
+ * Implemented over the private CoreBrightness framework; every entry point is
+ * safe to call on a Mac that lacks the feature (returns unsupported / -1). */
+
+#ifndef TB_DISPLAY_TWEAKS_H
+#define TB_DISPLAY_TWEAKS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 1 if the panel can do it, 0 otherwise. */
+int tb_night_shift_supported(void);
+int tb_true_tone_supported(void);
+
+/* Current state, so the sender's UI can follow changes made on this Mac. */
+int tb_true_tone_enabled(void);
+int tb_night_shift_enabled(void);
+
+/* 0 on success, -1 when unavailable. */
+int tb_night_shift_set(int enabled);
+int tb_true_tone_set(int enabled);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_display_tweaks.m
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_display_tweaks.m
@@ -1,0 +1,135 @@
+/* tb_display_tweaks.m — Night Shift and True Tone on the receiver's panel.
+ *
+ * Both live in the private CoreBrightness framework, so they are reached the
+ * same way this app already reaches DisplayServices for brightness: dlopen the
+ * framework and go through the Objective-C runtime, so a missing class or a
+ * renamed selector degrades to "unsupported" instead of breaking the build or
+ * crashing on a future macOS.
+ *
+ * Night Shift is CBBlueLightClient (setEnabled:).
+ * True Tone is CBTrueToneClient, which has no setter — it is activate/deactivate.
+ */
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#include <dlfcn.h>
+
+#include "tb_display_tweaks.h"
+
+static void tb_load_core_brightness(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        dlopen("/System/Library/PrivateFrameworks/CoreBrightness.framework/CoreBrightness",
+               RTLD_LAZY);
+    });
+}
+
+/* Call a no-argument BOOL getter, returning 0 if the selector is absent. */
+static int tb_bool_getter(id obj, SEL sel) {
+    if (!obj || ![obj respondsToSelector:sel]) return 0;
+    IMP imp = [obj methodForSelector:sel];
+    if (!imp) return 0;
+    BOOL (*fn)(id, SEL) = (BOOL (*)(id, SEL))imp;
+    return fn(obj, sel) ? 1 : 0;
+}
+
+/* ---- Night Shift ------------------------------------------------------- */
+
+static id tb_blue_light_client(void) {
+    static id client = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        tb_load_core_brightness();
+        Class cls = NSClassFromString(@"CBBlueLightClient");
+        if (cls) client = [[cls alloc] init];
+    });
+    return client;
+}
+
+int tb_night_shift_supported(void) {
+    return tb_bool_getter(tb_blue_light_client(), @selector(supported));
+}
+
+int tb_night_shift_enabled(void) {
+    id c = tb_blue_light_client();
+    SEL sel = @selector(getBlueLightStatus:);
+    if (!c || ![c respondsToSelector:sel]) return 0;
+    IMP imp = [c methodForSelector:sel];
+    if (!imp) return 0;
+
+    /* CBBlueLightClient has no `enabled` getter — only getBlueLightStatus:,
+     * which fills a private struct whose first two bytes are BOOL active then
+     * BOOL enabled. The layout is not API, so read defensively: a generously
+     * oversized zeroed buffer means a larger struct on some macOS version
+     * cannot overflow, and a changed layout misreports the state rather than
+     * crashing. Worst case the menu shows a stale toggle. */
+    unsigned char status[256];
+    memset(status, 0, sizeof(status));
+    BOOL (*fn)(id, SEL, void *) = (BOOL (*)(id, SEL, void *))imp;
+    if (!fn(c, sel, status)) return 0;
+    return status[1] ? 1 : 0;
+}
+
+int tb_night_shift_set(int enabled) {
+    id c = tb_blue_light_client();
+    SEL sel = @selector(setEnabled:);
+    if (!c || ![c respondsToSelector:sel]) return -1;
+    IMP imp = [c methodForSelector:sel];
+    if (!imp) return -1;
+    BOOL (*fn)(id, SEL, BOOL) = (BOOL (*)(id, SEL, BOOL))imp;
+    fn(c, sel, enabled ? YES : NO);
+    return 0;
+}
+
+/* ---- True Tone -------------------------------------------------------- */
+
+static id tb_true_tone_client(void) {
+    static id client = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        tb_load_core_brightness();
+        Class cls = NSClassFromString(@"CBTrueToneClient");
+        if (cls) client = [[cls alloc] init];
+    });
+    return client;
+}
+
+int tb_true_tone_supported(void) {
+    id c = tb_true_tone_client();
+    if (!c) return 0;
+    /* `supported` means the hardware has it; `available` means it can be used
+     * right now — it goes unavailable under some display profiles. Both must
+     * hold before offering the toggle. */
+    return tb_bool_getter(c, @selector(supported)) && tb_bool_getter(c, @selector(available));
+}
+
+int tb_true_tone_enabled(void) {
+    return tb_bool_getter(tb_true_tone_client(), @selector(enabled));
+}
+
+int tb_true_tone_set(int enabled) {
+    id c = tb_true_tone_client();
+    if (!c) return -1;
+
+    /* setEnabled: is the real switch. activate/deactivate look like the obvious
+     * pair and are not: measured on macOS 15, deactivate leaves `enabled`
+     * reporting 1 and the panel unchanged — they activate the *client session*,
+     * not the feature. Keep them only as a fallback for an OS that lacks the
+     * setter, so a missing selector degrades instead of failing outright. */
+    SEL set = @selector(setEnabled:);
+    if ([c respondsToSelector:set]) {
+        IMP imp = [c methodForSelector:set];
+        if (imp) {
+            BOOL (*fn)(id, SEL, BOOL) = (BOOL (*)(id, SEL, BOOL))imp;
+            return fn(c, set, enabled ? YES : NO) ? 0 : -1;
+        }
+    }
+
+    SEL sel = enabled ? @selector(activate) : @selector(deactivate);
+    if (![c respondsToSelector:sel]) return -1;
+    IMP imp = [c methodForSelector:sel];
+    if (!imp) return -1;
+    void (*fn)(id, SEL) = (void (*)(id, SEL))imp;
+    fn(c, sel);
+    return 0;
+}

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderBuildInfo.swift
@@ -1,5 +1,5 @@
 enum TBDisplaySenderBuildInfo {
     static let marketingVersion = "3.3.0"
-    static let buildNumber = "20260728035336"
+    static let buildNumber = "20260729194347"
     static let versionDisplay = "\(marketingVersion) + build \(buildNumber)"
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -1006,6 +1006,20 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             sendVolumeUpdate()
         }
     }
+    /// Night Shift / True Tone on the receiver's own panel. Only offered when
+    /// the receiver reports it can honour them (both are private CoreBrightness
+    /// features, and True Tone needs supporting hardware).
+    @Published var nightShiftEnabled = false {
+        didSet { if !adoptingReportedTweaks { sendDisplayTweaks() } }
+    }
+    @Published var trueToneEnabled = false {
+        didSet { if !adoptingReportedTweaks { sendDisplayTweaks() } }
+    }
+    /// Set while adopting state the receiver reported, so the didSet observers
+    /// above don't echo it back and start a loop.
+    private var adoptingReportedTweaks = false
+    @Published var receiverSupportsNightShift = false
+    @Published var receiverSupportsTrueTone = false
     var audioAddonAvailable = true
     var receiverSupportsHEVCDecodeHint: Bool?
     var receiverInputMonitoringTrustedHint: Bool?
@@ -1701,6 +1715,22 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         send(packet)
     }
 
+    private func applyReportedDisplayTweaks(_ tweaks: TBMonitorDisplayTweaks) {
+        guard nightShiftEnabled != tweaks.nightShift || trueToneEnabled != tweaks.trueTone else { return }
+        adoptingReportedTweaks = true
+        nightShiftEnabled = tweaks.nightShift
+        trueToneEnabled = tweaks.trueTone
+        adoptingReportedTweaks = false
+    }
+
+    private func sendDisplayTweaks() {
+        guard let packet = TBMonitorProtocol.makeJSONPacket(
+            type: .displayTweaks,
+            value: TBMonitorDisplayTweaks(nightShift: nightShiftEnabled, trueTone: trueToneEnabled)
+        ) else { return }
+        send(packet)
+    }
+
     private func sendVolumeUpdate() {
         guard let packet = TBMonitorProtocol.makeJSONPacket(
             type: .volume,
@@ -1808,6 +1838,14 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 setStatus(.receiverTerminatedSession)
                 stop(resetStatusTo: nil)
                 return
+            case .displayTweaks:
+                // Receiver reporting its real state (it may have been changed on
+                // that Mac directly). Adopt it without sending anything back —
+                // the didSet observers would otherwise bounce it straight to the
+                // receiver and the two could ping-pong.
+                if let tweaks = TBMonitorProtocol.decodeJSON(TBMonitorDisplayTweaks.self, from: payload) {
+                    applyReportedDisplayTweaks(tweaks)
+                }
             case .clipboard:
                 if let clipboard = TBMonitorProtocol.decodeJSON(TBMonitorClipboard.self, from: payload) {
                     let pasteboard = NSPasteboard.general
@@ -2169,6 +2207,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         if let accessibilityTrusted = profile.accessibilityTrusted {
             receiverAccessibilityTrustedHint = accessibilityTrusted
         }
+        receiverSupportsNightShift = profile.supportsNightShift ?? false
+        receiverSupportsTrueTone = profile.supportsTrueTone ?? false
         receiverPanelText = TBDisplaySenderL10n.receiverSummary(profile, language: language)
         sendHello()
         sendInputControlModeUpdate()

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
@@ -10,6 +10,7 @@ final class TBDisplaySenderStatusItemController: NSObject {
     // Retains the target objects for the current menu's sliders (NSSlider holds
     // its target weakly). Cleared and rebuilt each time the menu opens.
     private var sliderTargets: [TBMenuSliderTarget] = []
+    private var toggleRows: [TBMenuToggleRowView] = []
 
     init(service: TBDisplaySenderService) {
         self.service = service
@@ -98,6 +99,7 @@ final class TBDisplaySenderStatusItemController: NSObject {
     private func rebuildMenuItems(in menu: NSMenu) {
         menu.removeAllItems()
         sliderTargets.removeAll()
+        toggleRows.removeAll()
 
         let titleItem = NSMenuItem(title: "TargetBridge", action: nil, keyEquivalent: "")
         titleItem.isEnabled = false
@@ -119,13 +121,45 @@ final class TBDisplaySenderStatusItemController: NSObject {
                     header.isEnabled = false
                     menu.addItem(header)
                 }
-                menu.addItem(makeSliderItem(symbol: "sun.max", label: brightnessMenuLabel(), value: session.brightness) { [weak session] value in
+                menu.addItem(makeSliderItem(symbol: "sun.min.fill",
+                                            trailingSymbol: "sun.max.fill",
+                                            label: brightnessMenuLabel(),
+                                            value: session.brightness) { [weak session] value in
                     session?.brightness = value
                 })
-                if session.audioEnabled {
-                    menu.addItem(makeSliderItem(symbol: "speaker.wave.2.fill", label: volumeMenuLabel(), value: session.volume) { [weak session] value in
-                        session?.volume = value
-                    })
+                // No volume slider: with the TargetBridge audio device selected,
+                // macOS's own Sound slider and the F11/F12 keys already drive the
+                // receiver's hardware volume, so a second control here would just
+                // be a duplicate that can disagree with the system one.
+                var toggles: [TBMenuToggleSpec] = []
+                if session.receiverSupportsNightShift {
+                    toggles.append(TBMenuToggleSpec(
+                        symbol: "sun.lefthalf.filled",
+                        title: nightShiftMenuLabel(),
+                        stateText: session.nightShiftEnabled ? onWord() : offWord(),
+                        isOn: session.nightShiftEnabled) { [weak session] on in
+                            session?.nightShiftEnabled = on
+                        })
+                }
+                if session.receiverSupportsTrueTone {
+                    toggles.append(TBMenuToggleSpec(
+                        symbol: "sun.max.fill",
+                        title: trueToneMenuLabel(),
+                        stateText: session.trueToneEnabled ? onWord() : offWord(),
+                        isOn: session.trueToneEnabled) { [weak session] on in
+                            session?.trueToneEnabled = on
+                        })
+                }
+                if !toggles.isEmpty {
+                    let row = TBMenuToggleRowView(specs: toggles,
+                                                  width: TBMenuMetrics.width,
+                                                  leadingInset: TBMenuMetrics.inset)
+                    row.onWord = onWord()
+                    row.offWord = offWord()
+                    let item = NSMenuItem()
+                    item.view = row
+                    menu.addItem(item)
+                    toggleRows.append(row)
                 }
             }
         }
@@ -195,22 +229,54 @@ final class TBDisplaySenderStatusItemController: NSObject {
     /// Builds a menu row with an icon and a 0…1 slider whose changes are pushed
     /// live to `onChange` (which sets `session.brightness`/`.volume`, forwarding
     /// to the receiver).
-    private func makeSliderItem(symbol: String, label: String, value: Double, onChange: @escaping (Double) -> Void) -> NSMenuItem {
-        let width: CGFloat = 240
-        let height: CGFloat = 24
+    /// Brightness row: a small glyph, the system slider, and a larger glyph
+    /// closing the row. The trailing icon is what stops the track running to the
+    /// edge of the menu.
+    ///
+    /// Stock NSSlider, deliberately, after two attempts at Control Center's
+    /// accent-filled track. `trackFillColor` is set below and menus ignore it.
+    /// Overriding NSSliderCell.drawBar does produce the fill, but any drawing
+    /// override opts the cell out of AppKit's modern slider rendering and the
+    /// knob loses its pressed-state translucency — more noticeable than a grey
+    /// track, since it makes the control feel wrong rather than just look plain.
+    private func makeSliderItem(symbol: String, trailingSymbol: String, label: String,
+                                value: Double, onChange: @escaping (Double) -> Void) -> NSMenuItem {
+        let width = TBMenuMetrics.width
+        let height: CGFloat = 28
+        let inset = TBMenuMetrics.inset
+        let leadingIcon: CGFloat = 13
+        let trailingIcon: CGFloat = 17
+        let gap: CGFloat = 8
         let container = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
 
-        let icon = NSImageView(frame: NSRect(x: 14, y: (height - 15) / 2, width: 15, height: 15))
-        icon.image = NSImage(systemSymbolName: symbol, accessibilityDescription: label)
-        icon.contentTintColor = .secondaryLabelColor
-        icon.imageScaling = .scaleProportionallyUpOrDown
-        container.addSubview(icon)
+        func glyph(_ name: String, size: CGFloat, x: CGFloat) -> NSImageView {
+            let view = NSImageView(frame: NSRect(x: x, y: (height - size) / 2, width: size, height: size))
+            view.image = NSImage(systemSymbolName: name, accessibilityDescription: label)
+            // Decorative: the slider itself carries the name, so reading these
+            // as well would announce the row three times.
+            view.setAccessibilityElement(false)
+            view.contentTintColor = .secondaryLabelColor
+            view.imageScaling = .scaleProportionallyUpOrDown
+            return view
+        }
 
-        let slider = NSSlider(frame: NSRect(x: 38, y: (height - 19) / 2, width: width - 38 - 14, height: 19))
+        container.addSubview(glyph(symbol, size: leadingIcon, x: inset))
+        container.addSubview(glyph(trailingSymbol, size: trailingIcon,
+                                   x: width - inset - trailingIcon))
+
+        let sliderX = inset + leadingIcon + gap
+        let sliderWidth = width - sliderX - gap - trailingIcon - inset
+        let slider = NSSlider(frame: NSRect(x: sliderX, y: (height - 19) / 2,
+                                            width: sliderWidth, height: 19))
         slider.minValue = 0
         slider.maxValue = 1
         slider.doubleValue = value
         slider.isContinuous = true
+        // Set even though menus currently ignore it: harmless, and it is the
+        // supported way to get an accent-filled track if that changes.
+        slider.trackFillColor = .controlAccentColor
+        slider.controlSize = .small
+        slider.setAccessibilityLabel(label)
         let target = TBMenuSliderTarget(onChange)
         slider.target = target
         slider.action = #selector(TBMenuSliderTarget.changed(_:))
@@ -226,15 +292,57 @@ final class TBDisplaySenderStatusItemController: NSObject {
     private func brightnessMenuLabel() -> String {
         switch service.language {
         case .italian: return "Luminosità"
+        case .french: return "Luminosité"
         case .english: return "Brightness"
         case .german: return "Helligkeit"
         case .chinese: return "亮度"
         }
     }
 
+    private func onWord() -> String {
+        switch service.language {
+        case .italian: return "Attivo"
+        case .english: return "On"
+        case .german: return "Ein"
+        case .chinese: return "开"
+        case .french: return "Activé"
+        }
+    }
+
+    private func offWord() -> String {
+        switch service.language {
+        case .italian: return "Non attivo"
+        case .english: return "Off"
+        case .german: return "Aus"
+        case .chinese: return "关"
+        case .french: return "Désactivé"
+        }
+    }
+
+    private func nightShiftMenuLabel() -> String {
+        switch service.language {
+        case .italian: return "Night Shift"
+        case .english: return "Night Shift"
+        case .german: return "Night Shift"
+        case .chinese: return "夜览"
+        case .french: return "Night Shift"
+        }
+    }
+
+    private func trueToneMenuLabel() -> String {
+        switch service.language {
+        case .italian: return "True Tone"
+        case .english: return "True Tone"
+        case .german: return "True Tone"
+        case .chinese: return "原彩显示"
+        case .french: return "True Tone"
+        }
+    }
+
     private func volumeMenuLabel() -> String {
         switch service.language {
         case .italian: return "Volume"
+        case .french: return "Volume"
         case .english: return "Volume"
         case .german: return "Lautstärke"
         case .chinese: return "音量"
@@ -244,6 +352,7 @@ final class TBDisplaySenderStatusItemController: NSObject {
     private func connectionInfoMenuLabel() -> String {
         switch service.language {
         case .italian: return "Info connessione"
+        case .french: return "Infos de connexion"
         case .english: return "Connection info"
         case .german: return "Verbindungsinfo"
         case .chinese: return "连接信息"

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
@@ -7,6 +7,9 @@ final class TBDisplaySenderStatusItemController: NSObject {
     nonisolated(unsafe) private var statusItem: NSStatusItem?
     private var cancellables = Set<AnyCancellable>()
     private var hasActivated = false
+    // Retains the target objects for the current menu's sliders (NSSlider holds
+    // its target weakly). Cleared and rebuilt each time the menu opens.
+    private var sliderTargets: [TBMenuSliderTarget] = []
 
     init(service: TBDisplaySenderService) {
         self.service = service
@@ -94,6 +97,7 @@ final class TBDisplaySenderStatusItemController: NSObject {
 
     private func rebuildMenuItems(in menu: NSMenu) {
         menu.removeAllItems()
+        sliderTargets.removeAll()
 
         let titleItem = NSMenuItem(title: "TargetBridge", action: nil, keyEquivalent: "")
         titleItem.isEnabled = false
@@ -103,17 +107,27 @@ final class TBDisplaySenderStatusItemController: NSObject {
         statusItem.isEnabled = false
         menu.addItem(statusItem)
 
-        if !service.localInterfaces.isEmpty {
-            let ipItem = NSMenuItem(title: TBDisplaySenderL10n.topBarIP(service.language, service.localInterfaceSummaryText), action: nil, keyEquivalent: "")
-            ipItem.isEnabled = false
-            menu.addItem(ipItem)
-        }
-
-        for session in service.sessions {
-            let line = "\(service.sessionTitle(for: session)): \(session.statusText)"
-            let sessionItem = NSMenuItem(title: line, action: nil, keyEquivalent: "")
-            sessionItem.isEnabled = false
-            menu.addItem(sessionItem)
+        // Brightness / volume sliders for each connected session. Reliable and
+        // native-feeling: they drive the receiver directly via the existing
+        // brightness/volume path — no event taps, no cursor/keyboard routing.
+        let connectedSessions = service.sessions.filter { $0.isConnected }
+        if !connectedSessions.isEmpty {
+            menu.addItem(.separator())
+            for session in connectedSessions {
+                if connectedSessions.count > 1 {
+                    let header = NSMenuItem(title: service.sessionTitle(for: session), action: nil, keyEquivalent: "")
+                    header.isEnabled = false
+                    menu.addItem(header)
+                }
+                menu.addItem(makeSliderItem(symbol: "sun.max", label: brightnessMenuLabel(), value: session.brightness) { [weak session] value in
+                    session?.brightness = value
+                })
+                if session.audioEnabled {
+                    menu.addItem(makeSliderItem(symbol: "speaker.wave.2.fill", label: volumeMenuLabel(), value: session.volume) { [weak session] value in
+                        session?.volume = value
+                    })
+                }
+            }
         }
 
         menu.addItem(.separator())
@@ -143,6 +157,26 @@ final class TBDisplaySenderStatusItemController: NSObject {
         stopAllItem.isEnabled = service.anyConnected
         menu.addItem(stopAllItem)
 
+        // The verbose connection/IP details live behind a submenu so the default
+        // menu stays focused on the useful actions.
+        if !service.localInterfaces.isEmpty || !service.sessions.isEmpty {
+            let infoItem = NSMenuItem(title: connectionInfoMenuLabel(), action: nil, keyEquivalent: "")
+            let infoSubmenu = NSMenu()
+            if !service.localInterfaces.isEmpty {
+                let ipItem = NSMenuItem(title: TBDisplaySenderL10n.topBarIP(service.language, service.localInterfaceSummaryText), action: nil, keyEquivalent: "")
+                ipItem.isEnabled = false
+                infoSubmenu.addItem(ipItem)
+            }
+            for session in service.sessions {
+                let line = "\(service.sessionTitle(for: session)): \(session.statusText)"
+                let sessionItem = NSMenuItem(title: line, action: nil, keyEquivalent: "")
+                sessionItem.isEnabled = false
+                infoSubmenu.addItem(sessionItem)
+            }
+            infoItem.submenu = infoSubmenu
+            menu.addItem(infoItem)
+        }
+
         let hideItem = NSMenuItem(
             title: TBDisplaySenderL10n.hideMenuBarIcon(service.language),
             action: #selector(hideStatusItem),
@@ -156,6 +190,64 @@ final class TBDisplaySenderStatusItemController: NSObject {
         let quitItem = NSMenuItem(title: TBDisplaySenderL10n.quitApp(service.language), action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
+    }
+
+    /// Builds a menu row with an icon and a 0…1 slider whose changes are pushed
+    /// live to `onChange` (which sets `session.brightness`/`.volume`, forwarding
+    /// to the receiver).
+    private func makeSliderItem(symbol: String, label: String, value: Double, onChange: @escaping (Double) -> Void) -> NSMenuItem {
+        let width: CGFloat = 240
+        let height: CGFloat = 24
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+
+        let icon = NSImageView(frame: NSRect(x: 14, y: (height - 15) / 2, width: 15, height: 15))
+        icon.image = NSImage(systemSymbolName: symbol, accessibilityDescription: label)
+        icon.contentTintColor = .secondaryLabelColor
+        icon.imageScaling = .scaleProportionallyUpOrDown
+        container.addSubview(icon)
+
+        let slider = NSSlider(frame: NSRect(x: 38, y: (height - 19) / 2, width: width - 38 - 14, height: 19))
+        slider.minValue = 0
+        slider.maxValue = 1
+        slider.doubleValue = value
+        slider.isContinuous = true
+        let target = TBMenuSliderTarget(onChange)
+        slider.target = target
+        slider.action = #selector(TBMenuSliderTarget.changed(_:))
+        sliderTargets.append(target)
+        container.addSubview(slider)
+
+        let item = NSMenuItem()
+        item.view = container
+        item.toolTip = label
+        return item
+    }
+
+    private func brightnessMenuLabel() -> String {
+        switch service.language {
+        case .italian: return "Luminosità"
+        case .english: return "Brightness"
+        case .german: return "Helligkeit"
+        case .chinese: return "亮度"
+        }
+    }
+
+    private func volumeMenuLabel() -> String {
+        switch service.language {
+        case .italian: return "Volume"
+        case .english: return "Volume"
+        case .german: return "Lautstärke"
+        case .chinese: return "音量"
+        }
+    }
+
+    private func connectionInfoMenuLabel() -> String {
+        switch service.language {
+        case .italian: return "Info connessione"
+        case .english: return "Connection info"
+        case .german: return "Verbindungsinfo"
+        case .chinese: return "连接信息"
+        }
     }
 
     // Menu-item handlers run while the menu is still dismissing. Doing work
@@ -210,5 +302,20 @@ final class TBDisplaySenderStatusItemController: NSObject {
 extension TBDisplaySenderStatusItemController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         rebuildMenuItems(in: menu)
+    }
+}
+
+/// Target for a menu slider. NSSlider holds its target weakly, so the controller
+/// retains these for the lifetime of the open menu.
+@MainActor
+final class TBMenuSliderTarget: NSObject {
+    private let onChange: (Double) -> Void
+
+    init(_ onChange: @escaping (Double) -> Void) {
+        self.onChange = onChange
+    }
+
+    @objc func changed(_ sender: NSSlider) {
+        onChange(sender.doubleValue)
     }
 }

--- a/TargetBridge-Sender/TBDisplaySender/TBMenuMetrics.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBMenuMetrics.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+/// Geometry shared by the menu-bar panel's custom rows.
+///
+/// A menu takes the width of its widest item, so with only text items ours came
+/// out around 240 pt — narrow enough to read as cramped beside the system's own
+/// panels. Control Center's modules are ~340 pt, measured from the Sound and
+/// Display panels on macOS 15.
+///
+/// The content view is set below that, because a menu draws its own chrome
+/// around the item — a 340 pt view produced a visibly wider panel than Apple's.
+/// This is the width of the row, not of the panel the user sees; the value was
+/// settled by comparing the two panels on screen rather than by calculation.
+///
+/// Apple publishes no metrics for those panels — they are system UI, not a
+/// component we can adopt — so this is deliberate imitation rather than a
+/// documented standard. Two differences cannot be closed: menu items reserve a
+/// leading column for checkmarks, so text rows sit further right than Control
+/// Center's labels, and Control Center is a floating panel that draws its own
+/// rounded background where a menu draws its own chrome.
+enum TBMenuMetrics {
+    static let width: CGFloat = 300
+    static let inset: CGFloat = 14
+}

--- a/TargetBridge-Sender/TBDisplaySender/TBMenuToggleRowView.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBMenuToggleRowView.swift
@@ -1,0 +1,167 @@
+import AppKit
+
+/// One circular toggle in the row.
+struct TBMenuToggleSpec {
+    let symbol: String
+    let title: String
+    /// Shown under the title, e.g. "On" / "Off" — mirrors Control Center.
+    let stateText: String
+    let isOn: Bool
+    let onToggle: (Bool) -> Void
+}
+
+/// A row of circular on/off buttons laid out like Control Center's display
+/// panel: filled accent circle when on, muted circle when off, with the name and
+/// current state stacked underneath.
+///
+/// Built as a custom menu-item view rather than checkable NSMenuItems because
+/// these are display *modes* the user flips repeatedly while looking at the
+/// screen, and the Apple layout shows state at a glance without opening a
+/// submenu. Menus don't lay out subviews for us, so all geometry is explicit.
+final class TBMenuToggleRowView: NSView {
+
+    private var buttons: [NSButton] = []
+    private var stateFields: [NSTextField] = []
+    private var specs: [TBMenuToggleSpec] = []
+
+    private enum Metrics {
+        static let circle: CGFloat = 38
+        static let gap: CGFloat = 4          // circle -> title
+        static let titleHeight: CGFloat = 14
+        static let stateHeight: CGFloat = 13
+        static let topPadding: CGFloat = 6
+        static let bottomPadding: CGFloat = 8
+        static var height: CGFloat {
+            topPadding + circle + gap + titleHeight + stateHeight + bottomPadding
+        }
+    }
+
+    static var preferredHeight: CGFloat { Metrics.height }
+
+    init(specs: [TBMenuToggleSpec], width: CGFloat, leadingInset: CGFloat) {
+        self.specs = specs
+        super.init(frame: NSRect(x: 0, y: 0, width: width, height: Metrics.height))
+        build(width: width, leadingInset: leadingInset)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    private func build(width: CGFloat, leadingInset: CGFloat) {
+        guard !specs.isEmpty else { return }
+
+        let usable = width - leadingInset * 2
+        let cellWidth = usable / CGFloat(specs.count)
+
+        for (index, spec) in specs.enumerated() {
+            let cellX = leadingInset + cellWidth * CGFloat(index)
+            let centerX = cellX + cellWidth / 2
+
+            // Buttons are laid out from the top down; AppKit's origin is bottom
+            // left, so each y is measured back from the view's height.
+            let circleY = Metrics.height - Metrics.topPadding - Metrics.circle
+
+            let button = NSButton(frame: NSRect(x: centerX - Metrics.circle / 2,
+                                               y: circleY,
+                                               width: Metrics.circle,
+                                               height: Metrics.circle))
+            button.isBordered = false
+            button.bezelStyle = .regularSquare
+            button.title = ""
+            button.wantsLayer = true
+            button.layer?.cornerRadius = Metrics.circle / 2
+            button.imagePosition = .imageOnly
+            button.setButtonType(.momentaryChange)
+
+            let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
+            button.image = NSImage(systemSymbolName: spec.symbol,
+                                   accessibilityDescription: spec.title)?
+                .withSymbolConfiguration(config)
+            // A toggle, not a plain button: the checkbox role is what makes
+            // VoiceOver announce the on/off state, which is otherwise only
+            // conveyed by the caption underneath.
+            button.setAccessibilityLabel(spec.title)
+            button.setAccessibilityRole(.checkBox)
+            button.setAccessibilityValue(NSNumber(value: spec.isOn))
+
+            button.tag = index
+            button.target = self
+            button.action = #selector(tapped(_:))
+            applyStyle(to: button, isOn: spec.isOn)
+            addSubview(button)
+            buttons.append(button)
+
+            let titleY = circleY - Metrics.gap - Metrics.titleHeight
+            // The captions repeat what the button already announces, so keep
+            // them out of the accessibility tree rather than reading twice.
+            addSubview(label(spec.title,
+                             frame: NSRect(x: cellX, y: titleY, width: cellWidth, height: Metrics.titleHeight),
+                             font: .systemFont(ofSize: 11, weight: .medium),
+                             color: .labelColor))
+
+            let stateField = label(spec.stateText,
+                                   frame: NSRect(x: cellX, y: titleY - Metrics.stateHeight,
+                                                 width: cellWidth, height: Metrics.stateHeight),
+                                   font: .systemFont(ofSize: 10, weight: .regular),
+                                   color: .secondaryLabelColor)
+            addSubview(stateField)
+            stateFields.append(stateField)
+        }
+    }
+
+    private func label(_ text: String, frame: NSRect, font: NSFont, color: NSColor) -> NSTextField {
+        let field = NSTextField(labelWithString: text)
+        field.setAccessibilityElement(false)
+        field.frame = frame
+        field.font = font
+        field.textColor = color
+        field.alignment = .center
+        field.lineBreakMode = .byTruncatingTail
+        return field
+    }
+
+    private func applyStyle(to button: NSButton, isOn: Bool) {
+        // Accent fill + white glyph when on; muted fill + normal glyph when off,
+        // matching Control Center rather than inventing a colour scheme.
+        button.layer?.backgroundColor = isOn
+            ? NSColor.controlAccentColor.cgColor
+            : NSColor.quaternaryLabelColor.withAlphaComponent(0.22).cgColor
+        button.contentTintColor = isOn ? .white : .labelColor
+    }
+
+    @objc private func tapped(_ sender: NSButton) {
+        let index = sender.tag
+        guard specs.indices.contains(index) else { return }
+
+        let newState = !isOn(index)
+        states[index] = newState
+        applyStyle(to: sender, isOn: newState)
+        sender.setAccessibilityValue(NSNumber(value: newState))
+        // Reflect the change immediately; the menu usually closes on click, but
+        // if it stays open the row should not show a stale state.
+        if let field = stateField(at: index) {
+            field.stringValue = newState ? onWord : offWord
+        }
+        specs[index].onToggle(newState)
+    }
+
+    // MARK: - Live state
+
+    private lazy var states: [Int: Bool] = {
+        var map: [Int: Bool] = [:]
+        for (i, s) in specs.enumerated() { map[i] = s.isOn }
+        return map
+    }()
+
+    private func isOn(_ index: Int) -> Bool {
+        states[index] ?? specs[index].isOn
+    }
+
+    /// Words used when a tap updates the state line. Set by the owner so the
+    /// row stays localised without knowing about the localisation layer.
+    var onWord = "On"
+    var offWord = "Off"
+
+    private func stateField(at index: Int) -> NSTextField? {
+        stateFields.indices.contains(index) ? stateFields[index] : nil
+    }
+}

--- a/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBMonitorProtocol.swift
@@ -17,6 +17,8 @@ enum TBMonitorPacketType: UInt8 {
     case brightness = 0x35
     case clipboard = 0x36
     case volume = 0x37
+    /// Night Shift / True Tone on the receiver's panel.
+    case displayTweaks = 0x38
     case testData = 0x40
 }
 
@@ -44,6 +46,9 @@ struct TBMonitorDisplayProfile: Codable {
     var supportsRawNV12: Bool?
     var inputMonitoringTrusted: Bool?
     var accessibilityTrusted: Bool?
+    /// Optional so older receivers still decode; absent means "cannot".
+    var supportsNightShift: Bool?
+    var supportsTrueTone: Bool?
 }
 
 struct TBMonitorCreateSessionAck: Codable {
@@ -92,6 +97,11 @@ struct TBMonitorBrightness: Codable {
 
 struct TBMonitorVolume: Codable {
     var level: Double
+}
+
+struct TBMonitorDisplayTweaks: Codable {
+    var nightShift: Bool
+    var trueTone: Bool
 }
 
 struct TBMonitorClipboard: Codable {

--- a/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
+++ b/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		69C27FB23C2EF4078DD3D2F5 /* TBReceiverDiscoveryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2B1A011B9446090DA60A7 /* TBReceiverDiscoveryModelTests.swift */; };
 		6A54029FE56DEECA996A07B4 /* TBDisplaySenderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B483A658326FE85720BCBE2 /* TBDisplaySenderService.swift */; };
 		7528751850893B52660870E4 /* TBConfigurationDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7086193EE5710E2C37F86F1 /* TBConfigurationDiagnosticsTests.swift */; };
+		762884127C8093D3E9797790 /* TBMenuToggleRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040912357013932AE29CFD6A /* TBMenuToggleRowView.swift */; };
+		C7A1D4E29B3F45A88C3D0052 /* TBMenuMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1D4E29B3F45A88C3D0051 /* TBMenuMetrics.swift */; };
 		7F103818097EEBD191C5ADBF /* TBConnectionDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405452C4DA622D0B8887623E /* TBConnectionDiagnosticsTests.swift */; };
 		7F1AE9053DA59169FB761FAA /* de.json in Resources */ = {isa = PBXBuildFile; fileRef = C3658E86F5BE2168F4591491 /* de.json */; };
 		7FB34AA1E75B01E7D1EC3E21 /* it.json in Resources */ = {isa = PBXBuildFile; fileRef = 036E14097FA59989FFC456FD /* it.json */; };
@@ -65,6 +67,8 @@
 
 /* Begin PBXFileReference section */
 		036E14097FA59989FFC456FD /* it.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = it.json; sourceTree = "<group>"; };
+		040912357013932AE29CFD6A /* TBMenuToggleRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBMenuToggleRowView.swift; sourceTree = "<group>"; };
+		C7A1D4E29B3F45A88C3D0051 /* TBMenuMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBMenuMetrics.swift; sourceTree = "<group>"; };
 		06BABA1447D1E8DD50A6C2F0 /* TBReceiverDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBReceiverDiscovery.swift; sourceTree = "<group>"; };
 		06D011FF8AF7BB6D26EDC25B /* TBAddonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAddonStore.swift; sourceTree = "<group>"; };
 		0B483A658326FE85720BCBE2 /* TBDisplaySenderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderService.swift; sourceTree = "<group>"; };
@@ -144,6 +148,8 @@
 				4A72C42968FA2A6B2A0515B9 /* TBInputBinding.swift */,
 				20FE01BF2EA2F329442890AD /* TBInputBindingsView.swift */,
 				7E3DC447E3E8E522565E725B /* TBInputRelayController.swift */,
+				040912357013932AE29CFD6A /* TBMenuToggleRowView.swift */,
+				C7A1D4E29B3F45A88C3D0051 /* TBMenuMetrics.swift */,
 				06BABA1447D1E8DD50A6C2F0 /* TBReceiverDiscovery.swift */,
 				6630386DB9C3D210849E6211 /* TBVirtualDisplayModeMemory.swift */,
 			);
@@ -393,6 +399,8 @@
 				D5E6B5B7B49E740C92010C6F /* TBInputDebugLog.swift in Sources */,
 				CBA7C2F0FA57CC475E2307AF /* TBInputRelayController.swift in Sources */,
 				8A729C68ECAC4642FA20A284 /* TBLocalizationStore.swift in Sources */,
+				762884127C8093D3E9797790 /* TBMenuToggleRowView.swift in Sources */,
+				C7A1D4E29B3F45A88C3D0052 /* TBMenuMetrics.swift in Sources */,
 				C2CCAB017BC3CAB1DCFA5CCC /* TBMonitorProtocol.swift in Sources */,
 				06E4F7B33C77762A5E2CB616 /* TBReceiverDiscovery.swift in Sources */,
 				58980FE95A48D8F8EDB42055 /* TBVirtualDisplayModeMemory.swift in Sources */,


### PR DESCRIPTION

<img width="311" height="357" alt="image" src="https://github.com/user-attachments/assets/e8637c16-7535-4f76-8f87-ce0e33aabd5e" />


Adds Control-Center-style toggles to the menu bar for the receiver's **Night Shift** and **True Tone**, and drops the volume slider — with an audio device selected, macOS's own Sound slider already drives the receiver's hardware volume, so a second control here can only disagree with the system one.

Two-way: changing either on the receiver itself (Control Centre, System Settings) propagates back, so the toggles never show a stale state.

> **Builds on #143.** That PR's commit is included here, rebased onto current `main`. Merge #143 first, or merge this instead of it. The rebase also required filling in the French labels #143 predates — on current `main` its label switches are no longer exhaustive and it does not compile, which is worth knowing regardless of this PR.

## Private API, and how it's contained

Both features live in the private **CoreBrightness** framework, reached by `dlopen` plus the Objective-C runtime — the same approach this app already uses for DisplayServices brightness. A missing class or renamed selector degrades to "unsupported" rather than breaking the build or crashing on a future macOS. The receiver advertises `supportsNightShift` / `supportsTrueTone` in its display profile, and the toggles appear only when it does.

**`CBTrueToneClient` exposes both `activate`/`deactivate` and `setEnabled:`.** The first pair looks like the on/off switch and isn't — measured against the live framework, after `deactivate` the panel is unchanged and `enabled` still reports `1`. They activate the client *session*. `setEnabled:` is the real switch; `activate`/`deactivate` are kept only as a fallback.

**One deliberately fragile spot:** `CBBlueLightClient` has no `enabled` getter, only `getBlueLightStatus:`, which fills a private struct. It's read into an oversized zeroed buffer so a larger struct on a future macOS can't overflow, and a changed layout misreports the toggle rather than crashing. Worst case is a stale-looking toggle.

## Panel styling

The panel was ~240 pt against Control Center's ~340, and two symbols were simply the wrong picture.

Symbols were settled by **rendering every plausible SF Symbol and comparing against Control Center**, not by picking names that sounded right. Apple's family is half-circle → half-sun → full-sun for Dark Mode, Night Shift and True Tone — so Night Shift is a *sun with a dark half*, not a moon:

| | Before | After |
|---|---|---|
| Night Shift | `moon.fill` | `sun.lefthalf.filled` |
| True Tone | `sun.max` | `sun.max.fill` |
| Brightness ends | `sun.min` / `sun.max` | `.fill` variants |

True Tone's real glyph has lines through the disc and no SF Symbol does; Control Center appears to use a private asset, so `sun.max.fill` is the closest public match.

Width now comes from a single constant. Note the row width and the visible panel width are different numbers — a menu draws its own chrome around the item.

**The slider track stays grey, and that is a decision.** `trackFillColor` is set and menus ignore it. Overriding `NSSliderCell.drawBar` does produce the accent fill, but any drawing override opts the cell out of AppKit's modern slider rendering and the knob loses its pressed-state translucency. A control that *feels* wrong is worse than one that looks plain. The comment now says so, rather than leaving the next person to rediscover it.

## Accessibility

Fixed as part of this, since the custom views are ours:

- the slider carries its name — previously only its decorative glyphs had descriptions, so VoiceOver announced an unnamed slider flanked by two images
- the toggles use the checkbox role with a value that follows the state, instead of announcing a name with no on/off
- the captions are out of the accessibility tree rather than read as extra elements

## Conventions

Strings use the file's prevailing inline `switch language` pattern (105 such blocks across the sender, against 8 files using the shared `TBDisplaySenderL10n`). `docs/Translations.md` presents shared JSON as the mechanism, so this is a deliberate choice for local consistency — happy to move these keys into `TargetBridge-Shared/Languages/*.json` if the project is migrating that way. `check_localizations.sh` passes.

## Testing

Verified on a MacBook Pro M4 Pro sender and a 2020 Retina 5K iMac receiver: both toggles flip the iMac's panel, both reflect changes made on the iMac itself, and the toggles hide on a receiver that reports no support.
