### PR TITLE
Make monitor sessions headless and keep user Stop persistent

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -5,19 +6,33 @@ struct TBDisplaySenderApp: App {
     @StateObject private var service = TBDisplaySenderService.shared
     private let statusItemController = TBDisplaySenderStatusItemController(service: TBDisplaySenderService.shared)
 
+    @MainActor
+    init() {
+        // LaunchAgent automation must not depend on SwiftUI restoring or showing
+        // the main window on a headless Mac.
+        TBSenderAutomation.handleLaunchArguments(CommandLine.arguments)
+    }
+
     var body: some Scene {
         WindowGroup("TargetBridge", id: "main") {
             TBDisplaySenderContentView(service: service)
                 .frame(minWidth: 540)
                 .task {
                     statusItemController.activate()
-                    TBSenderAutomation.handleLaunchArguments(CommandLine.arguments)
                 }
                 .onOpenURL { url in
                     TBSenderAutomation.handle(url: url)
                 }
         }
         .defaultSize(width: 860, height: 860)
+        .commands {
+            CommandGroup(replacing: .appTermination) {
+                Button(TBDisplaySenderL10n.quitApp(service.language)) {
+                    service.quitAfterUserRequest()
+                }
+                .keyboardShortcut("q")
+            }
+        }
 
         Settings {
             TBDisplaySenderSettingsView(service: service)

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderAutomation.swift
@@ -17,6 +17,66 @@ import Foundation
 @MainActor
 enum TBSenderAutomation {
     private static var didHandleLaunchArguments = false
+    private static var continuousConnectTask: Task<Void, Never>?
+
+    static func senderEnabledFlagURL(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        homeDirectory
+            .appendingPathComponent("Library/Application Support/TargetBridge/Sender", isDirectory: true)
+            .appendingPathComponent("enabled", isDirectory: false)
+    }
+
+    static func suspendAutomaticReconnectAfterUserStop(
+        enabledFlagURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        suspendAutomaticReconnect(
+            enabledFlagURL: enabledFlagURL,
+            fileManager: fileManager,
+            logReason: "user stopped session"
+        )
+    }
+
+    static func suspendAutomaticReconnectForRequiredPermission(
+        enabledFlagURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        suspendAutomaticReconnect(
+            enabledFlagURL: enabledFlagURL,
+            fileManager: fileManager,
+            logReason: "screen recording permission required"
+        )
+    }
+
+    static func suspendAutomaticReconnectAfterCaptureFailure(
+        enabledFlagURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        suspendAutomaticReconnect(
+            enabledFlagURL: enabledFlagURL,
+            fileManager: fileManager,
+            logReason: "capture produced no frames"
+        )
+    }
+
+    private static func suspendAutomaticReconnect(
+        enabledFlagURL: URL?,
+        fileManager: FileManager,
+        logReason: String
+    ) {
+        continuousConnectTask?.cancel()
+        continuousConnectTask = nil
+        let marker = enabledFlagURL ?? senderEnabledFlagURL()
+        do {
+            if fileManager.fileExists(atPath: marker.path) {
+                try fileManager.removeItem(at: marker)
+            }
+            NSLog("[automation] \(logReason); automatic reconnect suspended")
+        } catch {
+            NSLog("[automation] unable to clear automatic reconnect marker: \(error.localizedDescription)")
+        }
+    }
 
     /// Handle a `targetbridge://` URL (from `.onOpenURL`).
     static func handle(url: URL) {
@@ -65,17 +125,54 @@ enum TBSenderAutomation {
     private static func run(action: String, params: [String: String]) {
         switch action {
         case "connect":
-            Task { await connect(params) }
+            continuousConnectTask?.cancel()
+            if flagEnabled(params["retry"] ?? params["autoreconnect"] ?? params["auto-reconnect"]) {
+                continuousConnectTask = Task { await connectContinuously(params) }
+            } else {
+                continuousConnectTask = nil
+                Task { _ = await connect(params) }
+            }
         case "disconnect":
+            continuousConnectTask?.cancel()
+            continuousConnectTask = nil
             disconnect(params)
         default:
             NSLog("[automation] unknown action '\(action)' (expected connect|disconnect)")
         }
     }
 
-    private static func connect(_ params: [String: String]) async {
+    private static func connectContinuously(_ params: [String: String]) async {
+        var attempt = 0
+        while !Task.isCancelled {
+            attempt += 1
+            NSLog("[automation] automatic connection attempt \(attempt)")
+
+            if let session = await connect(params) {
+                if await waitForConnection(session) {
+                    NSLog("[automation] automatic connection active; monitoring link")
+                    while !Task.isCancelled && (session.isConnected || session.isStreaming) {
+                        try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    }
+                    guard !Task.isCancelled else { return }
+                    NSLog("[automation] connection lost; retrying")
+                } else {
+                    NSLog("[automation] connection attempt did not become active; retrying")
+                }
+
+                if !session.isConnected && !session.isStreaming {
+                    session.stopForAutomaticReconnect()
+                }
+            }
+
+            guard !Task.isCancelled else { return }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+    }
+
+    @discardableResult
+    private static func connect(_ params: [String: String]) async -> TBDisplaySenderSession? {
         let service = TBDisplaySenderService.shared
-        guard let session = resolveSession(service, params["session"]) else { return }
+        guard let session = resolveSession(service, params["session"]) else { return nil }
 
         service.refreshLocalInterfaces()
 
@@ -87,7 +184,7 @@ enum TBSenderAutomation {
         if receiver.lowercased() == "auto" {
             guard let discovered = await waitForReceiver(service) else {
                 NSLog("[automation] no receivers discovered; aborting connect")
-                return
+                return nil
             }
             service.applyDiscoveredReceiver(discovered, to: session)
             session.selectedReceiverID = discovered.id
@@ -118,14 +215,15 @@ enum TBSenderAutomation {
 
         guard !session.receiverIP.isEmpty else {
             NSLog("[automation] no receiver IP resolved; aborting connect")
-            return
+            return nil
         }
         guard !session.localInterfaceIP.isEmpty else {
             NSLog("[automation] no local interface for transport \(session.transportKind.rawValue); aborting connect")
-            return
+            return nil
         }
         NSLog("[automation] connecting to \(session.receiverIP) via \(session.transportKind.rawValue) — \(session.captureSource.rawValue)/\(session.capturePreset.rawValue)")
         session.connect()
+        return session
     }
 
     private static func disconnect(_ params: [String: String]) {
@@ -200,6 +298,25 @@ enum TBSenderAutomation {
             try? await Task.sleep(nanoseconds: 300_000_000)
         }
         return service.discoveredReceivers.first
+    }
+
+    private static func waitForConnection(_ session: TBDisplaySenderSession) async -> Bool {
+        for _ in 0..<40 {
+            if session.isConnected || session.isStreaming { return true }
+            guard !Task.isCancelled else { return false }
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        return session.isConnected || session.isStreaming
+    }
+
+    static func flagEnabled(_ value: String?) -> Bool {
+        guard let value else { return false }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return true
+        }
     }
 
     // The pure parsing helpers below are `internal` (not `private`) so the

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderManager.swift
@@ -102,6 +102,7 @@ final class TBDisplaySenderService: ObservableObject {
             objectWillChange.send()
         }
     }
+    private var userQuitPending = false
     private var sessionCancellables: [UUID: AnyCancellable] = [:]
     private let receiverDiscovery = TBReceiverDiscovery()
     private let addonStore = TBAddonStore.shared
@@ -271,9 +272,44 @@ final class TBDisplaySenderService: ObservableObject {
         objectWillChange.send()
     }
 
-    func stopAll() {
-        sessions.forEach { $0.persistExtendedDisplayArrangementSnapshot() }
-        sessions.forEach { $0.stop(persistArrangement: false) }
+    func stopAll(completion: (@MainActor @Sendable () -> Void)? = nil) {
+        // A manual stop is an operator decision, not a transient disconnect.
+        TBSenderAutomation.suspendAutomaticReconnectAfterUserStop()
+        let sessionsToStop = sessions
+        sessionsToStop.forEach { $0.persistExtendedDisplayArrangementSnapshot() }
+        guard !sessionsToStop.isEmpty else {
+            completion?()
+            return
+        }
+
+        var remaining = sessionsToStop.count
+        sessionsToStop.forEach { session in
+            session.stop(persistArrangement: false) {
+                remaining -= 1
+                if remaining == 0 {
+                    completion?()
+                }
+            }
+        }
+    }
+
+    func quitAfterUserRequest() {
+        guard !userQuitPending else { return }
+        userQuitPending = true
+
+        // Allow the final teardown reason to reach the Receiver before quitting.
+        stopAll { [weak self] in
+            self?.finishUserRequestedQuit()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.finishUserRequestedQuit()
+        }
+    }
+
+    private func finishUserRequestedQuit() {
+        guard userQuitPending else { return }
+        userQuitPending = false
+        NSApp.terminate(nil)
     }
 
     // MARK: - Session persistence

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -6,6 +6,7 @@ import Darwin
 import Foundation
 import AVFoundation
 import IOSurface
+import IOKit.pwr_mgt
 import Network
 @preconcurrency import ScreenCaptureKit
 import VideoToolbox
@@ -1110,6 +1111,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private var sentSnapshot = 0
     private var sessionAckSent = false
+    private var captureBlockedByScreenRecordingPermission = false
     private var fpsTimer: Timer?
     private var heartbeatTimer: Timer?
     private var firstFrameTimer: Timer?
@@ -1125,6 +1127,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     private var heartbeatSequence: UInt64 = 0
     private var statusState: TBDisplaySenderStatusState = .ready
     private var streamingActivity: NSObjectProtocol?
+    private var displayWakeAssertionID = IOPMAssertionID(0)
     private var lastCheckedCursor: NSCursor?
     private var lastCheckedCursorType: Int = 0
     private var baselineDisplayIDs = Set<CGDirectDisplayID>()
@@ -1534,19 +1537,43 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         }
     }
 
-    func stop(persistArrangement: Bool = true) {
-        stop(resetStatusTo: .stopped, persistArrangement: persistArrangement)
+    func stop(
+        persistArrangement: Bool = true,
+        completion: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        TBSenderAutomation.suspendAutomaticReconnectAfterUserStop()
+        stop(
+            resetStatusTo: .stopped,
+            persistArrangement: persistArrangement,
+            teardownReason: "sender_user_stop",
+            teardownCompletion: completion
+        )
+    }
+
+    /// Internal retry stop. Unlike a GUI Stop, this must not disable the
+    /// LaunchAgent marker that represents the user's monitor-mode choice.
+    func stopForAutomaticReconnect() {
+        stop(
+            resetStatusTo: .stopped,
+            persistArrangement: false,
+            teardownReason: "sender_internal_stop"
+        )
     }
 
     func persistExtendedDisplayArrangementSnapshot() {
         persistExtendedDisplayArrangementIfNeeded()
     }
 
-    private func stop(resetStatusTo status: TBDisplaySenderStatusState?, persistArrangement: Bool = true) {
+    private func stop(
+        resetStatusTo status: TBDisplaySenderStatusState?,
+        persistArrangement: Bool = true,
+        teardownReason: String = "sender_internal_stop",
+        teardownCompletion: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        let connectionToClose = connection
         if persistArrangement {
             persistExtendedDisplayArrangementIfNeeded()
         }
-        sendTeardown(reason: "sender_stop")
         connectTimeoutWorkItem?.cancel()
         connectTimeoutWorkItem = nil
         heartbeatTimer?.invalidate()
@@ -1571,19 +1598,20 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             scStream = nil
         }
         captureDelegate = nil
-        if let activity = streamingActivity {
-            ProcessInfo.processInfo.endActivity(activity)
-            streamingActivity = nil
-        }
+        endCaptureActivity()
         pipeline?.stop()
         pipeline = nil
         releaseInjectedModifiersIfNeeded()
         remoteHeldModifierKeyCodes.removeAll()
         injectedLeftClickTracker.reset()
         suppressedTriggerKeyCode = nil
-        connection?.stateUpdateHandler = nil
-        connection?.cancel()
+        connectionToClose?.stateUpdateHandler = nil
         connection = nil
+        sendTeardownAndClose(
+            reason: teardownReason,
+            over: connectionToClose,
+            completion: teardownCompletion
+        )
         let currentSession = session
         Task { @MainActor in
             currentSession.destroy()
@@ -1783,12 +1811,39 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         send(packet)
     }
 
-    private func sendTeardown(reason: String) {
+    private func sendTeardownAndClose(
+        reason: String,
+        over connection: NWConnection?,
+        completion: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        guard let connection else {
+            completion?()
+            return
+        }
         guard let packet = TBMonitorProtocol.makeJSONPacket(
             type: .teardown,
             value: TBMonitorTeardown(reason: reason)
-        ) else { return }
-        send(packet)
+        ) else {
+            connection.cancel()
+            completion?()
+            return
+        }
+
+        // Preserve the explicit user/internal reason before closing the socket.
+        // Otherwise the Receiver cannot distinguish Stop from a dropped cable.
+        connection.send(
+            content: packet,
+            contentContext: .finalMessage,
+            isComplete: true,
+            completion: .contentProcessed { _ in
+                connection.cancel()
+                guard let completion else { return }
+                Task { @MainActor in completion() }
+            }
+        )
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2.0) {
+            connection.cancel()
+        }
     }
 
     private func receiveLoop(on connection: NWConnection) {
@@ -2267,8 +2322,13 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 return
             }
 
+            // A headless Sender may still expose a sleeping physical display.
+            // Wake and hold the graphical session before virtual display setup.
+            self.beginCaptureActivity()
             self.setStatus(.creatingVirtualDisplay)
-            self.baselineDisplayIDs = await self.fetchShareableDisplayIDs()
+            self.baselineDisplayIDs = self.captureSource == .extendedDesktop
+                ? await self.fetchShareableDisplayIDs()
+                : []
             let receiverKey = self.extendedDisplayIdentityKey(for: profile)
             let modeOverride: TBVirtualDisplayModeSize? = (self.matchRenderToStream && self.captureSource == .extendedDesktop)
                 ? self.capturePreset.renderMatchedDisplayMode
@@ -2293,13 +2353,15 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 return
             }
             if self.captureSource == .desktopMirror {
-                let displayReady = await self.waitForOnlineDisplay(self.session.displayID)
-                let mirrorConfigured = displayReady && self.configureDesktopMirror(for: self.session.displayID)
-                if !mirrorConfigured {
-                    NSLog(
-                        "TargetBridge: unable to enable mirror mode for virtual display %u on first attempt; scheduling retry",
-                        self.session.displayID
-                    )
+                if CGDisplayIsInMirrorSet(self.session.displayID) == 0 {
+                    let displayReady = await self.waitForOnlineDisplay(self.session.displayID)
+                    let mirrorConfigured = displayReady && self.configureDesktopMirror(for: self.session.displayID)
+                    if !mirrorConfigured {
+                        NSLog(
+                            "TargetBridge: unable to enable mirror mode for virtual display %u on first attempt; scheduling retry",
+                            self.session.displayID
+                        )
+                    }
                 }
             }
             self.virtualDisplayText = TBDisplaySenderL10n.virtualDisplaySummary(
@@ -2316,10 +2378,21 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             // armed against a session that has already delivered frames — it then
             // tears down a healthy stream ~4s in. See onFirstFrame wiring below.
             self.sessionAckSent = false
+            self.captureBlockedByScreenRecordingPermission = false
             self.setStatus(.startingCapture(self.capturePreset.description, self.captureSource))
             let started = await self.startCapture(for: profile)
             guard started else {
-                self.stop(resetStatusTo: nil)
+                if self.captureBlockedByScreenRecordingPermission {
+                    self.captureBlockedByScreenRecordingPermission = false
+                    TBSenderAutomation.suspendAutomaticReconnectForRequiredPermission()
+                    self.stop(
+                        resetStatusTo: nil,
+                        persistArrangement: false,
+                        teardownReason: "sender_user_stop"
+                    )
+                } else {
+                    self.stop(resetStatusTo: nil)
+                }
                 return
             }
 
@@ -2336,6 +2409,16 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private func startCapture(for profile: TBMonitorDisplayProfile) async -> Bool {
         do {
+            guard CGPreflightScreenCaptureAccess() else {
+                captureBlockedByScreenRecordingPermission = true
+                _ = CGRequestScreenCaptureAccess()
+                setStatus(.captureDesktopError(
+                    TBDisplaySenderL10n.missingScreenRecordingPermission(language: language)
+                ))
+                TBLog.connection.error("capture: screen recording permission missing; automatic reconnect suspended")
+                return false
+            }
+
             let preset = capturePreset
             let usesRawNV12 = rawNV12Enabled(for: profile)
             let codecType = resolvedCodecType(for: preset, profile: profile)
@@ -2366,11 +2449,14 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
             let display: SCDisplay
             if captureSource == .desktopMirror {
-                let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
-                guard let mainDisplay = content.displays.first(where: { $0.displayID == CGMainDisplayID() }) else {
+                if let mirrorDisplay = try await resolveMirrorCaptureDisplay() {
+                    display = mirrorDisplay
+                } else if let fallbackDisplayID = directMirrorFallbackDisplayID() {
+                    TBLog.connection.warning("capture: no virtual ScreenCaptureKit display; using direct fallback id=\(fallbackDisplayID, privacy: .public)")
+                    return startDirectDisplayStream(displayID: fallbackDisplayID, preset: preset)
+                } else {
                     return false
                 }
-                display = mainDisplay
             } else {
                 let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
                 if session.displayID != kCGNullDirectDisplay,
@@ -2435,10 +2521,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             scStream = stream
             isStreaming = true
             if largeCursor { startCursorUpdates(displayID: display.displayID) }
-            streamingActivity = ProcessInfo.processInfo.beginActivity(
-                options: activityOptions(),
-                reason: "TargetBridge streaming active"
-            )
+            beginCaptureActivity(wakeDisplay: false)
             startFPSTimer()
             startCaptureWatchdog()
             return true
@@ -2450,6 +2533,39 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             }
             return false
         }
+    }
+
+    /// Waking a headless graphical session is asynchronous. Poll briefly for a
+    /// receiver-native ScreenCaptureKit surface before using the direct fallback.
+    private func resolveMirrorCaptureDisplay() async throws -> SCDisplay? {
+        for attempt in 0..<30 {
+            let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            if session.displayID != kCGNullDirectDisplay,
+               let virtualDisplay = content.displays.first(where: { $0.displayID == session.displayID }) {
+                TBLog.connection.info("capture: using receiver-native mirrored display id=\(virtualDisplay.displayID, privacy: .public)")
+                return virtualDisplay
+            }
+            if let mainDisplay = content.displays.first(where: { $0.displayID == CGMainDisplayID() }) {
+                TBLog.connection.info("capture: using main display id=\(mainDisplay.displayID, privacy: .public)")
+                return mainDisplay
+            }
+            if attempt == 0 {
+                TBLog.connection.info("capture: graphical session is waking; waiting for a shareable display")
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return nil
+    }
+
+    private func directMirrorFallbackDisplayID() -> CGDirectDisplayID? {
+        if session.displayID != kCGNullDirectDisplay, CGDisplayIsOnline(session.displayID) != 0 {
+            return session.displayID
+        }
+        let mainDisplayID = CGMainDisplayID()
+        if mainDisplayID != kCGNullDirectDisplay, CGDisplayIsOnline(mainDisplayID) != 0 {
+            return mainDisplayID
+        }
+        return nil
     }
 
     private func startDirectDisplayStream(displayID: CGDirectDisplayID, preset: TBDisplayCapturePreset) -> Bool {
@@ -2473,10 +2589,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         captureDisplayText = TBDisplaySenderL10n.captureDisplayCGDisplayStream(language, id: displayID)
         isStreaming = true
         if largeCursor { startCursorUpdates(displayID: displayID) }
-        streamingActivity = ProcessInfo.processInfo.beginActivity(
-            options: activityOptions(),
-            reason: "TargetBridge streaming active"
-        )
+        beginCaptureActivity(wakeDisplay: false)
         startFPSTimer()
         startCaptureWatchdog()
         return true
@@ -2488,6 +2601,38 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             options.insert(.idleDisplaySleepDisabled)
         }
         return options
+    }
+
+    private func beginCaptureActivity(wakeDisplay: Bool = true) {
+        if streamingActivity == nil {
+            streamingActivity = ProcessInfo.processInfo.beginActivity(
+                options: activityOptions(),
+                reason: "TargetBridge streaming active"
+            )
+        }
+        guard wakeDisplay, preventDisplaySleep else { return }
+
+        let result = IOPMAssertionDeclareUserActivity(
+            "TargetBridge capture requested" as CFString,
+            kIOPMUserActiveLocal,
+            &displayWakeAssertionID
+        )
+        if result == kIOReturnSuccess {
+            TBLog.connection.info("capture: requested graphical-session wake")
+        } else {
+            TBLog.connection.error("capture: unable to wake graphical session result=\(result, privacy: .public)")
+        }
+    }
+
+    private func endCaptureActivity() {
+        if displayWakeAssertionID != 0 {
+            IOPMAssertionRelease(displayWakeAssertionID)
+            displayWakeAssertionID = 0
+        }
+        if let activity = streamingActivity {
+            ProcessInfo.processInfo.endActivity(activity)
+            streamingActivity = nil
+        }
     }
 
     private func waitForCaptureDisplay() async throws -> SCDisplay {
@@ -3088,10 +3233,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             scStream = nil
         }
         captureDelegate = nil
-        if let activity = streamingActivity {
-            ProcessInfo.processInfo.endActivity(activity)
-            streamingActivity = nil
-        }
+        endCaptureActivity()
         pipeline?.stop()
         pipeline = nil
         isStreaming = false
@@ -3101,6 +3243,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         cursorDisplayID = kCGNullDirectDisplay
         lastCursorPacket = nil
 
+        beginCaptureActivity()
         let started = await startCapture(for: profile)
         if !started {
             NSLog("TargetBridge: soft restart after wake failed — falling back to full stop")
@@ -3158,7 +3301,12 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 } else {
                     setStatus(.noFirstFrame)
                 }
-                stop(resetStatusTo: nil)
+                TBSenderAutomation.suspendAutomaticReconnectAfterCaptureFailure()
+                stop(
+                    resetStatusTo: nil,
+                    persistArrangement: false,
+                    teardownReason: "sender_user_stop"
+                )
             }
         }
     }

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderStatusItemController.swift
@@ -7,6 +7,7 @@ final class TBDisplaySenderStatusItemController: NSObject {
     nonisolated(unsafe) private var statusItem: NSStatusItem?
     private var cancellables = Set<AnyCancellable>()
     private var hasActivated = false
+    private var pendingMenuAction: (@MainActor @Sendable () -> Void)?
     // Retains the target objects for the current menu's sliders (NSSlider holds
     // its target weakly). Cleared and rebuilt each time the menu opens.
     private var sliderTargets: [TBMenuSliderTarget] = []
@@ -359,14 +360,13 @@ final class TBDisplaySenderStatusItemController: NSObject {
         }
     }
 
-    // Menu-item handlers run while the menu is still dismissing. Doing work
-    // synchronously here (activating the app, ordering windows front, mutating
-    // observed session state) interrupts the menu window's fade-out: its alpha
-    // animates to 0 but the window is never closed, leaving an invisible
-    // menu-layer window that swallows clicks at the menu's footprint. Deferring
-    // to the next runloop tick lets the menu fully tear down first.
-    private func runAfterMenuDismissal(_ action: @escaping () -> Void) {
-        DispatchQueue.main.async(execute: action)
+    // AppKit's menu uses a nested tracking loop. Run state changes only after it
+    // positively reports closure, avoiding an invisible menu window that can
+    // remain above the streamed desktop and swallow clicks.
+    private func runAfterMenuDismissal(
+        _ action: @escaping @MainActor @Sendable () -> Void
+    ) {
+        pendingMenuAction = action
     }
 
     @objc
@@ -402,8 +402,8 @@ final class TBDisplaySenderStatusItemController: NSObject {
 
     @objc
     private func quitApp() {
-        runAfterMenuDismissal {
-            NSApp.terminate(nil)
+        runAfterMenuDismissal { [service] in
+            service.quitAfterUserRequest()
         }
     }
 }
@@ -411,6 +411,12 @@ final class TBDisplaySenderStatusItemController: NSObject {
 extension TBDisplaySenderStatusItemController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         rebuildMenuItems(in: menu)
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        guard let action = pendingMenuAction else { return }
+        pendingMenuAction = nil
+        DispatchQueue.main.async(execute: action)
     }
 }
 

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
@@ -7,6 +7,69 @@ import XCTest
 /// silently reroute automation traffic.
 @MainActor
 final class TBSenderAutomationParsingTests: XCTestCase {
+    func testSenderEnabledFlagUsesSelectedHomeDirectory() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("targetbridge-automation-path-test", isDirectory: true)
+        XCTAssertEqual(
+            TBSenderAutomation.senderEnabledFlagURL(homeDirectory: root).path,
+            root.appendingPathComponent(
+                "Library/Application Support/TargetBridge/Sender/enabled",
+                isDirectory: false
+            ).path
+        )
+    }
+
+    func testUserStopRemovesAutomaticReconnectMarker() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("targetbridge-user-stop-\(UUID().uuidString)", isDirectory: true)
+        let marker = root.appendingPathComponent("enabled")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: marker.path, contents: Data()))
+
+        TBSenderAutomation.suspendAutomaticReconnectAfterUserStop(enabledFlagURL: marker)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testRequiredPermissionRemovesAutomaticReconnectMarker() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("targetbridge-permission-stop-\(UUID().uuidString)", isDirectory: true)
+        let marker = root.appendingPathComponent("enabled")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: marker.path, contents: Data()))
+
+        TBSenderAutomation.suspendAutomaticReconnectForRequiredPermission(enabledFlagURL: marker)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testCaptureFailureRemovesAutomaticReconnectMarker() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("targetbridge-capture-stop-\(UUID().uuidString)", isDirectory: true)
+        let marker = root.appendingPathComponent("enabled")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: marker.path, contents: Data()))
+
+        TBSenderAutomation.suspendAutomaticReconnectAfterCaptureFailure(enabledFlagURL: marker)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testAutomationFlagsEnableOnPresenceOrTruthyValues() {
+        for value in ["", "1", "true", "yes", "on", "unexpected"] {
+            XCTAssertTrue(TBSenderAutomation.flagEnabled(value), "value \(value)")
+        }
+    }
+
+    func testAutomationFlagsDisableOnMissingOrExplicitFalseValues() {
+        XCTAssertFalse(TBSenderAutomation.flagEnabled(nil))
+        for value in ["0", "false", "FALSE", "no", "off", " Off "] {
+            XCTAssertFalse(TBSenderAutomation.flagEnabled(value), "value \(value)")
+        }
+    }
 
     // MARK: - parseTransport
 

--- a/cli/targetbridge
+++ b/cli/targetbridge
@@ -9,7 +9,7 @@ set -euo pipefail
 #
 # Usage:
 #   targetbridge connect [--receiver auto|<id|name|ip>] [--mode mirror|extended]
-#                        [--preset <name>] [--transport tb|net] [--session N] [--local-ip <ip>]
+#                        [--preset <name>] [--transport tb|net] [--session N] [--local-ip <ip>] [--retry]
 #   targetbridge disconnect [--session N]
 #
 # Examples:

--- a/docs/Automation.md
+++ b/docs/Automation.md
@@ -23,7 +23,7 @@ targetbridge disconnect
 ```
 
 Options: `--receiver auto|<id|name|ip>`, `--mode mirror|extended`, `--preset <name>`,
-`--transport tb|net`, `--session N`, `--local-ip <ip>`.
+`--transport tb|net`, `--session N`, `--local-ip <ip>`, `--retry`.
 Presets: `standard1440p`, `smooth1440p60`, `smooth1800p60`, `crisp2160p60`, `native5k`,
 `native5k60Experimental` (aliases: `1440p`, `1440p60`, `1800p`, `4k`, `5k`, `5k60`).
 `native5k60Experimental` is an opt-in HEVC test profile for 5K at 60 FPS; it does not
@@ -55,6 +55,13 @@ handy for a Login Item or LaunchAgent:
 ```bash
 open -a TargetBridge --args --connect --receiver auto --mode mirror --preset 1440p
 ```
+
+Add `--retry` for monitor mode: the Sender keeps watching the active session and retries
+after transient startup, cable or Receiver failures. An explicit GUI Stop, Command-Q or
+Quit from the menu bar cancels that loop and removes
+`~/Library/Application Support/TargetBridge/Sender/enabled`. A LaunchAgent can use that
+file as a `PathState` marker so crash recovery remains automatic while a user Stop remains
+stopped. Packaging such a LaunchAgent is intentionally outside this change.
 
 ## Recipes
 


### PR DESCRIPTION
## A short story

Thank you for TargetBridge — I really enjoyed its architecture and the possibility it gives old iMacs.

My test setup is a Mac mini M4 with no permanent display and a 21.5-inch 2017 Retina 4K iMac as the Receiver. Once the video was working well, the remaining practical problem was startup: after a reboot or a temporary cable failure, the Mac mini still needed another monitor; conversely, an automatic retry loop could make the iMac impossible to stop. This change is the lifecycle part of that experiment.

It is split from the integrated prototype in #157 and is independent from both USB4 path selection (#159) and Retina 4K capture (#160), so it can be reviewed on its own.

## What this PR adds

- launch-argument automation is handled during app initialization, without depending on SwiftUI opening or restoring the main window;
- `--retry` monitors an active session and retries transient startup, Receiver and cable failures;
- GUI Stop, automation disconnect, Command-Q and menu-bar Quit cancel retry and remove a small `enabled` marker;
- internal recovery uses a separate stop reason and does not clear the user's monitor-mode choice;
- the final teardown reason is delivered before the connection closes, so a Receiver can distinguish a user Stop from a broken link;
- Quit waits for teardown delivery, with a two-second safety ceiling;
- capture wakes and holds the headless graphical session before virtual-display enumeration;
- Screen Recording permission failures and first-frame failures suspend retry instead of looping forever;
- ScreenCaptureKit is polled briefly after wake, then an online display can use the existing direct capture fallback;
- menu actions run only after AppKit confirms the status menu has closed, preventing an invisible menu layer from swallowing clicks.

## State marker

The optional marker is:

`~/Library/Application Support/TargetBridge/Sender/enabled`

This PR only defines its lifecycle semantics. A later, separate installer PR can use it as a LaunchAgent `PathState`: presence means automatic monitor mode is wanted; removal means the user explicitly stopped it. No LaunchAgent or packaging files are included here.

## Validation

- Xcode test suite on the standalone branch: **90 passed, 0 failed, 0 skipped**;
- six focused tests cover marker paths, user/permission/capture stop behavior and retry-flag parsing;
- CLI syntax and `git diff --check` passed.

The integrated hardware prototype was also exercised across three Sender restarts and one Receiver restart, recovering in approximately 3.1–7.4 seconds. That run is supporting hardware evidence; the reproducible validation for this intentionally standalone PR is the suite above.

## Deliberately out of scope

- selecting or measuring USB4/Thunderbolt/Ethernet/Wi-Fi paths;
- the Retina 4K profile and frame-rate changes;
- Receiver-side Start/Stop UI and remote recovery transport;
- keyboard, mouse or clipboard relay;
- installer and LaunchAgent creation.
