### PR TITLE
Keep fullscreen Receiver video above local notifications

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -496,13 +496,17 @@ static void tb_disp_rebuild_status_texture(struct tb_display *d,
 static void tb_disp_refresh_window_mode(struct tb_display *d) {
     if (!d || !d->win) return;
 
-    if ((d->is_connected || d->is_connecting) && d->preferred_fullscreen) {
+    const int monitor_shield_active =
+        (d->is_connected || d->is_connecting) && d->preferred_fullscreen;
+
+    if (monitor_shield_active) {
         SDL_SetWindowFullscreen(d->win, SDL_WINDOW_FULLSCREEN_DESKTOP);
     } else {
         SDL_SetWindowFullscreen(d->win, 0);
         SDL_SetWindowSize(d->win, 980, 620);
         SDL_SetWindowPosition(d->win, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
     }
+    tb_receiver_set_monitor_shield(monitor_shield_active);
 
     const int should_hide_cursor =
         ((d->is_connected || d->is_connecting) && d->preferred_fullscreen) ||

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
@@ -10,4 +10,8 @@ void tb_gesture_bridge_set_active(int active);
  * Space (or can't be determined), 0 if it is on a different Space. */
 int tb_window_on_active_space(void *sdl_window);
 
+/* Keep the fullscreen monitor surface above Notification Center while a
+ * session is active, restoring the normal window level on Stop/disconnect. */
+void tb_receiver_set_monitor_shield(int active);
+
 #endif

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
@@ -3,6 +3,64 @@
 #import <AppKit/AppKit.h>
 #include <stdio.h>
 
+static NSWindow *tb_receiver_content_window(void) {
+    NSWindow *content = nil;
+    CGFloat best_area = 0.0;
+    for (NSWindow *window in NSApp.windows) {
+        if (!window.isVisible) continue;
+        NSSize size = window.frame.size;
+        CGFloat area = size.width * size.height;
+        if (area < 200.0 * 200.0) continue;
+        if (area > best_area) {
+            best_area = area;
+            content = window;
+        }
+    }
+    return content;
+}
+
+static BOOL g_monitor_shield_active = NO;
+
+static void tb_apply_monitor_shield(void) {
+    NSWindow *content = tb_receiver_content_window();
+    if (!content) return;
+
+    /* The public status-window level keeps ordinary local banners and the menu
+     * bar behind the active monitor surface without using invasive private or
+     * screen-saver window levels. */
+    NSWindowLevel desired = g_monitor_shield_active
+        ? (NSWindowLevel)CGWindowLevelForKey(kCGStatusWindowLevelKey)
+        : NSNormalWindowLevel;
+    if (content.level != desired) {
+        content.level = desired;
+    }
+}
+
+void tb_receiver_set_monitor_shield(int active) {
+    @autoreleasepool {
+        BOOL normalized = active ? YES : NO;
+        BOOL changed = normalized != g_monitor_shield_active;
+        g_monitor_shield_active = normalized;
+        tb_apply_monitor_shield();
+
+        /* SDL completes part of its native fullscreen transition after the
+         * call returns. Reapply the latest desired state once afterward. */
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 300 * NSEC_PER_MSEC),
+                       dispatch_get_main_queue(), ^{
+            tb_apply_monitor_shield();
+        });
+
+        if (changed) {
+            fprintf(stderr,
+                    "[display] monitor shield=%d level=%ld\n",
+                    normalized ? 1 : 0,
+                    (long)(normalized
+                        ? CGWindowLevelForKey(kCGStatusWindowLevelKey)
+                        : NSNormalWindowLevel));
+        }
+    }
+}
+
 int tb_window_on_active_space(void *sdl_window) {
     /* Whether the receiver's content window is on the Space the user is
      * currently viewing. Used to gate receiverMaster forwarding so local work
@@ -17,16 +75,9 @@ int tb_window_on_active_space(void *sdl_window) {
      * remains the active application on another Space. */
     (void)sdl_window;
 
-    NSWindow *content = nil;
-    CGFloat best_area = 0.0;
-    NSArray<NSWindow *> *windows = [NSApp windows];
-    for (NSWindow *w in windows) {
-        if (!w.isVisible) continue;
-        NSSize s = w.frame.size;
-        CGFloat area = s.width * s.height;
-        if (area < 200.0 * 200.0) continue;   /* skip tiny status/aux windows */
-        if (area > best_area) { best_area = area; content = w; }
-    }
+    NSWindow *content = tb_receiver_content_window();
+    CGFloat best_area = content ? content.frame.size.width * content.frame.size.height : 0.0;
+    NSArray<NSWindow *> *windows = NSApp.windows;
 
     /* Fail open (forward) only when we genuinely can't find a content window. */
     int on_active = content ? (content.isOnActiveSpace ? 1 : 0) : 1;


### PR DESCRIPTION
## A short story

Thank you again for TargetBridge. While using a 21.5-inch 2017 Retina 4K iMac as the Receiver for a Mac mini M4, the streamed desktop itself worked very well, but local iMac notification banners could remain above the fullscreen video and hide the top-right corner. This small PR isolates only that visual issue from the larger experiment in #157.

It does not depend on USB4 selection (#159), Retina 4K capture (#160) or headless lifecycle changes (#161).

## What changes

- when the Receiver enters an active fullscreen session, its native Cocoa content window is raised to the public status-window level;
- on Stop/disconnect or when fullscreen is disabled, the normal window level is restored;
- the desired level is reapplied once 300 ms after SDL's fullscreen call because the native transition completes asynchronously;
- the delayed callback reads the latest state, so a rapid Stop cannot raise the window again with stale data;
- the existing largest-content-window lookup is shared with the active-Space check instead of duplicated.

The implementation uses only public AppKit/CoreGraphics window levels. It does not change Focus, hide all notifications globally, use private APIs or use the more invasive screen-saver/shielding levels.

## Validation

- the complete Receiver builds successfully, including the Objective-C Cocoa bridge;
- Receiver parser suite: **60 checks passed**;
- `git diff --check` clean.

The same behavior was also observed on the actual 2017 iMac Receiver: local login-item notifications no longer remained over the Mac mini video, and normal window behavior returned after leaving the session.

## Scope

Three Receiver files only; no Sender, protocol, networking, input, audio, installer or version changes.
