### PR TITLE
Add measured USB4 and network path selection

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -31,7 +31,7 @@ LDFLAGS  += $(shell $(PKG) --libs libavcodec libavutil sdl2)
 
 UNAME_S  := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices -framework CoreAudio
+LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices -framework CoreAudio -framework SystemConfiguration
 endif
 
 C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/tb_i18n.c
@@ -56,10 +56,14 @@ clean:
 # Unit tests for the packet parser. net.c is pure POSIX, so this needs no
 # ffmpeg/SDL/pkgconf — it runs anywhere, including CI, with no hardware.
 TEST_CFLAGS = -O2 -g -Wall -Wextra -Wno-unused-parameter -std=c11
+TEST_LDFLAGS =
+ifeq ($(UNAME_S),Darwin)
+TEST_LDFLAGS += -framework CoreFoundation -framework SystemConfiguration
+endif
 TEST_BIN = test_net_parser
 
 $(TEST_BIN): tests/test_net_parser.c src/net.c src/net.h src/proto.h
-	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c -o $@
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c $(TEST_LDFLAGS) -o $@
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -82,7 +82,10 @@ struct app {
 
     char     ip_text[64];
     char     tb_ip_text[64];
+    char     usb_ip_text[64];
     char     net_ip_text[64];
+    char     ethernet_ip_text[64];
+    char     wifi_ip_text[64];
     char     display_host[128]; /* short hostname (or hostname+IP), cached at startup */
     char     status_text[128];
     char     sender_text[128];
@@ -597,8 +600,17 @@ static void bonjour_update(struct app *a, uint16_t port) {
     if (a->tb_ip_text[0] != '\0') {
         TXTRecordSetValue(&txt, "tbIP", (uint8_t)strlen(a->tb_ip_text), a->tb_ip_text);
     }
+    if (a->usb_ip_text[0] != '\0') {
+        TXTRecordSetValue(&txt, "usbIP", (uint8_t)strlen(a->usb_ip_text), a->usb_ip_text);
+    }
     if (a->net_ip_text[0] != '\0') {
         TXTRecordSetValue(&txt, "netIP", (uint8_t)strlen(a->net_ip_text), a->net_ip_text);
+    }
+    if (a->ethernet_ip_text[0] != '\0') {
+        TXTRecordSetValue(&txt, "ethernetIP", (uint8_t)strlen(a->ethernet_ip_text), a->ethernet_ip_text);
+    }
+    if (a->wifi_ip_text[0] != '\0') {
+        TXTRecordSetValue(&txt, "wifiIP", (uint8_t)strlen(a->wifi_ip_text), a->wifi_ip_text);
     }
     TXTRecordSetValue(&txt, "panel", (uint8_t)strlen(a->panel_text), a->panel_text);
     TXTRecordSetValue(&txt, "version", (uint8_t)strlen(TB_RECEIVER_VERSION), TB_RECEIVER_VERSION);
@@ -1858,16 +1870,30 @@ int main(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
 
     char tb_ip[64] = {0};
+    char usb_ip[64] = {0};
     char net_ip[64] = {0};
+    char ethernet_ip[64] = {0};
+    char wifi_ip[64] = {0};
     if (tb_net_get_tb_ip(tb_ip, sizeof(tb_ip)) == 0) {
         printf("TBReceiver: Thunderbolt Bridge IP = %s\n", tb_ip);
     } else {
         printf("TBReceiver: warning, no bridge IP detected (169.254.x.x)\n");
     }
+    if (tb_net_get_link_local_ip(usb_ip, sizeof(usb_ip)) == 0) {
+        printf("TBReceiver: Direct USB-NCM IP = %s\n", usb_ip);
+    } else {
+        printf("TBReceiver: warning, no direct USB-NCM/link-local IP detected\n");
+    }
     if (tb_net_get_lan_ip(net_ip, sizeof(net_ip)) == 0) {
         printf("TBReceiver: Local network IP = %s\n", net_ip);
     } else {
         printf("TBReceiver: warning, no LAN IP detected (RFC1918 IPv4)\n");
+    }
+    if (tb_net_get_ethernet_ip(ethernet_ip, sizeof(ethernet_ip)) == 0) {
+        printf("TBReceiver: Ethernet IP = %s\n", ethernet_ip);
+    }
+    if (tb_net_get_wifi_ip(wifi_ip, sizeof(wifi_ip)) == 0) {
+        printf("TBReceiver: Wi-Fi IP = %s\n", wifi_ip);
     }
     printf("TBReceiver: listening on TCP port %d\n", TB_PORT);
 
@@ -1883,14 +1909,21 @@ int main(int argc, char **argv) {
         snprintf(a.bonjour_name, sizeof(a.bonjour_name), "TargetBridge %s", host);
     }
     snprintf(a.tb_ip_text, sizeof(a.tb_ip_text), "%s", tb_ip);
+    snprintf(a.usb_ip_text, sizeof(a.usb_ip_text), "%s", usb_ip);
     snprintf(a.net_ip_text, sizeof(a.net_ip_text), "%s", net_ip);
-    snprintf(a.ip_text, sizeof(a.ip_text), "%s", tb_ip[0] ? tb_ip : (net_ip[0] ? net_ip : tb_i18n_get("receiver.network.not_detected")));
+    snprintf(a.ethernet_ip_text, sizeof(a.ethernet_ip_text), "%s", ethernet_ip);
+    snprintf(a.wifi_ip_text, sizeof(a.wifi_ip_text), "%s", wifi_ip);
+    snprintf(a.ip_text, sizeof(a.ip_text), "%s",
+             tb_ip[0] ? tb_ip
+                      : (usb_ip[0] ? usb_ip
+                                   : (net_ip[0] ? net_ip : tb_i18n_get("receiver.network.not_detected"))));
     snprintf(a.language_pref, sizeof(a.language_pref), "%s", startup_language_pref);
     snprintf(a.input_control_mode, sizeof(a.input_control_mode), "%s", "off");
     a.last_input_monitoring_trusted = -1;
     a.last_accessibility_trusted = -1;
     tb_refresh_idle_localized_strings(&a);
-    build_display_host(a.display_host, sizeof(a.display_host), a.ip_text, tb_ip[0] || net_ip[0]);
+    build_display_host(a.display_host, sizeof(a.display_host), a.ip_text,
+                       tb_ip[0] || usb_ip[0] || net_ip[0]);
     tb_receiver_apply_language_preference(&a);
     tb_gesture_bridge_install(tb_receiver_space_switch_callback, &a);
     tb_gesture_bridge_set_active(0);
@@ -1949,27 +1982,50 @@ int main(int argc, char **argv) {
 
         if (t - a.last_ip_check_ms >= 1000) {
             char refreshed_tb_ip[64] = {0};
+            char refreshed_usb_ip[64] = {0};
             char refreshed_net_ip[64] = {0};
+            char refreshed_ethernet_ip[64] = {0};
+            char refreshed_wifi_ip[64] = {0};
             a.last_ip_check_ms = t;
             (void)tb_net_get_tb_ip(refreshed_tb_ip, sizeof(refreshed_tb_ip));
+            (void)tb_net_get_link_local_ip(refreshed_usb_ip, sizeof(refreshed_usb_ip));
             (void)tb_net_get_lan_ip(refreshed_net_ip, sizeof(refreshed_net_ip));
+            (void)tb_net_get_ethernet_ip(refreshed_ethernet_ip, sizeof(refreshed_ethernet_ip));
+            (void)tb_net_get_wifi_ip(refreshed_wifi_ip, sizeof(refreshed_wifi_ip));
 
-            const int have_refreshed_ip = refreshed_tb_ip[0] || refreshed_net_ip[0];
+            const int have_refreshed_ip =
+                refreshed_tb_ip[0] || refreshed_usb_ip[0] || refreshed_net_ip[0];
             const char *preferred_ip = refreshed_tb_ip[0] ? refreshed_tb_ip
-                                     : (refreshed_net_ip[0] ? refreshed_net_ip
-                                     : tb_i18n_get("receiver.network.not_detected"));
+                                     : (refreshed_usb_ip[0] ? refreshed_usb_ip
+                                      : (refreshed_net_ip[0] ? refreshed_net_ip
+                                      : tb_i18n_get("receiver.network.not_detected")));
             if (strcmp(a.tb_ip_text, refreshed_tb_ip) != 0 ||
+                strcmp(a.usb_ip_text, refreshed_usb_ip) != 0 ||
                 strcmp(a.net_ip_text, refreshed_net_ip) != 0 ||
+                strcmp(a.ethernet_ip_text, refreshed_ethernet_ip) != 0 ||
+                strcmp(a.wifi_ip_text, refreshed_wifi_ip) != 0 ||
                 strcmp(a.ip_text, preferred_ip) != 0) {
                 snprintf(a.tb_ip_text, sizeof(a.tb_ip_text), "%s", refreshed_tb_ip);
+                snprintf(a.usb_ip_text, sizeof(a.usb_ip_text), "%s", refreshed_usb_ip);
                 snprintf(a.net_ip_text, sizeof(a.net_ip_text), "%s", refreshed_net_ip);
+                snprintf(a.ethernet_ip_text, sizeof(a.ethernet_ip_text), "%s", refreshed_ethernet_ip);
+                snprintf(a.wifi_ip_text, sizeof(a.wifi_ip_text), "%s", refreshed_wifi_ip);
                 snprintf(a.ip_text, sizeof(a.ip_text), "%s", preferred_ip);
                 build_display_host(a.display_host, sizeof(a.display_host), preferred_ip, have_refreshed_ip);
                 if (refreshed_tb_ip[0] != '\0') {
                     fprintf(stderr, "[main] Thunderbolt Bridge IP = %s\n", refreshed_tb_ip);
                 }
+                if (refreshed_usb_ip[0] != '\0') {
+                    fprintf(stderr, "[main] Direct USB-NCM IP = %s\n", refreshed_usb_ip);
+                }
                 if (refreshed_net_ip[0] != '\0') {
                     fprintf(stderr, "[main] Local network IP = %s\n", refreshed_net_ip);
+                }
+                if (refreshed_ethernet_ip[0] != '\0') {
+                    fprintf(stderr, "[main] Ethernet IP = %s\n", refreshed_ethernet_ip);
+                }
+                if (refreshed_wifi_ip[0] != '\0') {
+                    fprintf(stderr, "[main] Wi-Fi IP = %s\n", refreshed_wifi_ip);
                 }
                 bonjour_update(&a, TB_PORT);
             }

--- a/TargetBridge-Receiver/TBReceiverC/src/net.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/net.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -15,6 +16,11 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+#if defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#include <SystemConfiguration/SystemConfiguration.h>
+#endif
 
 /* ---- Parser ----------------------------------------------------------- */
 
@@ -160,6 +166,76 @@ static int is_rfc1918_ipv4(const char *host) {
     return a == 172 && b >= 16 && b <= 31;
 }
 
+enum tb_lan_interface_kind {
+    TB_LAN_INTERFACE_ETHERNET = 1,
+    TB_LAN_INTERFACE_WIFI = 2
+};
+
+static int interface_matches_kind(const char *name, enum tb_lan_interface_kind kind) {
+    if (!name || !*name) return 0;
+#if defined(__APPLE__)
+    CFArrayRef interfaces = SCNetworkInterfaceCopyAll();
+    if (!interfaces) return 0;
+    int matched = 0;
+    CFIndex count = CFArrayGetCount(interfaces);
+    for (CFIndex index = 0; index < count; index++) {
+        SCNetworkInterfaceRef interface = (SCNetworkInterfaceRef)CFArrayGetValueAtIndex(interfaces, index);
+        CFStringRef bsd_name = SCNetworkInterfaceGetBSDName(interface);
+        CFStringRef interface_type = SCNetworkInterfaceGetInterfaceType(interface);
+        if (!bsd_name || !interface_type) continue;
+
+        char candidate_name[IFNAMSIZ] = {0};
+        if (!CFStringGetCString(bsd_name, candidate_name, sizeof(candidate_name), kCFStringEncodingUTF8)) continue;
+        if (strcmp(candidate_name, name) != 0) continue;
+
+        CFStringRef expected_type = kind == TB_LAN_INTERFACE_WIFI
+            ? kSCNetworkInterfaceTypeIEEE80211
+            : kSCNetworkInterfaceTypeEthernet;
+        matched = CFEqual(interface_type, expected_type);
+        break;
+    }
+    CFRelease(interfaces);
+    return matched;
+#else
+    if (kind == TB_LAN_INTERFACE_WIFI) {
+        return strncmp(name, "wlan", 4) == 0 || strncmp(name, "wifi", 4) == 0;
+    }
+    return strncmp(name, "en", 2) == 0 || strncmp(name, "eth", 3) == 0;
+#endif
+}
+
+static int get_lan_ip_for_kind(char *buf, size_t bufsz, enum tb_lan_interface_kind kind) {
+    struct ifaddrs *ifap = NULL;
+    if (!buf || bufsz == 0) return -1;
+    buf[0] = '\0';
+    if (getifaddrs(&ifap) != 0) return -1;
+
+    int ret = -1;
+    for (struct ifaddrs *p = ifap; p; p = p->ifa_next) {
+        if (!p->ifa_addr) continue;
+        if (p->ifa_addr->sa_family != AF_INET) continue;
+        if (!interface_matches_kind(p->ifa_name, kind)) continue;
+
+        char host[NI_MAXHOST];
+        if (getnameinfo(p->ifa_addr, sizeof(struct sockaddr_in),
+                        host, sizeof(host), NULL, 0, NI_NUMERICHOST) == 0 &&
+            is_rfc1918_ipv4(host)) {
+            snprintf(buf, bufsz, "%s", host);
+            ret = 0;
+            break;
+        }
+    }
+    freeifaddrs(ifap);
+    return ret;
+}
+
+int tb_net_is_link_local_ipv4(const char *host) {
+    unsigned int a = 0, b = 0, c = 0, d = 0;
+    if (!host) return 0;
+    if (sscanf(host, "%u.%u.%u.%u", &a, &b, &c, &d) != 4) return 0;
+    return a == 169 && b == 254 && c <= 255 && d <= 255;
+}
+
 int tb_net_get_tb_ip(char *buf, size_t bufsz) {
     struct ifaddrs *ifap = NULL;
     if (getifaddrs(&ifap) != 0) return -1;
@@ -184,8 +260,10 @@ int tb_net_get_tb_ip(char *buf, size_t bufsz) {
     return ret;
 }
 
-int tb_net_get_lan_ip(char *buf, size_t bufsz) {
+int tb_net_get_link_local_ip(char *buf, size_t bufsz) {
     struct ifaddrs *ifap = NULL;
+    if (!buf || bufsz == 0) return -1;
+    buf[0] = '\0';
     if (getifaddrs(&ifap) != 0) return -1;
 
     int ret = -1;
@@ -196,14 +274,26 @@ int tb_net_get_lan_ip(char *buf, size_t bufsz) {
 
         char host[NI_MAXHOST];
         if (getnameinfo(p->ifa_addr, sizeof(struct sockaddr_in),
-                        host, sizeof(host), NULL, 0, NI_NUMERICHOST) == 0) {
-            if (is_rfc1918_ipv4(host)) {
-                snprintf(buf, bufsz, "%s", host);
-                ret = 0;
-                break;
-            }
+                        host, sizeof(host), NULL, 0, NI_NUMERICHOST) == 0 &&
+            tb_net_is_link_local_ipv4(host)) {
+            snprintf(buf, bufsz, "%s", host);
+            ret = 0;
+            break;
         }
     }
     freeifaddrs(ifap);
     return ret;
+}
+
+int tb_net_get_lan_ip(char *buf, size_t bufsz) {
+    if (tb_net_get_ethernet_ip(buf, bufsz) == 0) return 0;
+    return tb_net_get_wifi_ip(buf, bufsz);
+}
+
+int tb_net_get_ethernet_ip(char *buf, size_t bufsz) {
+    return get_lan_ip_for_kind(buf, bufsz, TB_LAN_INTERFACE_ETHERNET);
+}
+
+int tb_net_get_wifi_ip(char *buf, size_t bufsz) {
+    return get_lan_ip_for_kind(buf, bufsz, TB_LAN_INTERFACE_WIFI);
 }

--- a/TargetBridge-Receiver/TBReceiverC/src/net.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/net.h
@@ -34,8 +34,22 @@ int  tb_net_accept   (int server_fd);
  * buf size must be at least INET_ADDRSTRLEN (16) bytes. Returns 0 on success. */
 int  tb_net_get_tb_ip(char *buf, size_t bufsz);
 
+/* Returns IP address of the first non-Thunderbolt enX/ethX interface using
+ * IPv4 link-local addressing (169.254/16). macOS exposes direct USB-NCM
+ * Mac-to-Mac links this way. Returns 0 on success. */
+int  tb_net_get_link_local_ip(char *buf, size_t bufsz);
+
 /* Returns IP address of a likely local LAN interface (for example en0/eth0, RFC1918 IPv4).
  * buf size must be at least INET_ADDRSTRLEN (16) bytes. Returns 0 on success. */
 int  tb_net_get_lan_ip(char *buf, size_t bufsz);
+
+/* Returns RFC1918 IPv4 addresses for the physical Ethernet and Wi-Fi
+ * interfaces independently. Interface roles are resolved from macOS
+ * SystemConfiguration instead of assuming en0/en1 numbering. */
+int  tb_net_get_ethernet_ip(char *buf, size_t bufsz);
+int  tb_net_get_wifi_ip(char *buf, size_t bufsz);
+
+/* Address classifier exposed for hardware-free unit tests. */
+int  tb_net_is_link_local_ipv4(const char *host);
 
 #endif

--- a/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
+++ b/TargetBridge-Receiver/TBReceiverC/tests/test_net_parser.c
@@ -73,6 +73,16 @@ static size_t build_packet(uint8_t *buf, uint8_t type, const void *payload, size
 
 /* ---- tests ------------------------------------------------------------- */
 
+static void test_link_local_ipv4_classifier(void) {
+    CHECK(tb_net_is_link_local_ipv4("169.254.189.3"), "USB-NCM link-local address");
+    CHECK(tb_net_is_link_local_ipv4("169.254.0.1"), "link-local lower boundary");
+    CHECK(tb_net_is_link_local_ipv4("169.254.255.254"), "link-local upper boundary");
+    CHECK(!tb_net_is_link_local_ipv4("169.255.1.1"), "outside link-local prefix");
+    CHECK(!tb_net_is_link_local_ipv4("10.77.77.2"), "private LAN is not link-local");
+    CHECK(!tb_net_is_link_local_ipv4("not-an-ip"), "invalid address rejected");
+    CHECK(!tb_net_is_link_local_ipv4(NULL), "NULL address rejected");
+}
+
 static void test_single_packet_whole_feed(void) {
     struct tb_parser p;
     tb_parser_init(&p, capture_cb, NULL);
@@ -213,6 +223,7 @@ static void test_large_payload_roundtrip(void) {
 }
 
 int main(void) {
+    test_link_local_ipv4_classifier();
     test_single_packet_whole_feed();
     test_byte_by_byte_feed();
     test_two_contiguous_packets();

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
@@ -83,16 +83,52 @@ enum TBSenderAutomation {
             session.transportKind = parseTransport(transport)
         }
 
+        let rawPath = params["path"] ?? params["connection-path"] ?? params["connection"]
+        let pathPreference: TBConnectionPathPreference?
+        if let rawPath {
+            guard let parsed = TBConnectionPathPreference.parse(rawPath) else {
+                NSLog("[automation] unknown connection path '\(rawPath)'; aborting connect")
+                return
+            }
+            pathPreference = parsed
+        } else {
+            pathPreference = nil
+        }
+
         let receiver = params["receiver"].flatMap { $0.isEmpty ? nil : $0 } ?? "auto"
         if receiver.lowercased() == "auto" {
             guard let discovered = await waitForReceiver(service) else {
                 NSLog("[automation] no receivers discovered; aborting connect")
                 return
             }
-            service.applyDiscoveredReceiver(discovered, to: session)
+            if let pathPreference {
+                guard let selected = await selectConnectionPath(
+                    receiver: discovered,
+                    preference: pathPreference,
+                    requestedLocalIP: params["localip"] ?? params["local-ip"]
+                ) else {
+                    NSLog("[automation] no working \(pathPreference.rawValue) path; aborting connect")
+                    return
+                }
+                apply(selected, receiver: discovered, to: session)
+            } else {
+                service.applyDiscoveredReceiver(discovered, to: session)
+            }
             session.selectedReceiverID = discovered.id
         } else if let discovered = service.discoveredReceivers.first(where: { matches(receiver, $0) }) {
-            service.applyDiscoveredReceiver(discovered, to: session)
+            if let pathPreference {
+                guard let selected = await selectConnectionPath(
+                    receiver: discovered,
+                    preference: pathPreference,
+                    requestedLocalIP: params["localip"] ?? params["local-ip"]
+                ) else {
+                    NSLog("[automation] no working \(pathPreference.rawValue) path to \(receiver); aborting connect")
+                    return
+                }
+                apply(selected, receiver: discovered, to: session)
+            } else {
+                service.applyDiscoveredReceiver(discovered, to: session)
+            }
             session.selectedReceiverID = discovered.id
         } else {
             // Treat as a raw IP / hostname (bypasses Bonjour).
@@ -100,7 +136,9 @@ enum TBSenderAutomation {
             session.selectedReceiverID = ""
         }
 
-        if let localIP = (params["localip"] ?? params["local-ip"]), !localIP.isEmpty {
+        if pathPreference == nil,
+           let localIP = (params["localip"] ?? params["local-ip"]),
+           !localIP.isEmpty {
             session.localInterfaceIP = localIP
         }
         if session.localInterfaceIP.isEmpty {
@@ -124,7 +162,7 @@ enum TBSenderAutomation {
             NSLog("[automation] no local interface for transport \(session.transportKind.rawValue); aborting connect")
             return
         }
-        NSLog("[automation] connecting to \(session.receiverIP) via \(session.transportKind.rawValue) — \(session.captureSource.rawValue)/\(session.capturePreset.rawValue)")
+        NSLog("[automation] connecting to \(session.receiverIP) from \(session.localInterfaceIP) via \(session.transportKind.rawValue) — \(session.captureSource.rawValue)/\(session.capturePreset.rawValue)")
         session.connect()
     }
 
@@ -202,6 +240,70 @@ enum TBSenderAutomation {
         return service.discoveredReceivers.first
     }
 
+    private static func selectConnectionPath(
+        receiver: TBDiscoveredReceiver,
+        preference: TBConnectionPathPreference,
+        requestedLocalIP: String?
+    ) async -> TBConnectionMeasurement? {
+        let allInterfaces = TBConnectionDiagnostics.currentIPv4Interfaces()
+        let eligibleInterfaces: [TBConnectionDiagnostics.LocalInterface]
+        if let requestedLocalIP, !requestedLocalIP.isEmpty {
+            eligibleInterfaces = allInterfaces.filter { $0.ip == requestedLocalIP }
+        } else {
+            eligibleInterfaces = allInterfaces
+        }
+
+        let allCandidates = TBConnectionDiagnostics.connectionCandidates(
+            receiver: receiver,
+            interfaces: eligibleInterfaces,
+            hardwareKinds: TBConnectionDiagnostics.hardwarePathKinds()
+        )
+        let candidates = allCandidates.filter { preference.allows($0.kind) }
+        guard !candidates.isEmpty else {
+            NSLog("[automation] no candidate interfaces/endpoints for path \(preference.rawValue)")
+            return nil
+        }
+
+        let measurements = await Task.detached(priority: .userInitiated) {
+            var values: [TBConnectionMeasurement] = []
+            for candidate in candidates {
+                guard !Task.isCancelled else { break }
+                NSLog("[automation] probing \(candidate.kind.rawValue): \(candidate.localIP) (\(candidate.localInterfaceName)) -> \(candidate.receiverIP)")
+                do {
+                    let measurement = try TBConnectionDiagnostics.probe(candidate)
+                    NSLog(
+                        "[automation] path \(candidate.kind.rawValue) measured \(String(format: "%.3f", measurement.throughputGbps)) Gbit/s, \(String(format: "%.2f", measurement.connectLatencyMilliseconds)) ms"
+                    )
+                    values.append(measurement)
+                } catch {
+                    NSLog("[automation] path \(candidate.kind.rawValue) unavailable: \(error.localizedDescription)")
+                }
+                usleep(100_000)
+            }
+            return values
+        }.value
+
+        guard let selected = TBConnectionDiagnostics.selectBestMeasurement(
+            measurements,
+            preference: preference
+        ) else { return nil }
+        NSLog(
+            "[automation] selected \(selected.candidate.kind.rawValue) on \(selected.candidate.localInterfaceName) at \(String(format: "%.3f", selected.throughputGbps)) Gbit/s"
+        )
+        return selected
+    }
+
+    private static func apply(
+        _ measurement: TBConnectionMeasurement,
+        receiver: TBDiscoveredReceiver,
+        to session: TBDisplaySenderSession
+    ) {
+        session.transportKind = measurement.candidate.transportKind
+        session.localInterfaceIP = measurement.candidate.localIP
+        session.receiverIP = measurement.candidate.receiverIP
+        session.receiverSupportsHEVCDecodeHint = receiver.supportsHEVCDecode
+    }
+
     // The pure parsing helpers below are `internal` (not `private`) so the
     // unit-test bundle can exercise them directly.
     static func matches(_ value: String, _ receiver: TBDiscoveredReceiver) -> Bool {
@@ -211,7 +313,11 @@ enum TBSenderAutomation {
         if let host = receiver.shortHostName?.lowercased(), host == needle { return true }
         return receiver.preferredIP.lowercased() == needle
             || receiver.thunderboltIP.lowercased() == needle
+            || receiver.usbIP.lowercased() == needle
+            || receiver.ethernetIP.lowercased() == needle
+            || receiver.wifiIP.lowercased() == needle
             || receiver.networkIP.lowercased() == needle
+            || receiver.resolvedIPv4Addresses.contains(where: { $0.lowercased() == needle })
     }
 
     static func parseTransport(_ value: String) -> TBTransportKind {

--- a/TargetBridge-Sender/TBDisplaySender/TBReceiverDiscovery.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBReceiverDiscovery.swift
@@ -5,11 +5,45 @@ struct TBDiscoveredReceiver: Identifiable, Equatable {
     let receiverName: String
     let preferredIP: String
     let thunderboltIP: String
+    let usbIP: String
     let networkIP: String
+    let ethernetIP: String
+    let wifiIP: String
+    let resolvedIPv4Addresses: [String]
     let panelSummary: String
     let version: String
     let supportsHEVCDecode: Bool
     let hostName: String?
+
+    init(
+        serviceName: String,
+        receiverName: String,
+        preferredIP: String,
+        thunderboltIP: String,
+        usbIP: String = "",
+        networkIP: String,
+        ethernetIP: String = "",
+        wifiIP: String = "",
+        resolvedIPv4Addresses: [String] = [],
+        panelSummary: String,
+        version: String,
+        supportsHEVCDecode: Bool,
+        hostName: String?
+    ) {
+        self.serviceName = serviceName
+        self.receiverName = receiverName
+        self.preferredIP = preferredIP
+        self.thunderboltIP = thunderboltIP
+        self.usbIP = usbIP
+        self.networkIP = networkIP
+        self.ethernetIP = ethernetIP
+        self.wifiIP = wifiIP
+        self.resolvedIPv4Addresses = resolvedIPv4Addresses
+        self.panelSummary = panelSummary
+        self.version = version
+        self.supportsHEVCDecode = supportsHEVCDecode
+        self.hostName = hostName
+    }
 
     var id: String { "\(serviceName)|\(preferredIP)" }
 
@@ -25,26 +59,40 @@ struct TBDiscoveredReceiver: Identifiable, Equatable {
         return String(first)
     }
 
-    func ip(for transportKind: TBTransportKind) -> String {
+    func ip(for transportKind: TBTransportKind, localInterfaceIP: String = "") -> String {
         switch transportKind {
         case .thunderboltBridge:
             return !thunderboltIP.isEmpty ? thunderboltIP : preferredIP
         case .networkLink:
+            if localInterfaceIP.hasPrefix("169.254."), !usbIP.isEmpty {
+                return usbIP
+            }
             return !networkIP.isEmpty ? networkIP : preferredIP
         }
     }
 
     var displayText: String {
+        var addresses: [(label: String, ip: String)] = []
+        var seenIPs = Set<String>()
+        func appendAddress(_ label: String, _ ip: String) {
+            guard !ip.isEmpty, seenIPs.insert(ip).inserted else { return }
+            addresses.append((label, ip))
+        }
+        appendAddress("TB", thunderboltIP)
+        appendAddress("USB", usbIP)
+        appendAddress("ETH", ethernetIP)
+        appendAddress("Wi-Fi", wifiIP)
+        appendAddress("NET", networkIP)
+
         let addressSummary: String
-        switch (thunderboltIP.isEmpty, networkIP.isEmpty) {
-        case (false, false):
-            addressSummary = "TB \(thunderboltIP) · NET \(networkIP)"
-        case (false, true):
-            addressSummary = thunderboltIP
-        case (true, false):
-            addressSummary = networkIP
-        case (true, true):
+        if addresses.isEmpty {
             addressSummary = preferredIP
+        } else if addresses.count == 1 {
+            addressSummary = addresses[0].ip
+        } else {
+            addressSummary = addresses
+                .map { "\($0.label) \($0.ip)" }
+                .joined(separator: " · ")
         }
 
         let name: String
@@ -112,8 +160,18 @@ final class TBReceiverDiscovery: NSObject, ObservableObject {
         let receiverName = stringValue("name").isEmpty ? service.name : stringValue("name")
         let receiverIP = stringValue("ip")
         let thunderboltIP = stringValue("tbIP")
+        let usbIP = stringValue("usbIP")
         let networkIP = stringValue("netIP")
-        let preferredIP = !receiverIP.isEmpty ? receiverIP : (!thunderboltIP.isEmpty ? thunderboltIP : networkIP)
+        let ethernetIP = stringValue("ethernetIP")
+        let wifiIP = stringValue("wifiIP")
+        let resolvedIPv4Addresses = resolvedIPv4Addresses(from: service)
+        let preferredIP = !receiverIP.isEmpty
+            ? receiverIP
+            : (!thunderboltIP.isEmpty
+                ? thunderboltIP
+                : (!usbIP.isEmpty
+                    ? usbIP
+                    : (!networkIP.isEmpty ? networkIP : (resolvedIPv4Addresses.first ?? ""))))
         guard !preferredIP.isEmpty else { return }
 
         let panelName = stringValue("panel")
@@ -138,14 +196,18 @@ final class TBReceiverDiscovery: NSObject, ObservableObject {
             receiverName: receiverName,
             preferredIP: preferredIP,
             thunderboltIP: thunderboltIP,
+            usbIP: usbIP,
             networkIP: networkIP,
+            ethernetIP: ethernetIP,
+            wifiIP: wifiIP,
+            resolvedIPv4Addresses: resolvedIPv4Addresses,
             panelSummary: panelSummary,
             version: version,
             supportsHEVCDecode: supportsHEVCDecode,
             hostName: service.hostName
         )
 
-        if let index = receivers.firstIndex(where: { $0.id == receiver.id }) {
+        if let index = receivers.firstIndex(where: { $0.serviceName == receiver.serviceName }) {
             receivers[index] = receiver
         } else {
             receivers.append(receiver)
@@ -156,6 +218,39 @@ final class TBReceiverDiscovery: NSObject, ObservableObject {
             }
             return lhs.receiverName.localizedCaseInsensitiveCompare(rhs.receiverName) == .orderedAscending
         }
+    }
+
+    private func resolvedIPv4Addresses(from service: NetService) -> [String] {
+        guard let addresses = service.addresses else { return [] }
+        var result: [String] = []
+        var seen = Set<String>()
+
+        for addressData in addresses {
+            let address: String? = addressData.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress,
+                      rawBuffer.count >= MemoryLayout<sockaddr>.size
+                else { return nil }
+                let socketAddress = baseAddress.assumingMemoryBound(to: sockaddr.self)
+                guard socketAddress.pointee.sa_family == UInt8(AF_INET) else { return nil }
+                var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                let length = socklen_t(min(rawBuffer.count, Int(socketAddress.pointee.sa_len)))
+                guard getnameinfo(
+                    socketAddress,
+                    length,
+                    &host,
+                    socklen_t(host.count),
+                    nil,
+                    0,
+                    NI_NUMERICHOST
+                ) == 0 else { return nil }
+                return String(cString: host)
+            }
+            if let address, seen.insert(address).inserted {
+                result.append(address)
+            }
+        }
+
+        return result.sorted()
     }
 
     private func removeService(_ service: NetService) {

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBConnectionDiagnosticsTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBConnectionDiagnosticsTests.swift
@@ -11,6 +11,7 @@ final class TBConnectionDiagnosticsTests: XCTestCase {
     private let interfaces: [Interface] = [
         Interface(name: "en0", ip: "192.168.1.225"),
         Interface(name: "bridge0", ip: "169.254.109.86"),
+        Interface(name: "en8", ip: "169.254.190.84"),
     ]
 
     // MARK: - interfaceName(forLocalIP:)
@@ -30,6 +31,20 @@ final class TBConnectionDiagnosticsTests: XCTestCase {
         XCTAssertNil(TBConnectionDiagnostics.interfaceName(forLocalIP: "10.0.0.1", in: interfaces))
         XCTAssertNil(TBConnectionDiagnostics.interfaceName(forLocalIP: "", in: interfaces))
         XCTAssertNil(TBConnectionDiagnostics.interfaceName(forLocalIP: "169.254.109.86", in: []))
+    }
+
+    // MARK: - Direct USB-NCM interface classification
+
+    func testDirectLinkInterfaceAcceptsUSBNCMLinkLocalAddress() {
+        XCTAssertTrue(TBConnectionDiagnostics.isDirectLinkInterface(name: "en8", ip: "169.254.190.84"))
+        XCTAssertTrue(TBConnectionDiagnostics.isDirectLinkInterface(name: "eth2", ip: "169.254.1.2"))
+    }
+
+    func testDirectLinkInterfaceRejectsThunderboltLANAndMalformedAddresses() {
+        XCTAssertFalse(TBConnectionDiagnostics.isDirectLinkInterface(name: "bridge0", ip: "169.254.109.86"))
+        XCTAssertFalse(TBConnectionDiagnostics.isDirectLinkInterface(name: "en8", ip: "192.168.178.93"))
+        XCTAssertFalse(TBConnectionDiagnostics.isDirectLinkInterface(name: "en8", ip: "169.254.300.1"))
+        XCTAssertFalse(TBConnectionDiagnostics.isDirectLinkInterface(name: "en8", ip: "169.254.1"))
     }
 
     // MARK: - scopedReceiverHost
@@ -67,6 +82,17 @@ final class TBConnectionDiagnosticsTests: XCTestCase {
                 interfaces: interfaces
             ),
             "169.254.89.80"
+        )
+    }
+
+    func testUSBNCMLinkLocalReceiverIsNotGivenAnIPv4ZoneSuffix() {
+        XCTAssertEqual(
+            TBConnectionDiagnostics.scopedReceiverHost(
+                receiverIP: "169.254.189.3",
+                localIP: "169.254.190.84",
+                interfaces: interfaces
+            ),
+            "169.254.189.3"
         )
     }
 
@@ -118,5 +144,139 @@ final class TBConnectionDiagnosticsTests: XCTestCase {
             XCTAssertFalse(iface.name.isEmpty)
             XCTAssertFalse(iface.ip.hasPrefix("127."), "loopback must be excluded, found \(iface.ip) on \(iface.name)")
         }
+    }
+
+    // MARK: - Automatic path candidates and ranking
+
+    func testPathPreferenceAcceptsUSB4AndUserFacingAliases() {
+        XCTAssertEqual(TBConnectionPathPreference.parse("auto"), .automatic)
+        XCTAssertEqual(TBConnectionPathPreference.parse("wired"), .wired)
+        XCTAssertEqual(TBConnectionPathPreference.parse("Thunderbolt Bridge"), .thunderbolt)
+        XCTAssertEqual(TBConnectionPathPreference.parse("USB4"), .usb)
+        XCTAssertEqual(TBConnectionPathPreference.parse("USB-C"), .usb)
+        XCTAssertEqual(TBConnectionPathPreference.parse("LAN"), .ethernet)
+        XCTAssertEqual(TBConnectionPathPreference.parse("wireless"), .wifi)
+        XCTAssertNil(TBConnectionPathPreference.parse("fibre-channel"))
+    }
+
+    private func candidate(
+        _ kind: TBConnectionPathKind,
+        localIP: String,
+        receiverIP: String
+    ) -> TBConnectionCandidate {
+        TBConnectionCandidate(
+            kind: kind,
+            localInterfaceName: kind == .thunderbolt ? "bridge0" : "en8",
+            localIP: localIP,
+            receiverIP: receiverIP
+        )
+    }
+
+    func testCandidateDiscoverySeparatesThunderboltUSBEthernetAndWiFi() {
+        let receiver = TBDiscoveredReceiver(
+            serviceName: "TargetBridge iMac",
+            receiverName: "iMac",
+            preferredIP: "192.168.178.101",
+            thunderboltIP: "169.254.50.32",
+            usbIP: "169.254.190.85",
+            networkIP: "192.168.178.101",
+            ethernetIP: "10.77.77.2",
+            wifiIP: "192.168.178.101",
+            resolvedIPv4Addresses: ["169.254.50.32", "169.254.190.85", "10.77.77.2", "192.168.178.101"],
+            panelSummary: "iMac 4K",
+            version: "3.2.1",
+            supportsHEVCDecode: true,
+            hostName: "iMac.local."
+        )
+        let local = [
+            Interface(name: "bridge0", ip: "169.254.50.31"),
+            Interface(name: "en8", ip: "169.254.190.84"),
+            Interface(name: "en0", ip: "10.77.77.1"),
+            Interface(name: "en1", ip: "192.168.178.93"),
+        ]
+        let candidates = TBConnectionDiagnostics.connectionCandidates(
+            receiver: receiver,
+            interfaces: local,
+            hardwareKinds: ["en0": .ethernet, "en1": .wifi]
+        )
+
+        XCTAssertTrue(candidates.contains(candidate(.thunderbolt, localIP: "169.254.50.31", receiverIP: "169.254.50.32")))
+        XCTAssertTrue(candidates.contains(candidate(.usb, localIP: "169.254.190.84", receiverIP: "169.254.190.85")))
+        XCTAssertTrue(candidates.contains {
+            $0.kind == .ethernet && $0.localIP == "10.77.77.1" && $0.receiverIP == "10.77.77.2"
+        })
+        XCTAssertTrue(candidates.contains {
+            $0.kind == .wifi && $0.localIP == "192.168.178.93" && $0.receiverIP == "192.168.178.101"
+        })
+    }
+
+    func testAutoSelectionLetsGigabitEthernetBeatSlowerUSB() {
+        let usb = TBConnectionMeasurement(
+            candidate: candidate(.usb, localIP: "169.254.1.1", receiverIP: "169.254.1.2"),
+            throughputGbps: 0.48,
+            connectLatencyMilliseconds: 0.20
+        )
+        let ethernet = TBConnectionMeasurement(
+            candidate: candidate(.ethernet, localIP: "10.77.77.1", receiverIP: "10.77.77.2"),
+            throughputGbps: 0.94,
+            connectLatencyMilliseconds: 0.35
+        )
+        XCTAssertEqual(
+            TBConnectionDiagnostics.selectBestMeasurement([usb, ethernet], preference: .automatic),
+            ethernet
+        )
+    }
+
+    func testAutoSelectionChoosesMeasuredFastestPhysicalPath() {
+        let thunderbolt = TBConnectionMeasurement(
+            candidate: candidate(.thunderbolt, localIP: "169.254.50.31", receiverIP: "169.254.50.32"),
+            throughputGbps: 4.2,
+            connectLatencyMilliseconds: 0.16
+        )
+        let ethernet = TBConnectionMeasurement(
+            candidate: candidate(.ethernet, localIP: "10.77.77.1", receiverIP: "10.77.77.2"),
+            throughputGbps: 0.94,
+            connectLatencyMilliseconds: 0.22
+        )
+        XCTAssertEqual(
+            TBConnectionDiagnostics.selectBestMeasurement([ethernet, thunderbolt], preference: .automatic),
+            thunderbolt
+        )
+    }
+
+    func testManualSelectionFiltersOutFasterOtherPaths() {
+        let usb = TBConnectionMeasurement(
+            candidate: candidate(.usb, localIP: "169.254.1.1", receiverIP: "169.254.1.2"),
+            throughputGbps: 0.42,
+            connectLatencyMilliseconds: 0.20
+        )
+        let thunderbolt = TBConnectionMeasurement(
+            candidate: candidate(.thunderbolt, localIP: "169.254.2.1", receiverIP: "169.254.2.2"),
+            throughputGbps: 7.0,
+            connectLatencyMilliseconds: 0.10
+        )
+        XCTAssertEqual(
+            TBConnectionDiagnostics.selectBestMeasurement([thunderbolt, usb], preference: .usb),
+            usb
+        )
+        XCTAssertNil(TBConnectionDiagnostics.selectBestMeasurement([thunderbolt], preference: .wifi))
+    }
+
+    func testWiredModeNeverFallsBackToFasterWiFi() {
+        let ethernet = TBConnectionMeasurement(
+            candidate: candidate(.ethernet, localIP: "10.77.77.1", receiverIP: "10.77.77.2"),
+            throughputGbps: 0.94,
+            connectLatencyMilliseconds: 0.22
+        )
+        let wifi = TBConnectionMeasurement(
+            candidate: candidate(.wifi, localIP: "192.168.178.93", receiverIP: "192.168.178.101"),
+            throughputGbps: 1.20,
+            connectLatencyMilliseconds: 0.15
+        )
+        XCTAssertEqual(
+            TBConnectionDiagnostics.selectBestMeasurement([wifi, ethernet], preference: .wired),
+            ethernet
+        )
+        XCTAssertNil(TBConnectionDiagnostics.selectBestMeasurement([wifi], preference: .wired))
     }
 }

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBReceiverDiscoveryModelTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBReceiverDiscoveryModelTests.swift
@@ -12,6 +12,7 @@ final class TBReceiverDiscoveryModelTests: XCTestCase {
         receiverName: String = "Test-iMac",
         preferredIP: String = "192.168.1.64",
         thunderboltIP: String = "",
+        usbIP: String = "",
         networkIP: String = "",
         panelSummary: String = "",
         version: String = "3.1.0",
@@ -23,6 +24,7 @@ final class TBReceiverDiscoveryModelTests: XCTestCase {
             receiverName: receiverName,
             preferredIP: preferredIP,
             thunderboltIP: thunderboltIP,
+            usbIP: usbIP,
             networkIP: networkIP,
             panelSummary: panelSummary,
             version: version,
@@ -51,6 +53,30 @@ final class TBReceiverDiscoveryModelTests: XCTestCase {
     func testNetworkTransportFallsBackToPreferredIP() {
         let receiver = makeReceiver(preferredIP: "169.254.89.80", thunderboltIP: "169.254.89.80", networkIP: "")
         XCTAssertEqual(receiver.ip(for: .networkLink), "169.254.89.80")
+    }
+
+    func testNetworkTransportUsesUSBIPForLinkLocalLocalInterface() {
+        let receiver = makeReceiver(
+            preferredIP: "169.254.189.3",
+            usbIP: "169.254.189.3",
+            networkIP: "192.168.178.101"
+        )
+        XCTAssertEqual(
+            receiver.ip(for: .networkLink, localInterfaceIP: "169.254.190.84"),
+            "169.254.189.3"
+        )
+    }
+
+    func testNetworkTransportKeepsLANIPForLANLocalInterface() {
+        let receiver = makeReceiver(
+            preferredIP: "169.254.189.3",
+            usbIP: "169.254.189.3",
+            networkIP: "192.168.178.101"
+        )
+        XCTAssertEqual(
+            receiver.ip(for: .networkLink, localInterfaceIP: "192.168.178.93"),
+            "192.168.178.101"
+        )
     }
 
     // MARK: - Identity
@@ -85,10 +111,11 @@ final class TBReceiverDiscoveryModelTests: XCTestCase {
     func testDisplayTextShowsBothTransportsWhenAvailable() {
         let receiver = makeReceiver(
             thunderboltIP: "169.254.89.80",
+            usbIP: "169.254.189.3",
             networkIP: "192.168.1.64",
             hostName: "Jonathans-iMac.local."
         )
-        XCTAssertEqual(receiver.displayText, "Jonathans-iMac (TB 169.254.89.80 · NET 192.168.1.64)")
+        XCTAssertEqual(receiver.displayText, "Jonathans-iMac (TB 169.254.89.80 · USB 169.254.189.3 · NET 192.168.1.64)")
     }
 
     func testDisplayTextSingleTransportOnly() {
@@ -104,5 +131,24 @@ final class TBReceiverDiscoveryModelTests: XCTestCase {
     func testDisplayTextAppendsPanelSummary() {
         let receiver = makeReceiver(networkIP: "192.168.1.64", panelSummary: "iMac 5K (5120x2880)")
         XCTAssertEqual(receiver.displayText, "192.168.1.64 · iMac 5K (5120x2880)")
+    }
+
+    func testDisplayTextDistinguishesEthernetAndWiFiWhenAdvertised() {
+        let receiver = TBDiscoveredReceiver(
+            serviceName: "TargetBridge iMac",
+            receiverName: "iMac",
+            preferredIP: "192.168.178.101",
+            thunderboltIP: "",
+            usbIP: "",
+            networkIP: "192.168.178.101",
+            ethernetIP: "10.77.77.2",
+            wifiIP: "192.168.178.101",
+            resolvedIPv4Addresses: ["10.77.77.2", "192.168.178.101"],
+            panelSummary: "",
+            version: "3.2.1",
+            supportsHEVCDecode: true,
+            hostName: "iMac.local."
+        )
+        XCTAssertEqual(receiver.displayText, "iMac (ETH 10.77.77.2 · Wi-Fi 192.168.178.101)")
     }
 }

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
@@ -101,7 +101,11 @@ final class TBSenderAutomationParsingTests: XCTestCase {
             receiverName: "Jonathans-iMac",
             preferredIP: "192.168.1.64",
             thunderboltIP: "169.254.89.80",
+            usbIP: "169.254.189.3",
             networkIP: "192.168.1.64",
+            ethernetIP: "10.77.77.2",
+            wifiIP: "192.168.1.64",
+            resolvedIPv4Addresses: ["172.20.10.2"],
             panelSummary: "iMac 5K",
             version: "3.1.0",
             supportsHEVCDecode: true,
@@ -121,6 +125,9 @@ final class TBSenderAutomationParsingTests: XCTestCase {
     func testMatchesByAnyAdvertisedIP() {
         XCTAssertTrue(TBSenderAutomation.matches("192.168.1.64", makeReceiver()), "preferred/network IP")
         XCTAssertTrue(TBSenderAutomation.matches("169.254.89.80", makeReceiver()), "thunderbolt IP")
+        XCTAssertTrue(TBSenderAutomation.matches("169.254.189.3", makeReceiver()), "direct USB IP")
+        XCTAssertTrue(TBSenderAutomation.matches("10.77.77.2", makeReceiver()), "Ethernet IP")
+        XCTAssertTrue(TBSenderAutomation.matches("172.20.10.2", makeReceiver()), "resolved Bonjour IP")
     }
 
     func testMatchesByID() {

--- a/TargetBridge-Sender/TBDisplayShared/TBConnectionDiagnostics.swift
+++ b/TargetBridge-Sender/TBDisplayShared/TBConnectionDiagnostics.swift
@@ -1,6 +1,98 @@
 import Foundation
+import Darwin
 import Network
 import os
+import SystemConfiguration
+
+enum TBConnectionPathPreference: String, CaseIterable {
+    case automatic
+    case wired
+    case thunderbolt
+    case usb
+    case ethernet
+    case wifi
+
+    static func parse(_ value: String?) -> TBConnectionPathPreference? {
+        guard let value else { return nil }
+        switch value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "") {
+        case "auto", "automatic", "automatico", "best", "alwaysavailable", "sempredisponibile": return .automatic
+        case "wired", "cable", "cabled", "cableonly", "solocavo", "onlycable": return .wired
+        case "tb", "thunderbolt", "thunderboltbridge", "bridge": return .thunderbolt
+        case "usb", "usb4", "usbc", "directusb": return .usb
+        case "ethernet", "eth", "lan": return .ethernet
+        case "wifi", "wireless", "wlan": return .wifi
+        default: return nil
+        }
+    }
+
+    func allows(_ kind: TBConnectionPathKind) -> Bool {
+        switch self {
+        case .automatic:
+            return true
+        case .wired:
+            return kind != .wifi
+        case .thunderbolt, .usb, .ethernet, .wifi:
+            return kind.rawValue == rawValue
+        }
+    }
+}
+
+enum TBConnectionPathKind: String, CaseIterable {
+    case thunderbolt
+    case usb
+    case ethernet
+    case wifi
+
+    var transportKind: TBTransportKind {
+        self == .thunderbolt ? .thunderboltBridge : .networkLink
+    }
+
+    fileprivate var tieBreakPriority: Int {
+        switch self {
+        case .thunderbolt: return 4
+        case .usb: return 3
+        case .ethernet: return 2
+        case .wifi: return 1
+        }
+    }
+}
+
+struct TBConnectionCandidate: Hashable {
+    let kind: TBConnectionPathKind
+    let localInterfaceName: String
+    let localIP: String
+    let receiverIP: String
+
+    var transportKind: TBTransportKind { kind.transportKind }
+    var id: String { "\(kind.rawValue)|\(localInterfaceName)|\(localIP)|\(receiverIP)" }
+}
+
+struct TBConnectionMeasurement: Equatable {
+    let candidate: TBConnectionCandidate
+    let throughputGbps: Double
+    let connectLatencyMilliseconds: Double
+}
+
+enum TBConnectionProbeError: LocalizedError {
+    case invalidAddress(String)
+    case interfaceUnavailable(String)
+    case socketFailure(String)
+    case timeout
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAddress(let value): return "Invalid IPv4 address: \(value)"
+        case .interfaceUnavailable(let value): return "Interface unavailable: \(value)"
+        case .socketFailure(let value): return value
+        case .timeout: return "Connection-path probe timed out"
+        }
+    }
+}
 
 /// Unified-logging entry points for the sender. `log stream --predicate
 /// 'subsystem == "com.targetbridge.sender"'` (or Console.app) shows the
@@ -32,9 +124,338 @@ enum TBConnectionDiagnostics {
         return interfaces.first(where: { $0.ip == localIP })?.name
     }
 
-    /// For a link-local (`169.254.x`) receiver address, returns
-    /// `"<ip>%<interface>"` so the dial is scoped to the interface that owns
-    /// `localIP`. Everything else is returned unchanged.
+    /// Direct Mac-to-Mac USB connections are exposed by macOS as USB-NCM
+    /// Ethernet interfaces (normally enX) with an IPv4 link-local address.
+    /// Keep bridgeX reserved for the Thunderbolt Bridge transport.
+    static func isDirectLinkInterface(name: String, ip: String) -> Bool {
+        guard name.hasPrefix("en") || name.hasPrefix("eth") else { return false }
+        let octets = ip.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4,
+              let first = Int(octets[0]),
+              let second = Int(octets[1]),
+              octets.dropFirst(2).allSatisfy({ component in
+                  guard let value = Int(component) else { return false }
+                  return (0...255).contains(value)
+              })
+        else {
+            return false
+        }
+        return first == 169 && second == 254
+    }
+
+    static func isIPv4LinkLocal(_ ip: String) -> Bool {
+        let octets = ipv4Octets(ip)
+        return octets?.count == 4 && octets?[0] == 169 && octets?[1] == 254
+    }
+
+    static func isPrivateIPv4(_ ip: String) -> Bool {
+        guard let octets = ipv4Octets(ip) else { return false }
+        return octets[0] == 10
+            || (octets[0] == 172 && (16...31).contains(octets[1]))
+            || (octets[0] == 192 && octets[1] == 168)
+    }
+
+    private static func ipv4Octets(_ ip: String) -> [Int]? {
+        let components = ip.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 4 else { return nil }
+        let octets = components.compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ (0...255).contains($0) }) else { return nil }
+        return octets
+    }
+
+    /// Maps BSD interface names to their physical role using SystemConfiguration.
+    /// This avoids assuming that Wi-Fi is always en0/en1, which changes between Macs.
+    static func hardwarePathKinds() -> [String: TBConnectionPathKind] {
+        guard let all = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] else { return [:] }
+        var result: [String: TBConnectionPathKind] = [:]
+        for interface in all {
+            guard let bsdNameValue = SCNetworkInterfaceGetBSDName(interface),
+                  let type = SCNetworkInterfaceGetInterfaceType(interface)
+            else { continue }
+            let bsdName = bsdNameValue as String
+            if CFEqual(type, kSCNetworkInterfaceTypeIEEE80211) {
+                result[bsdName] = .wifi
+            } else if CFEqual(type, kSCNetworkInterfaceTypeEthernet) {
+                result[bsdName] = .ethernet
+            }
+        }
+        return result
+    }
+
+    static func pathKind(
+        for interface: LocalInterface,
+        hardwareKinds: [String: TBConnectionPathKind]
+    ) -> TBConnectionPathKind? {
+        if interface.name.hasPrefix("bridge"), isIPv4LinkLocal(interface.ip) {
+            return .thunderbolt
+        }
+        if isDirectLinkInterface(name: interface.name, ip: interface.ip) {
+            return .usb
+        }
+        if hardwareKinds[interface.name] == .wifi, isPrivateIPv4(interface.ip) {
+            return .wifi
+        }
+        if hardwareKinds[interface.name] == .ethernet, isPrivateIPv4(interface.ip) {
+            return .ethernet
+        }
+        // Some third-party USB Ethernet adapters are absent from the SC inventory.
+        if (interface.name.hasPrefix("en") || interface.name.hasPrefix("eth")), isPrivateIPv4(interface.ip) {
+            return .ethernet
+        }
+        return nil
+    }
+
+    /// Builds every plausible local/remote pair. Real probing decides which pair
+    /// is alive; a cable type is never presumed to be faster merely from its name.
+    static func connectionCandidates(
+        receiver: TBDiscoveredReceiver,
+        interfaces: [LocalInterface],
+        hardwareKinds: [String: TBConnectionPathKind]
+    ) -> [TBConnectionCandidate] {
+        let allReceiverIPs = uniqueIPv4Addresses([
+            receiver.thunderboltIP,
+            receiver.usbIP,
+            receiver.ethernetIP,
+            receiver.wifiIP,
+            receiver.networkIP,
+            receiver.preferredIP,
+        ] + receiver.resolvedIPv4Addresses)
+
+        var candidates: [TBConnectionCandidate] = []
+        var seen = Set<String>()
+        for interface in interfaces {
+            guard let kind = pathKind(for: interface, hardwareKinds: hardwareKinds) else { continue }
+            let explicitIP: String
+            switch kind {
+            case .thunderbolt: explicitIP = receiver.thunderboltIP
+            case .usb: explicitIP = receiver.usbIP
+            case .ethernet: explicitIP = receiver.ethernetIP
+            case .wifi: explicitIP = receiver.wifiIP
+            }
+
+            let addressPool: [String]
+            if kind == .thunderbolt || kind == .usb {
+                addressPool = uniqueIPv4Addresses([explicitIP] + allReceiverIPs.filter(isIPv4LinkLocal))
+            } else {
+                let privateAddresses = allReceiverIPs.filter(isPrivateIPv4)
+                let sameSubnet = privateAddresses.filter { likelySameIPv4Subnet(interface.ip, $0) }
+                // Prefer a same-/24 endpoint. If Bonjour only exposes a different
+                // subnet, retain it as a probe candidate so routed LANs still work.
+                addressPool = uniqueIPv4Addresses(
+                    [explicitIP] + (sameSubnet.isEmpty ? privateAddresses : sameSubnet)
+                )
+            }
+
+            for receiverIP in addressPool where receiverIP != interface.ip {
+                let candidate = TBConnectionCandidate(
+                    kind: kind,
+                    localInterfaceName: interface.name,
+                    localIP: interface.ip,
+                    receiverIP: receiverIP
+                )
+                if seen.insert(candidate.id).inserted {
+                    candidates.append(candidate)
+                }
+            }
+        }
+
+        return candidates.sorted {
+            if $0.kind.tieBreakPriority != $1.kind.tieBreakPriority {
+                return $0.kind.tieBreakPriority > $1.kind.tieBreakPriority
+            }
+            if $0.localInterfaceName != $1.localInterfaceName {
+                return $0.localInterfaceName < $1.localInterfaceName
+            }
+            return $0.receiverIP < $1.receiverIP
+        }
+    }
+
+    static func selectBestMeasurement(
+        _ measurements: [TBConnectionMeasurement],
+        preference: TBConnectionPathPreference
+    ) -> TBConnectionMeasurement? {
+        let eligible: [TBConnectionMeasurement]
+        eligible = measurements.filter { preference.allows($0.candidate.kind) }
+        guard let fastest = eligible.max(by: { $0.throughputGbps < $1.throughputGbps }) else { return nil }
+
+        // Results within 10% are effectively tied for a short startup probe.
+        // In that narrow band prefer lower latency, then the more direct medium.
+        let competitive = eligible.filter {
+            $0.throughputGbps >= fastest.throughputGbps * 0.90
+        }
+        return competitive.sorted {
+            let latencyDifference = abs($0.connectLatencyMilliseconds - $1.connectLatencyMilliseconds)
+            if latencyDifference > 0.25 {
+                return $0.connectLatencyMilliseconds < $1.connectLatencyMilliseconds
+            }
+            if $0.candidate.kind.tieBreakPriority != $1.candidate.kind.tieBreakPriority {
+                return $0.candidate.kind.tieBreakPriority > $1.candidate.kind.tieBreakPriority
+            }
+            return $0.throughputGbps > $1.throughputGbps
+        }.first
+    }
+
+    /// Sends a bounded stream of protocol-valid TEST_DATA packets through one
+    /// explicitly bound interface. The receiver already discards this packet
+    /// type, so the probe measures the real path without starting video capture.
+    static func probe(
+        _ candidate: TBConnectionCandidate,
+        port: UInt16 = TBMonitorProtocol.port,
+        payloadBytes: Int = 16 * 1024 * 1024,
+        timeout: TimeInterval = 3.0
+    ) throws -> TBConnectionMeasurement {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+        guard fd >= 0 else { throw socketError("socket") }
+        defer { Darwin.close(fd) }
+
+        var noSignal: Int32 = 1
+        guard setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout.size(ofValue: noSignal))) == 0 else {
+            throw socketError("setsockopt(SO_NOSIGPIPE)")
+        }
+
+        let interfaceIndex = if_nametoindex(candidate.localInterfaceName)
+        guard interfaceIndex != 0 else { throw TBConnectionProbeError.interfaceUnavailable(candidate.localInterfaceName) }
+        var boundIndex = interfaceIndex
+        guard setsockopt(fd, IPPROTO_IP, IP_BOUND_IF, &boundIndex, socklen_t(MemoryLayout.size(ofValue: boundIndex))) == 0 else {
+            throw socketError("setsockopt(IP_BOUND_IF)")
+        }
+
+        var localAddress = try socketAddress(ip: candidate.localIP, port: 0)
+        let bindResult = withUnsafePointer(to: &localAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else { throw socketError("bind") }
+
+        let originalFlags = fcntl(fd, F_GETFL, 0)
+        guard originalFlags >= 0, fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) == 0 else {
+            throw socketError("fcntl")
+        }
+
+        var remoteAddress = try socketAddress(ip: candidate.receiverIP, port: port)
+        let connectStarted = DispatchTime.now().uptimeNanoseconds
+        let connectResult = withUnsafePointer(to: &remoteAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if connectResult != 0 {
+            guard errno == EINPROGRESS else { throw socketError("connect") }
+            try waitForSocket(fd, events: Int16(POLLOUT), timeout: timeout)
+            var socketStatus: Int32 = 0
+            var socketStatusLength = socklen_t(MemoryLayout.size(ofValue: socketStatus))
+            guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketStatus, &socketStatusLength) == 0 else {
+                throw socketError("getsockopt(SO_ERROR)")
+            }
+            guard socketStatus == 0 else {
+                throw TBConnectionProbeError.socketFailure("connect: \(String(cString: strerror(socketStatus)))")
+            }
+        }
+        let connectedAt = DispatchTime.now().uptimeNanoseconds
+
+        let chunkBytes = min(256 * 1024, max(1, payloadBytes))
+        let payload = Data(repeating: 0xA5, count: chunkBytes)
+        let fullPacket = TBMonitorProtocol.makePacket(type: .testData, payload: payload)
+        let sendStarted = DispatchTime.now().uptimeNanoseconds
+        let deadline = sendStarted + UInt64(timeout * 1_000_000_000)
+        var sentPayloadBytes = 0
+
+        while sentPayloadBytes < payloadBytes {
+            let remaining = payloadBytes - sentPayloadBytes
+            let packet = remaining >= chunkBytes
+                ? fullPacket
+                : TBMonitorProtocol.makePacket(type: .testData, payload: Data(repeating: 0xA5, count: remaining))
+            try sendAll(packet, socket: fd, deadline: deadline)
+            sentPayloadBytes += min(chunkBytes, remaining)
+        }
+        let finishedAt = DispatchTime.now().uptimeNanoseconds
+        let sendSeconds = max(Double(finishedAt - sendStarted) / 1_000_000_000.0, 0.000_001)
+        let throughput = (Double(sentPayloadBytes) * 8.0) / 1_000_000_000.0 / sendSeconds
+        let latency = Double(connectedAt - connectStarted) / 1_000_000.0
+        return TBConnectionMeasurement(
+            candidate: candidate,
+            throughputGbps: throughput,
+            connectLatencyMilliseconds: latency
+        )
+    }
+
+    private static func uniqueIPv4Addresses(_ values: [String]) -> [String] {
+        var result: [String] = []
+        var seen = Set<String>()
+        for value in values where ipv4Octets(value) != nil && seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
+    }
+
+    private static func likelySameIPv4Subnet(_ lhs: String, _ rhs: String) -> Bool {
+        guard let left = ipv4Octets(lhs), let right = ipv4Octets(rhs) else { return false }
+        return left[0] == right[0] && left[1] == right[1] && left[2] == right[2]
+    }
+
+    private static func socketAddress(ip: String, port: UInt16) throws -> sockaddr_in {
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = port.bigEndian
+        guard ip.withCString({ inet_pton(AF_INET, $0, &address.sin_addr) }) == 1 else {
+            throw TBConnectionProbeError.invalidAddress(ip)
+        }
+        return address
+    }
+
+    private static func waitForSocket(_ fd: Int32, events: Int16, timeout: TimeInterval) throws {
+        var descriptor = pollfd(fd: fd, events: events, revents: 0)
+        let milliseconds = Int32(max(1, min(timeout * 1000.0, Double(Int32.max))))
+        while true {
+            let result = Darwin.poll(&descriptor, 1, milliseconds)
+            if result > 0 {
+                guard (descriptor.revents & (Int16(POLLERR) | Int16(POLLHUP) | Int16(POLLNVAL))) == 0 else {
+                    throw TBConnectionProbeError.socketFailure("socket became unavailable")
+                }
+                return
+            }
+            if result == 0 { throw TBConnectionProbeError.timeout }
+            if errno != EINTR { throw socketError("poll") }
+        }
+    }
+
+    private static func sendAll(_ data: Data, socket fd: Int32, deadline: UInt64) throws {
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let now = DispatchTime.now().uptimeNanoseconds
+                if now >= deadline {
+                    throw TBConnectionProbeError.timeout
+                }
+                let sent = Darwin.send(fd, baseAddress.advanced(by: offset), buffer.count - offset, 0)
+                if sent > 0 {
+                    offset += sent
+                } else if sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    let waitStarted = DispatchTime.now().uptimeNanoseconds
+                    guard waitStarted < deadline else { throw TBConnectionProbeError.timeout }
+                    let remainingSeconds = Double(deadline - waitStarted) / 1_000_000_000.0
+                    try waitForSocket(fd, events: Int16(POLLOUT), timeout: max(0.001, remainingSeconds))
+                } else if sent < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw socketError("send")
+                }
+            }
+        }
+    }
+
+    private static func socketError(_ operation: String) -> TBConnectionProbeError {
+        TBConnectionProbeError.socketFailure("\(operation): \(String(cString: strerror(errno)))")
+    }
+
+    /// For a link-local (`169.254.x`) receiver reached through bridgeX,
+    /// returns `"<ip>%<interface>"` so the Thunderbolt dial is scoped to the
+    /// interface that owns `localIP`. Direct USB-NCM enX links remain
+    /// unscoped: macOS installs a host route for the USB peer and Network.framework
+    /// does not reliably accept an IPv4 `%enX` zone suffix.
     ///
     /// Why: macOS keeps a single routing-table entry for all of
     /// 169.254.0.0/16, pointing at the primary interface (usually Wi-Fi). A
@@ -49,6 +470,7 @@ enum TBConnectionDiagnostics {
     ) -> String {
         guard receiverIP.hasPrefix("169.254."), !receiverIP.contains("%") else { return receiverIP }
         guard let name = interfaceName(forLocalIP: localIP, in: interfaces) else { return receiverIP }
+        guard name.hasPrefix("bridge") else { return receiverIP }
         return "\(receiverIP)%\(name)"
     }
 

--- a/cli/targetbridge
+++ b/cli/targetbridge
@@ -9,12 +9,13 @@ set -euo pipefail
 #
 # Usage:
 #   targetbridge connect [--receiver auto|<id|name|ip>] [--mode mirror|extended]
-#                        [--preset <name>] [--transport tb|net] [--session N] [--local-ip <ip>]
+#                        [--preset <name>] [--path auto|wired|thunderbolt|usb|ethernet|wifi]
+#                        [--transport tb|net] [--session N] [--local-ip <ip>]
 #   targetbridge disconnect [--session N]
 #
 # Examples:
 #   targetbridge connect                                  # auto receiver, app defaults
-#   targetbridge connect --receiver auto --mode mirror --preset 1440p
+#   targetbridge connect --receiver auto --mode mirror --preset 1440p --path auto
 #   targetbridge connect --receiver 169.254.0.2 --mode extended --preset 5k
 #   targetbridge disconnect
 #
@@ -61,6 +62,7 @@ while [ $# -gt 0 ]; do
     --receiver)  add receiver  "${2:-}"; shift 2 ;;
     --mode)      add mode      "${2:-}"; shift 2 ;;
     --preset)    add preset    "${2:-}"; shift 2 ;;
+    --path)      add path      "${2:-}"; shift 2 ;;
     --transport) add transport "${2:-}"; shift 2 ;;
     --session)   add session   "${2:-}"; shift 2 ;;
     --local-ip)  add localIP   "${2:-}"; shift 2 ;;

--- a/docs/Automation.md
+++ b/docs/Automation.md
@@ -17,18 +17,30 @@ install -m 0755 cli/targetbridge /usr/local/bin/targetbridge   # or ~/bin, etc.
 
 ```bash
 targetbridge connect                                            # auto-pick receiver, app defaults
-targetbridge connect --receiver auto --mode mirror --preset 1440p
+targetbridge connect --receiver auto --mode mirror --preset 1440p --path auto
 targetbridge connect --receiver 169.254.0.2 --mode extended --preset 5k
 targetbridge disconnect
 ```
 
 Options: `--receiver auto|<id|name|ip>`, `--mode mirror|extended`, `--preset <name>`,
-`--transport tb|net`, `--session N`, `--local-ip <ip>`.
+`--path auto|wired|thunderbolt|usb|ethernet|wifi`, `--transport tb|net`, `--session N`,
+`--local-ip <ip>`.
 Presets: `standard1440p`, `smooth1440p60`, `smooth1800p60`, `crisp2160p60`, `native5k`,
 `native5k60Experimental` (aliases: `1440p`, `1440p60`, `1800p`, `4k`, `5k`, `5k60`).
 `native5k60Experimental` is an opt-in HEVC test profile for 5K at 60 FPS; it does not
 replace the stable 5K 48 FPS profile. A receiver of `auto` waits briefly for
 Bonjour discovery and uses the first receiver found; a raw IP/hostname bypasses discovery.
+
+With `--path auto`, the Sender discovers the receiver addresses advertised for
+Thunderbolt Bridge, direct USB/USB4 networking, Ethernet and Wi-Fi, then performs a
+short bounded transfer over each working route and selects the measured fastest one.
+Use `--path wired` to exclude Wi-Fi, or choose a specific path to force it.
+
+On macOS a direct USB-C/USB4 connection between two Macs is exposed as a USB-NCM
+network interface, usually with a self-assigned `169.254.x.x` address. TargetBridge
+continues to send its encoded network stream over that interface: this does not turn
+the iMac into a native USB-C/DisplayPort video sink, and the reported USB4 link speed
+is not the same as the application-level video throughput.
 
 It launches the Sender on demand and works whether the app is already running or not.
 


### PR DESCRIPTION
## Context — a short story

I discovered TargetBridge while looking for a practical way to reuse a 21.5-inch 2017 Retina 4K iMac as the display for a Mac mini M4. Apple's Target Display Mode is unavailable on this iMac, while ordinary screen sharing was too slow for comfortable daily use.

I really liked TargetBridge's design: it creates a virtual display on the Sender and carries a low-latency encoded stream to the Receiver, instead of pretending that the iMac is a physical DisplayPort monitor. While testing it with Thunderbolt, USB4/USB-C, direct Ethernet and Wi-Fi, I found that the hardest part for a non-technical user was not the stream itself, but making sure it used the best cable instead of silently falling back to Wi-Fi.

This PR isolates that one improvement from the larger integrated prototype in #157, so it can be reviewed and accepted independently.

## What this PR adds

- Discovers separate Receiver endpoints for:
  - Thunderbolt Bridge
  - direct USB/USB4 networking
  - Ethernet
  - Wi-Fi
- Identifies the matching local interface without assuming that Wi-Fi is always `en0` or `en1`.
- Performs a bounded, protocol-valid 16 MiB transfer over each candidate path.
- Binds every probe to the exact local interface and measures application-level throughput plus connection latency.
- Selects the measured fastest working path; interface names are used only as a tie-breaker.
- Adds explicit preferences: `auto`, `wired`, `thunderbolt`, `usb`, `ethernet`, and `wifi`.
- Exposes the selection through `targetbridge connect --path ...` and the existing URL/launch-argument automation.
- Keeps legacy behavior unchanged when `--path` is omitted.

## USB4 clarification

This does **not** turn the iMac into a native USB-C/DisplayPort sink and does not claim a raw 40 Gbit/s video path.

When macOS creates a direct USB-C/USB4 network interface between the two Macs, it normally appears as USB-NCM with a self-assigned `169.254.x.x` address. TargetBridge continues to use its encoded network protocol over that interface. The selector measures the throughput TargetBridge can actually obtain, rather than trusting the cable's advertised link rate.

The same mechanism deliberately supports direct Ethernet and Thunderbolt Bridge, because the fastest real path depends on both Macs, adapters, macOS routing and the cable.

## Receiver behavior

The Receiver advertises its Thunderbolt, USB/link-local, Ethernet and Wi-Fi IPv4 addresses as separate Bonjour TXT fields. Probe packets use the existing `TEST_DATA` packet type, which the Receiver discards without marking a video session active, so path selection does not start capture or flash the fullscreen session UI.

## Examples

```bash
targetbridge connect --receiver auto --path auto
targetbridge connect --receiver auto --path wired
targetbridge connect --receiver auto --path usb
```

## Intentionally not included

To keep this review focused, this PR does not include:

- automatic retry or headless startup
- Receiver-side Start/Stop controls
- Retina 4K/60 capture changes
- keyboard, mouse or clipboard forwarding
- audio/display controls
- installer or packaging changes

Those parts remain described in #157 and can be proposed as separate PRs by utility.

## Validation

Tested on a Mac mini M4 and a 21.5-inch 2017 Retina 4K iMac with direct USB4/USB-C, Thunderbolt Bridge, Ethernet and Wi-Fi paths.

- Sender: 96 XCTest tests passed
- Receiver networking: 67 C checks passed
- Receiver: full build completed successfully
- CLI: shell syntax and help output verified
- `git diff --check`: clean

No credentials, privileged helper, kernel extension or third-party dependency is added.
