### PR TITLE
Build and publish Sender for x86_64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,21 @@ name: CI Build Verification
 
 on:
   push:
-    branches: [ main, 3.1-maint, 3.2-dev, dev-3.3.0 ]
+    branches: [ main, 3.1-maint, 3.2-dev, dev-3.3.0, dev-3.4.0 ]
   pull_request:
-    branches: [ main, 3.1-maint, 3.2-dev, dev-3.3.0 ]
+    branches: [ main, 3.1-maint, 3.2-dev, dev-3.3.0, dev-3.4.0 ]
 
 jobs:
   build-sender:
-    name: Build Sender (macOS 15 - Apple Silicon)
-    runs-on: macos-15
+    name: Build Sender (${{ matrix.os }} - ${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - os: macos-15-intel
+            arch: x86_64
+          - os: macos-15
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -26,6 +33,7 @@ jobs:
         run: |
           cd TargetBridge-Sender
           ./scripts/build_targetbridge_sender_app.sh
+          file build/TargetBridge.app/Contents/MacOS/TargetBridge | grep -q "${{ matrix.arch }}"
 
       - name: Run Sender Unit Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,15 @@ permissions:
 
 jobs:
   build-sender:
-    name: Build Sender (Apple Silicon)
-    runs-on: macos-15
+    name: Build Sender (${{ matrix.os }} - ${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - os: macos-15-intel
+            arch: x86_64
+          - os: macos-15
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -26,22 +33,23 @@ jobs:
         run: |
           cd TargetBridge-Sender
           ./scripts/build_targetbridge_sender_app.sh
+          file build/TargetBridge.app/Contents/MacOS/TargetBridge | grep -q "${{ matrix.arch }}"
 
       - name: Zip App Bundle
         run: |
           cd build
-          zip -r TargetBridge-arm64.app.zip TargetBridge.app
+          zip -r TargetBridge-${{ matrix.arch }}.app.zip TargetBridge.app
 
       - name: Generate build provenance attestation
         uses: actions/attest@v4
         with:
-          subject-path: build/TargetBridge-arm64.app.zip
+          subject-path: build/TargetBridge-${{ matrix.arch }}.app.zip
 
       - name: Upload Sender Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: TargetBridge-arm64.app.zip
-          path: build/TargetBridge-arm64.app.zip
+          name: TargetBridge-${{ matrix.arch }}.app.zip
+          path: build/TargetBridge-${{ matrix.arch }}.app.zip
           retention-days: 1
 
   build-receiver:
@@ -95,6 +103,12 @@ jobs:
       - name: Download Sender Artifact
         uses: actions/download-artifact@v8
         with:
+          name: TargetBridge-x86_64.app.zip
+          path: ./artifacts
+
+      - name: Download Sender Artifact (arm64)
+        uses: actions/download-artifact@v8
+        with:
           name: TargetBridge-arm64.app.zip
           path: ./artifacts
 
@@ -115,6 +129,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
+            ./artifacts/TargetBridge-x86_64.app.zip \
             ./artifacts/TargetBridge-arm64.app.zip \
             ./artifacts/TargetBridge-Receiver-x86_64.app.zip \
             ./artifacts/TargetBridge-Receiver-arm64.app.zip \


### PR DESCRIPTION
## Summary

- Build and test the Sender on both Intel (`x86_64`) and Apple Silicon (`arm64`) macOS runners.
- Verify the produced executable architecture in CI.
- Publish both Sender ZIP artifacts and provenance attestations in tagged releases.

## Validation

- `dev-3.4.0` was built natively as `x86_64` on an Intel iMac (macOS Sequoia 15.7.7).
- Sender unit suite passed: 84/84 tests.
- This PR intentionally contains no fork-specific bundle identity, UI, profile, localization, Receiver, or VideoToolbox behavior changes.

This is the first focused Intel Sender contribution discussed in #64.