### PR TITLE
Add stable Retina 4K 60 fps capture

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
@@ -241,6 +241,7 @@ enum TBSenderAutomation {
         case "1440p60", "smooth", "smooth1440": return .smooth1440p60
         case "1800p", "1800p60", "smooth1800": return .smooth1800p60
         case "2160p", "2160p60", "4k", "crisp": return .crisp2160p60
+        case "retina4k", "retina4k60", "4096x2304", "imac4k": return .retina4k60
         case "5k60", "native5k60": return .native5k60Experimental
         case "5k", "native", "5120x2880": return .native5k
         default: return nil

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderLocalization.swift
@@ -567,6 +567,8 @@ extension TBDisplayCapturePreset {
             return TBDisplaySenderL10n.text("sender.profile.smooth_plus", language)
         case .crisp2160p60:
             return TBDisplaySenderL10n.text("sender.profile.crisp", language)
+        case .retina4k60:
+            return TBDisplaySenderL10n.text("sender.profile.retina_4k", language)
         case .native5k:
             return TBDisplaySenderL10n.text("sender.profile.native_5k", language)
         case .native5k60Experimental:

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -15,6 +15,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
     case smooth1440p60
     case smooth1800p60
     case crisp2160p60
+    case retina4k60
     case native5k
     case native5k60Experimental
 
@@ -30,6 +31,8 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return "Smooth+"
         case .crisp2160p60:
             return "Crisp"
+        case .retina4k60:
+            return "Retina 4K"
         case .native5k:
             return "5K"
         case .native5k60Experimental:
@@ -47,6 +50,8 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return "3200 × 1800 @ 60"
         case .crisp2160p60:
             return "3840 × 2160 @ 60"
+        case .retina4k60:
+            return "4096 × 2304 @ 60"
         case .native5k:
             return "5120 × 2880 @ 48"
         case .native5k60Experimental:
@@ -62,6 +67,8 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 3200
         case .crisp2160p60:
             return 3840
+        case .retina4k60:
+            return 4096
         case .native5k, .native5k60Experimental:
             return 5120
         }
@@ -75,6 +82,8 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 1800
         case .crisp2160p60:
             return 2160
+        case .retina4k60:
+            return 2304
         case .native5k, .native5k60Experimental:
             return 2880
         }
@@ -90,6 +99,8 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 78_000_000
         case .crisp2160p60:
             return 105_000_000
+        case .retina4k60:
+            return 120_000_000
         case .native5k:
             return 120_000_000
         case .native5k60Experimental:
@@ -101,7 +112,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p, .smooth1440p60, .smooth1800p60:
             return "H.264"
-        case .crisp2160p60, .native5k, .native5k60Experimental:
+        case .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return "HEVC"
         }
     }
@@ -110,7 +121,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p, .smooth1440p60, .smooth1800p60:
             return kCMVideoCodecType_H264
-        case .crisp2160p60, .native5k, .native5k60Experimental:
+        case .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return kCMVideoCodecType_HEVC
         }
     }
@@ -119,7 +130,16 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         if let envVal = ProcessInfo.processInfo.environment["QD"], let parsed = Int(envVal) {
             return parsed
         }
-        return 2
+        switch self {
+        case .standard1440p:
+            return 3
+        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .retina4k60,
+             .native5k, .native5k60Experimental:
+            // Five surfaces protect WindowServer from starvation during
+            // high-frame-rate 4K capture while the serial pipeline prevents an
+            // application-side frame backlog.
+            return 5
+        }
     }
 
     var expectedFrameRate: Int {
@@ -130,13 +150,20 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 60
         case .smooth1800p60:
             return 60
-        case .crisp2160p60:
+        case .crisp2160p60, .retina4k60:
             return 60
         case .native5k:
             return 48
         case .native5k60Experimental:
             return 60
         }
+    }
+
+    /// ScreenCaptureKit treats `minimumFrameInterval` as a throttle rather than
+    /// a target cadence. Requesting headroom avoids losing refreshes to scheduler
+    /// tolerance; `TBFrameRatePacer` applies the exact output ceiling later.
+    var captureRequestFrameRate: Int {
+        expectedFrameRate >= 48 ? expectedFrameRate * 2 : expectedFrameRate
     }
 
     var maxKeyFrameInterval: Int {
@@ -147,7 +174,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 60
         case .smooth1800p60:
             return 60
-        case .crisp2160p60:
+        case .crisp2160p60, .retina4k60:
             return 60
         case .native5k:
             return 48
@@ -162,7 +189,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 2
         case .smooth1440p60:
             return 1
-        case .smooth1800p60, .crisp2160p60:
+        case .smooth1800p60, .crisp2160p60, .retina4k60:
             return 1
         case .native5k, .native5k60Experimental:
             return 1
@@ -173,7 +200,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p:
             return false
-        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .native5k, .native5k60Experimental:
+        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return true
         }
     }
@@ -189,7 +216,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p:
             return 1
-        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .native5k, .native5k60Experimental:
+        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return 0
         }
     }
@@ -198,7 +225,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p:
             return false
-        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .native5k, .native5k60Experimental:
+        case .smooth1440p60, .smooth1800p60, .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return true
         }
     }
@@ -214,7 +241,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
         switch self {
         case .standard1440p, .smooth1440p60, .smooth1800p60:
             return .nominal
-        case .crisp2160p60, .native5k, .native5k60Experimental:
+        case .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return .best
         }
     }
@@ -225,7 +252,7 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
             return 60
         case .smooth1440p60, .smooth1800p60:
             return 60
-        case .crisp2160p60:
+        case .crisp2160p60, .retina4k60:
             return 60
         case .native5k:
             return 48
@@ -247,6 +274,47 @@ enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
     /// Logical desktop size the user ends up with under render matching.
     var renderMatchedDesktopDescription: String {
         "\(width / 2) × \(height / 2)"
+    }
+}
+
+/// A zero-buffer frame-rate ceiling for capture callbacks. Deadlines advance on
+/// the ideal output timeline, allowing 75 Hz input to be sampled evenly at 60 Hz.
+/// Long idle gaps reset the cadence instead of accumulating burst credit.
+struct TBFrameRatePacer {
+    private let frameInterval: CMTime
+    private let deadlineTolerance = CMTime(value: 1, timescale: 10_000)
+    private var nextDeadline: CMTime?
+
+    init(maximumFrameRate: Int) {
+        frameInterval = maximumFrameRate > 0
+            ? CMTime(value: 1, timescale: CMTimeScale(maximumFrameRate))
+            : .invalid
+    }
+
+    mutating func shouldEmit(presentationTime: CMTime) -> Bool {
+        guard frameInterval.isValid, presentationTime.isValid,
+              !presentationTime.isIndefinite else { return true }
+
+        guard let deadline = nextDeadline else {
+            nextDeadline = CMTimeAdd(presentationTime, frameInterval)
+            return true
+        }
+
+        if CMTimeCompare(presentationTime, CMTimeSubtract(deadline, frameInterval)) < 0 {
+            nextDeadline = CMTimeAdd(presentationTime, frameInterval)
+            return true
+        }
+
+        guard CMTimeCompare(CMTimeAdd(presentationTime, deadlineTolerance), deadline) >= 0 else {
+            return false
+        }
+
+        if CMTimeCompare(CMTimeSubtract(presentationTime, deadline), frameInterval) > 0 {
+            nextDeadline = CMTimeAdd(presentationTime, frameInterval)
+        } else {
+            nextDeadline = CMTimeAdd(deadline, frameInterval)
+        }
+        return true
     }
 }
 
@@ -385,12 +453,17 @@ private final class TBVideoPipeline: @unchecked Sendable {
     private var inFlightEncodeFrames = 0
     private var displayStreamFrameSequence: CMTimeValue = 0
     private var lastEncodedDisplayPTS: CMTime?
+    private var frameRatePacer: TBFrameRatePacer
     private var ackSent: Bool
     private var running = false
 
     // Read from the main thread (fps timer / watchdog); guarded by `lock`.
     private let lock = NSLock()
     private var _sentFrames = 0
+    private var capturedFrames = 0
+    private var droppedByFrameRatePacer = 0
+    private var droppedBeforeEncodeFrames = 0
+    private var droppedAfterEncodeFrames = 0
     private var _lastCaptureFrameAt = Date()
 
     init(preset: TBDisplayCapturePreset,
@@ -407,6 +480,7 @@ private final class TBVideoPipeline: @unchecked Sendable {
         self.displayName = displayName
         self.displayID = displayID
         self.usesRawNV12 = usesRawNV12
+        self.frameRatePacer = TBFrameRatePacer(maximumFrameRate: preset.expectedFrameRate)
         self.ackSent = ackAlreadySent
         self.onFirstFrame = onFirstFrame
     }
@@ -452,11 +526,22 @@ private final class TBVideoPipeline: @unchecked Sendable {
         return _lastCaptureFrameAt
     }
 
-    func diagnosticsSnapshot() -> (pending: Int, inFlight: Int, ptsSeq: CMTimeValue) {
-        queue.sync { (pending: pendingVideoPackets, inFlight: inFlightEncodeFrames, ptsSeq: displayStreamFrameSequence) }
+    func diagnosticsSnapshot() -> (pending: Int, inFlight: Int, ptsSeq: CMTimeValue, captured: Int, droppedPacing: Int, droppedPre: Int, droppedPost: Int) {
+        queue.sync {
+            (
+                pending: pendingVideoPackets,
+                inFlight: inFlightEncodeFrames,
+                ptsSeq: displayStreamFrameSequence,
+                captured: capturedFrames,
+                droppedPacing: droppedByFrameRatePacer,
+                droppedPre: droppedBeforeEncodeFrames,
+                droppedPost: droppedAfterEncodeFrames
+            )
+        }
     }
 
     private func markCaptureFrame() {
+        capturedFrames += 1
         lock.lock(); _lastCaptureFrameAt = Date(); lock.unlock()
     }
 
@@ -533,6 +618,11 @@ private final class TBVideoPipeline: @unchecked Sendable {
     /// SCStream capture path. Must be dispatched onto `queue` by the caller.
     func encode(_ sampleBuffer: CMSampleBuffer) {
         markCaptureFrame()
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        guard frameRatePacer.shouldEmit(presentationTime: pts) else {
+            droppedByFrameRatePacer += 1
+            return
+        }
         if usesRawNV12 {
             sendRawFrame(sampleBuffer)
             return
@@ -543,9 +633,9 @@ private final class TBVideoPipeline: @unchecked Sendable {
         if preset.dropsBeforeEncodeWhenBacklogged,
            (pendingVideoPackets >= preset.maxPendingVideoPackets ||
             inFlightEncodeFrames >= preset.maxInFlightEncodeFrames) {
+            droppedBeforeEncodeFrames += 1
             return
         }
-        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         encode(pixelBuffer: pixelBuffer, presentationTimeStamp: pts, using: encoder)
     }
 
@@ -554,9 +644,22 @@ private final class TBVideoPipeline: @unchecked Sendable {
     func encodeDisplaySurface(_ surface: IOSurfaceRef, displayTime: UInt64) {
         markCaptureFrame()
         guard running, let encoder = vtEncoder else { return }
+
+        var pts = displayTime != 0
+            ? CMClockMakeHostTimeFromSystemUnits(displayTime)
+            : CMClockGetTime(CMClockGetHostTimeClock())
+        if let last = lastEncodedDisplayPTS, CMTimeCompare(pts, last) <= 0 {
+            // VTCompressionSession requires strictly increasing PTS.
+            pts = CMTimeAdd(last, CMTime(value: 1, timescale: 600))
+        }
+        guard frameRatePacer.shouldEmit(presentationTime: pts) else {
+            droppedByFrameRatePacer += 1
+            return
+        }
         if preset.dropsBeforeEncodeWhenBacklogged,
            (pendingVideoPackets >= preset.maxPendingVideoPackets ||
             inFlightEncodeFrames >= preset.maxInFlightEncodeFrames) {
+            droppedBeforeEncodeFrames += 1
             return
         }
 
@@ -583,13 +686,6 @@ private final class TBVideoPipeline: @unchecked Sendable {
         // frame-counter PTS would drift away from real wall-clock time over a
         // long session and pace the receiver progressively wrong. displayTime is
         // in mach-absolute units, the same host clock the SCStream path uses.
-        var pts = displayTime != 0
-            ? CMClockMakeHostTimeFromSystemUnits(displayTime)
-            : CMClockGetTime(CMClockGetHostTimeClock())
-        if let last = lastEncodedDisplayPTS, CMTimeCompare(pts, last) <= 0 {
-            // VTCompressionSession requires strictly increasing PTS.
-            pts = CMTimeAdd(last, CMTime(value: 1, timescale: 600))
-        }
         lastEncodedDisplayPTS = pts
         encode(pixelBuffer: pixelBuffer, presentationTimeStamp: pts, using: encoder)
     }
@@ -631,6 +727,7 @@ private final class TBVideoPipeline: @unchecked Sendable {
         let isKeyframe = !notSync
 
         if !isKeyframe, pendingVideoPackets >= preset.maxPendingVideoPackets {
+            droppedAfterEncodeFrames += 1
             return
         }
 
@@ -661,7 +758,10 @@ private final class TBVideoPipeline: @unchecked Sendable {
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
         // Backpressure: never pile frames on top of a network that can't keep up.
-        if pendingVideoPackets >= preset.maxPendingVideoPackets { return }
+        if pendingVideoPackets >= preset.maxPendingVideoPackets {
+            droppedBeforeEncodeFrames += 1
+            return
+        }
         guard CVPixelBufferGetPlaneCount(pixelBuffer) >= 2 else { return }
 
         CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
@@ -1249,7 +1349,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 return kCMVideoCodecType_HEVC
             }
             return kCMVideoCodecType_H264
-        case .crisp2160p60, .native5k, .native5k60Experimental:
+        case .crisp2160p60, .retina4k60, .native5k, .native5k60Experimental:
             return preset.codecType
         }
     }
@@ -2367,10 +2467,19 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             let display: SCDisplay
             if captureSource == .desktopMirror {
                 let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
-                guard let mainDisplay = content.displays.first(where: { $0.displayID == CGMainDisplayID() }) else {
+                // In mirror mode both surfaces carry the same desktop. Prefer the
+                // receiver-native virtual surface to avoid rescaling the physical
+                // display to the Retina stream dimensions.
+                if session.displayID != kCGNullDirectDisplay,
+                   let virtualDisplay = content.displays.first(where: { $0.displayID == session.displayID }) {
+                    display = virtualDisplay
+                    TBLog.connection.info("capture: using receiver-native mirrored display id=\(virtualDisplay.displayID, privacy: .public)")
+                } else if let mainDisplay = content.displays.first(where: { $0.displayID == CGMainDisplayID() }) {
+                    display = mainDisplay
+                    TBLog.connection.info("capture: receiver display unavailable; using main display id=\(mainDisplay.displayID, privacy: .public)")
+                } else {
                     return false
                 }
-                display = mainDisplay
             } else {
                 let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
                 if session.displayID != kCGNullDirectDisplay,
@@ -2384,13 +2493,14 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             let configuration = SCStreamConfiguration()
             configuration.width = preset.width
             configuration.height = preset.height
-            configuration.minimumFrameInterval = CMTime(value: 1, timescale: Int32(preset.expectedFrameRate))
+            configuration.minimumFrameInterval = CMTime(value: 1, timescale: Int32(preset.captureRequestFrameRate))
             configuration.queueDepth = preset.queueDepth
             configuration.pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            configuration.shouldBeOpaque = true
             configuration.showsCursor = !largeCursor
             configuration.scalesToFit = true
             configuration.captureResolution = preset.captureResolution
-            configuration.capturesAudio = true
+            configuration.capturesAudio = audioEnabled
             configuration.excludesCurrentProcessAudio = true
             configuration.sampleRate = 48000
             configuration.channelCount = 2
@@ -2404,7 +2514,10 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
             let delegate = CaptureDelegate()
             delegate.onFrame = { sampleBuffer in
-                pipeline.queue.async { pipeline.encode(sampleBuffer) }
+                // ScreenCaptureKit already invokes this closure on pipeline.queue.
+                // Encode immediately so its IOSurface returns to WindowServer
+                // without an extra dispatch hop.
+                pipeline.encode(sampleBuffer)
             }
             delegate.onAudio = { [weak self] sampleBuffer in
                 self?.processAudio(sampleBuffer)
@@ -2424,13 +2537,15 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             try stream.addStreamOutput(
                 delegate,
                 type: .screen,
-                sampleHandlerQueue: DispatchQueue(label: "fd.tbmonitor.sender.capture", qos: .userInteractive)
+                sampleHandlerQueue: pipeline.queue
             )
-            try stream.addStreamOutput(
-                delegate,
-                type: .audio,
-                sampleHandlerQueue: DispatchQueue(label: "fd.tbmonitor.sender.audio", qos: .userInteractive)
-            )
+            if audioEnabled {
+                try stream.addStreamOutput(
+                    delegate,
+                    type: .audio,
+                    sampleHandlerQueue: DispatchQueue(label: "fd.tbmonitor.sender.audio", qos: .userInteractive)
+                )
+            }
             try await stream.startCapture()
             scStream = stream
             isStreaming = true
@@ -2491,7 +2606,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
 
     private func waitForCaptureDisplay() async throws -> SCDisplay {
-        let targetDisplayID = (captureSource == .desktopMirror) ? CGMainDisplayID() : session.displayID
+        let targetDisplayID = session.displayID != kCGNullDirectDisplay
+            ? session.displayID
+            : CGMainDisplayID()
         return try await waitForVirtualDisplay(
             matching: targetDisplayID,
             baselineDisplayIDs: baselineDisplayIDs
@@ -3022,16 +3139,28 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         guard verboseDisplayLogging else { return }
         let online = onlineDisplayIDs()
         let virtualOnline = online.contains(session.displayID)
-        let diag = pipeline?.diagnosticsSnapshot() ?? (pending: 0, inFlight: 0, ptsSeq: 0)
+        let diag = pipeline?.diagnosticsSnapshot() ?? (
+            pending: 0,
+            inFlight: 0,
+            ptsSeq: 0,
+            captured: 0,
+            droppedPacing: 0,
+            droppedPre: 0,
+            droppedPost: 0
+        )
         NSLog(
-            "TargetBridge: stream snapshot streaming=%@ fps=%d virtualID=%u online=%@ pendingPackets=%d inFlightEncode=%d ptsSeq=%lld",
+            "TargetBridge: stream snapshot streaming=%@ fps=%d virtualID=%u online=%@ pendingPackets=%d inFlightEncode=%d ptsSeq=%lld captured=%d droppedPacing=%d droppedPre=%d droppedPost=%d",
             isStreaming ? "yes" : "no",
             liveMetrics.senderFPS,
             session.displayID,
             virtualOnline ? "yes" : "no",
             diag.pending,
             diag.inFlight,
-            diag.ptsSeq
+            diag.ptsSeq,
+            diag.captured,
+            diag.droppedPacing,
+            diag.droppedPre,
+            diag.droppedPost
         )
     }
 
@@ -3153,7 +3282,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 guard isStreaming, !sessionAckSent else { return }
                 let sentFrames = self.pipeline?.sentFramesSnapshot ?? 0
                 TBLog.connection.error("capture: first-frame timeout preset=\(self.capturePreset.rawValue, privacy: .public) source=\(String(describing: self.captureSource), privacy: .public) connected=\(self.isConnected, privacy: .public) sentFrames=\(sentFrames, privacy: .public)")
-                if self.capturePreset == .native5k || self.capturePreset == .native5k60Experimental {
+                if self.capturePreset == .retina4k60 || self.capturePreset == .native5k || self.capturePreset == .native5k60Experimental {
                     setStatus(.hevcNoFrames)
                 } else {
                     setStatus(.noFirstFrame)

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
@@ -1,3 +1,4 @@
+import CoreMedia
 import XCTest
 @testable import TargetBridge
 
@@ -7,6 +8,44 @@ import XCTest
 /// silently reroute automation traffic.
 @MainActor
 final class TBSenderAutomationParsingTests: XCTestCase {
+    func testHighFrameRatePresetsUseFiveCaptureSurfaces() {
+        XCTAssertEqual(TBDisplayCapturePreset.standard1440p.queueDepth, 3)
+        XCTAssertEqual(TBDisplayCapturePreset.smooth1440p60.queueDepth, 5)
+        XCTAssertEqual(TBDisplayCapturePreset.retina4k60.queueDepth, 5)
+        XCTAssertEqual(TBDisplayCapturePreset.native5k60Experimental.queueDepth, 5)
+    }
+
+    func testHighFrameRatePresetsRequestCaptureHeadroom() {
+        XCTAssertEqual(TBDisplayCapturePreset.standard1440p.captureRequestFrameRate, 30)
+        XCTAssertEqual(TBDisplayCapturePreset.smooth1440p60.captureRequestFrameRate, 120)
+        XCTAssertEqual(TBDisplayCapturePreset.retina4k60.captureRequestFrameRate, 120)
+        XCTAssertEqual(TBDisplayCapturePreset.native5k.captureRequestFrameRate, 96)
+    }
+
+    func testFrameRatePacerSamples75HzInputAt60Hz() {
+        var pacer = TBFrameRatePacer(maximumFrameRate: 60)
+        let emitted = (0..<750).filter { frame in
+            pacer.shouldEmit(presentationTime: CMTime(seconds: Double(frame) / 75.0, preferredTimescale: 60_000))
+        }
+        XCTAssertEqual(emitted.count, 600)
+    }
+
+    func testFrameRatePacerPreservesInputsAtOrBelowCeiling() {
+        for inputRate in [30, 60] {
+            var pacer = TBFrameRatePacer(maximumFrameRate: 60)
+            let emitted = (0..<(inputRate * 10)).filter { frame in
+                pacer.shouldEmit(presentationTime: CMTime(seconds: Double(frame) / Double(inputRate), preferredTimescale: 60_000))
+            }
+            XCTAssertEqual(emitted.count, inputRate * 10)
+        }
+    }
+
+    func testFrameRatePacerDoesNotAccumulateBurstCreditAfterIdleGap() {
+        var pacer = TBFrameRatePacer(maximumFrameRate: 60)
+        XCTAssertTrue(pacer.shouldEmit(presentationTime: CMTime(seconds: 0, preferredTimescale: 60_000)))
+        XCTAssertTrue(pacer.shouldEmit(presentationTime: CMTime(seconds: 1, preferredTimescale: 60_000)))
+        XCTAssertFalse(pacer.shouldEmit(presentationTime: CMTime(seconds: 1 + 1.0 / 75.0, preferredTimescale: 60_000)))
+    }
 
     // MARK: - parseTransport
 
@@ -55,6 +94,7 @@ final class TBSenderAutomationParsingTests: XCTestCase {
         XCTAssertEqual(TBSenderAutomation.parsePreset("smooth1440p60"), .smooth1440p60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("smooth1800p60"), .smooth1800p60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("crisp2160p60"), .crisp2160p60)
+        XCTAssertEqual(TBSenderAutomation.parsePreset("retina4k60"), .retina4k60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("native5k"), .native5k)
         XCTAssertEqual(TBSenderAutomation.parsePreset("native5k60Experimental"), .native5k60Experimental)
     }
@@ -67,6 +107,10 @@ final class TBSenderAutomationParsingTests: XCTestCase {
         XCTAssertEqual(TBSenderAutomation.parsePreset("1800p"), .smooth1800p60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("4k"), .crisp2160p60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("crisp"), .crisp2160p60)
+        XCTAssertEqual(TBSenderAutomation.parsePreset("retina4k"), .retina4k60)
+        XCTAssertEqual(TBSenderAutomation.parsePreset("RETINA4K60"), .retina4k60)
+        XCTAssertEqual(TBSenderAutomation.parsePreset("4096x2304"), .retina4k60)
+        XCTAssertEqual(TBSenderAutomation.parsePreset("imac4k"), .retina4k60)
         XCTAssertEqual(TBSenderAutomation.parsePreset("5k60"), .native5k60Experimental)
         XCTAssertEqual(TBSenderAutomation.parsePreset("native5k60"), .native5k60Experimental)
         XCTAssertEqual(TBSenderAutomation.parsePreset("5k"), .native5k)
@@ -91,6 +135,18 @@ final class TBSenderAutomationParsingTests: XCTestCase {
         XCTAssertEqual(preset.virtualDisplayRefreshRate, 60)
         XCTAssertEqual(preset.codecName, "HEVC")
         XCTAssertEqual(preset.averageBitRate, 150_000_000)
+    }
+
+    func testRetina4KPresetMatches215InchIMacPanel() {
+        let preset = TBDisplayCapturePreset.retina4k60
+
+        XCTAssertEqual(preset.width, 4096)
+        XCTAssertEqual(preset.height, 2304)
+        XCTAssertEqual(preset.expectedFrameRate, 60)
+        XCTAssertEqual(preset.virtualDisplayRefreshRate, 60)
+        XCTAssertEqual(preset.averageBitRate, 120_000_000)
+        XCTAssertEqual(preset.codecName, "HEVC")
+        XCTAssertEqual(preset.renderMatchedDesktopDescription, "2048 × 1152")
     }
 
     // MARK: - matches (receiver selection for --receiver <value>)

--- a/TargetBridge-Shared/Languages/de.json
+++ b/TargetBridge-Shared/Languages/de.json
@@ -136,6 +136,7 @@
   "sender.profile.smooth": "Smooth",
   "sender.profile.smooth_plus": "Smooth+",
   "sender.profile.crisp": "Crisp",
+  "sender.profile.retina_4k": "Retina 4K",
   "sender.profile.native_5k": "5K",
   "sender.profile.native_5k_60_experimental": "5K 60 (Experimentell)",
   "sender.capture_display.na": "n/a",

--- a/TargetBridge-Shared/Languages/en.json
+++ b/TargetBridge-Shared/Languages/en.json
@@ -136,6 +136,7 @@
   "sender.profile.smooth": "Smooth",
   "sender.profile.smooth_plus": "Smooth+",
   "sender.profile.crisp": "Crisp",
+  "sender.profile.retina_4k": "Retina 4K",
   "sender.profile.native_5k": "5K",
   "sender.profile.native_5k_60_experimental": "5K 60 (Experimental)",
   "sender.capture_display.na": "n/a",

--- a/TargetBridge-Shared/Languages/fr.json
+++ b/TargetBridge-Shared/Languages/fr.json
@@ -136,6 +136,7 @@
   "sender.profile.smooth": "Fluide",
   "sender.profile.smooth_plus": "Fluide+",
   "sender.profile.crisp": "Net",
+  "sender.profile.retina_4k": "Retina 4K",
   "sender.profile.native_5k": "5K",
   "sender.profile.native_5k_60_experimental": "5K 60 (Expérimental)",
   "sender.capture_display.na": "n/d",

--- a/TargetBridge-Shared/Languages/it.json
+++ b/TargetBridge-Shared/Languages/it.json
@@ -136,6 +136,7 @@
   "sender.profile.smooth": "Smooth",
   "sender.profile.smooth_plus": "Smooth+",
   "sender.profile.crisp": "Crisp",
+  "sender.profile.retina_4k": "Retina 4K",
   "sender.profile.native_5k": "5K",
   "sender.profile.native_5k_60_experimental": "5K 60 (Sperimentale)",
   "sender.capture_display.na": "n/a",

--- a/TargetBridge-Shared/Languages/zh.json
+++ b/TargetBridge-Shared/Languages/zh.json
@@ -136,6 +136,7 @@
   "sender.profile.smooth": "Smooth",
   "sender.profile.smooth_plus": "Smooth+",
   "sender.profile.crisp": "Crisp",
+  "sender.profile.retina_4k": "Retina 4K",
   "sender.profile.native_5k": "5K",
   "sender.profile.native_5k_60_experimental": "5K 60（实验性）",
   "sender.capture_display.na": "n/a",

--- a/cli/targetbridge
+++ b/cli/targetbridge
@@ -18,7 +18,7 @@ set -euo pipefail
 #   targetbridge connect --receiver 169.254.0.2 --mode extended --preset 5k
 #   targetbridge disconnect
 #
-# Presets: standard1440p | smooth1440p60 | smooth1800p60 | crisp2160p60 | native5k
+# Presets: standard1440p | smooth1440p60 | smooth1800p60 | crisp2160p60 | retina4k60 | native5k
 #          (aliases: 1440p, 1440p60, 1800p, 4k, 5k)
 #
 # Remote / SSH: run it on the sender over SSH (the sender must be at a logged-in

--- a/docs/Automation.md
+++ b/docs/Automation.md
@@ -24,8 +24,11 @@ targetbridge disconnect
 
 Options: `--receiver auto|<id|name|ip>`, `--mode mirror|extended`, `--preset <name>`,
 `--transport tb|net`, `--session N`, `--local-ip <ip>`.
-Presets: `standard1440p`, `smooth1440p60`, `smooth1800p60`, `crisp2160p60`, `native5k`,
-`native5k60Experimental` (aliases: `1440p`, `1440p60`, `1800p`, `4k`, `5k`, `5k60`).
+Presets: `standard1440p`, `smooth1440p60`, `smooth1800p60`, `crisp2160p60`, `retina4k60`,
+`native5k`, `native5k60Experimental` (aliases: `1440p`, `1440p60`, `1800p`, `4k`,
+`5k`, `5k60`). The `retina4k60` aliases `retina4k`, `4096x2304` and `imac4k` match
+the 4096 × 2304 panel in the 21.5-inch Retina 4K iMac without changing the existing
+`4k` alias for the 3840 × 2160 preset.
 `native5k60Experimental` is an opt-in HEVC test profile for 5K at 60 FPS; it does not
 replace the stable 5K 48 FPS profile. A receiver of `auto` waits briefly for
 Bonjour discovery and uses the first receiver found; a raw IP/hostname bypasses discovery.


### PR DESCRIPTION
## A short story

First of all, thank you for TargetBridge — I genuinely enjoyed the project and its approach.

I had a 21.5-inch 2017 Retina 4K iMac next to a Mac mini M4 and wanted to reuse the iMac's excellent panel instead of buying another display. TargetBridge was the first solution I tried that felt close to turning that machine into a real monitor. While testing it daily over direct links, I experimented with a few additions. I am splitting them by purpose so each idea can be reviewed, accepted or declined independently.

This PR is only the display-quality part. The complete prototype and proposed split are described in #157; measured USB4/network path selection is separate in #159.

## What this PR adds

- a dedicated `retina4k60` preset matching the 21.5-inch iMac panel: 4096 × 2304 at 60 fps, HEVC, 120 Mbps;
- explicit `retina4k`, `4096x2304` and `imac4k` automation aliases while preserving the existing `4k` alias for 3840 × 2160;
- capture headroom plus a zero-buffer frame pacer, so scheduler tolerance does not reduce a nominal 60 fps stream to roughly 53–55 fps;
- five ScreenCaptureKit surfaces for high-rate profiles and three for the standard profile;
- direct frame handling on the pipeline queue, avoiding an extra dispatch and returning IOSurfaces to WindowServer sooner;
- capture of the receiver-native mirrored virtual display when available, avoiding unnecessary scaling from the sender's physical display;
- audio capture setup only when audio streaming is enabled;
- counters for captured, paced and backpressure-dropped frames in verbose diagnostics;
- localized preset naming, CLI/docs updates and focused regression tests.

## Why the pacer requests more than 60 callbacks

`SCStreamConfiguration.minimumFrameInterval` behaves as a minimum interval, not a guaranteed cadence. Requesting exactly 1/60 left measurable refreshes unused on the Mac mini M4. The capture request therefore has scheduling headroom, while `TBFrameRatePacer` applies the actual 60 fps ceiling before encoding. It does not buffer frames and resets after idle gaps, so it cannot build up a burst.

## Validation

- Xcode test suite: **90 passed, 0 failed, 0 skipped** on macOS;
- JSON localization files and CLI shell syntax validated;
- `git diff --check` clean.

The integrated prototype using this same 4K pipeline was also exercised on the actual Mac mini M4 → 2017 21.5-inch Retina 4K iMac setup for about three minutes of high-entropy full-screen motion: sender remained at 60 fps, receiver varied around 59–61 fps, with no observed pipeline backlog or dropped-frame counters. That hardware run predates this intentionally smaller branch, so the automated results above are the reproducible validation for this PR.

## Deliberately out of scope

- USB4/Thunderbolt/Ethernet/Wi-Fi path discovery and benchmarking (#159);
- headless startup, reconnect ownership and receiver-side Start/Stop;
- keyboard, mouse and clipboard relay;
- display/audio controls and notification shielding;
- installer or packaging changes.

Those are kept separate so this PR can be judged strictly as a capture-quality improvement.
