### PR TITLE
Receiver: preserve key and button releases under queue pressure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ tbreceiver
 
 # C test outputs
 test_net_parser
+test_input_queue
 *.dSYM/

--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -34,7 +34,7 @@ ifeq ($(UNAME_S),Darwin)
 LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices -framework CoreAudio -framework SystemConfiguration
 endif
 
-C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/tb_i18n.c
+C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/input_queue.c src/tb_i18n.c
 OBJC_SRC = src/tb_gesture_bridge.m src/tb_display_tweaks.m
 OBJ = $(C_SRC:.c=.o) $(OBJC_SRC:.m=.o)
 BIN = tbreceiver
@@ -51,7 +51,7 @@ $(BIN): $(OBJ)
 	$(CC) $(CFLAGS) -fobjc-arc -c -o $@ $<
 
 clean:
-	rm -f $(OBJ) $(BIN) $(TEST_BIN)
+	rm -f $(OBJ) $(BIN) $(TEST_BIN) $(TEST_INPUT_QUEUE_BIN)
 
 # Unit tests for the packet parser. net.c is pure POSIX, so this needs no
 # ffmpeg/SDL/pkgconf — it runs anywhere, including CI, with no hardware.
@@ -61,11 +61,16 @@ ifeq ($(UNAME_S),Darwin)
 TEST_LDFLAGS += -framework CoreFoundation -framework SystemConfiguration
 endif
 TEST_BIN = test_net_parser
+TEST_INPUT_QUEUE_BIN = test_input_queue
 
 $(TEST_BIN): tests/test_net_parser.c src/net.c src/net.h src/proto.h
 	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c $(TEST_LDFLAGS) -o $@
 
-test: $(TEST_BIN)
+$(TEST_INPUT_QUEUE_BIN): tests/test_input_queue.c src/input_queue.c src/input_queue.h
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_input_queue.c src/input_queue.c -o $@
+
+test: $(TEST_BIN) $(TEST_INPUT_QUEUE_BIN)
 	./$(TEST_BIN)
+	./$(TEST_INPUT_QUEUE_BIN)
 
 .PHONY: all clean test

--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -40,9 +40,7 @@ struct tb_display {
     int           is_connecting;
     int           input_capture_active;
     int           input_intercept_active;
-    struct tb_input_event input_events[128];
-    int           input_head;
-    int           input_tail;
+    struct tb_input_queue input_queue;
     uint32_t      last_target_switch_tick;
     uint32_t      last_space_switch_tick;
     uint32_t      last_space_gesture_tick;
@@ -182,12 +180,7 @@ static uint16_t tb_disp_mac_keycode_for_sdl_scancode(SDL_Scancode scancode) {
 
 static void tb_disp_queue_input_event(struct tb_display *d, const struct tb_input_event *event) {
     if (!d || !event) return;
-    int next = (d->input_head + 1) % 128;
-    if (next == d->input_tail) {
-        d->input_tail = (d->input_tail + 1) % 128;
-    }
-    d->input_events[d->input_head] = *event;
-    d->input_head = next;
+    (void)tb_input_queue_push(&d->input_queue, event);
 }
 
 static void tb_disp_destroy_status_texture(struct tb_display *d) {
@@ -1313,10 +1306,7 @@ unsigned int tb_disp_poll_actions(struct tb_display *d) {
 
 int tb_disp_pop_input_event(struct tb_display *d, struct tb_input_event *out) {
     if (!d || !out) return 0;
-    if (d->input_tail == d->input_head) return 0;
-    *out = d->input_events[d->input_tail];
-    d->input_tail = (d->input_tail + 1) % 128;
-    return 1;
+    return tb_input_queue_pop(&d->input_queue, out);
 }
 
 int tb_disp_get_info(struct tb_display *d, struct tb_display_info *info) {

--- a/TargetBridge-Receiver/TBReceiverC/src/display.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "input_queue.h"
+
 struct tb_display;
 
 struct tb_display_info {
@@ -22,38 +24,6 @@ enum tb_display_action {
     TB_DISP_ACTION_NONE = 0,
     TB_DISP_ACTION_QUIT = 1 << 0,
     TB_DISP_ACTION_CYCLE_LANGUAGE = 1 << 1
-};
-
-enum tb_input_event_kind {
-    TB_INPUT_EVENT_NONE = 0,
-    TB_INPUT_EVENT_MOVE,
-    TB_INPUT_EVENT_LEFT_DRAG,
-    TB_INPUT_EVENT_RIGHT_DRAG,
-    TB_INPUT_EVENT_OTHER_DRAG,
-    TB_INPUT_EVENT_SCROLL,
-    TB_INPUT_EVENT_LEFT_DOWN,
-    TB_INPUT_EVENT_LEFT_UP,
-    TB_INPUT_EVENT_RIGHT_DOWN,
-    TB_INPUT_EVENT_RIGHT_UP,
-    TB_INPUT_EVENT_OTHER_DOWN,
-    TB_INPUT_EVENT_OTHER_UP,
-    TB_INPUT_EVENT_KEY_DOWN,
-    TB_INPUT_EVENT_KEY_UP,
-    TB_INPUT_EVENT_SWITCH_PREV_TARGET,
-    TB_INPUT_EVENT_SWITCH_NEXT_TARGET,
-    TB_INPUT_EVENT_SWITCH_PREV_SPACE,
-    TB_INPUT_EVENT_SWITCH_NEXT_SPACE,
-    TB_INPUT_EVENT_DEACTIVATE_CONTROL
-};
-
-struct tb_input_event {
-    enum tb_input_event_kind kind;
-    int dx;
-    int dy;
-    int scroll_x;
-    int scroll_y;
-    uint16_t key_code;
-    int click_count;
 };
 
 struct tb_display *tb_disp_create(int fullscreen);

--- a/TargetBridge-Receiver/TBReceiverC/src/input_queue.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/input_queue.c
@@ -1,0 +1,68 @@
+#include "input_queue.h"
+
+#include <string.h>
+
+static int tb_input_event_is_lossy(enum tb_input_event_kind kind) {
+    return kind == TB_INPUT_EVENT_MOVE ||
+           kind == TB_INPUT_EVENT_LEFT_DRAG ||
+           kind == TB_INPUT_EVENT_RIGHT_DRAG ||
+           kind == TB_INPUT_EVENT_OTHER_DRAG ||
+           kind == TB_INPUT_EVENT_SCROLL;
+}
+
+static size_t tb_input_queue_index(const struct tb_input_queue *queue,
+                                   size_t logical_index) {
+    return (queue->head + logical_index) % TB_INPUT_QUEUE_CAPACITY;
+}
+
+static int tb_input_queue_remove_oldest_lossy(struct tb_input_queue *queue) {
+    size_t lossy_index = queue->count;
+    for (size_t i = 0; i < queue->count; i++) {
+        if (tb_input_event_is_lossy(queue->events[tb_input_queue_index(queue, i)].kind)) {
+            lossy_index = i;
+            break;
+        }
+    }
+    if (lossy_index == queue->count) return 0;
+
+    for (size_t i = lossy_index; i + 1 < queue->count; i++) {
+        queue->events[tb_input_queue_index(queue, i)] =
+            queue->events[tb_input_queue_index(queue, i + 1)];
+    }
+    queue->count--;
+    return 1;
+}
+
+int tb_input_queue_push(struct tb_input_queue *queue,
+                        const struct tb_input_event *event) {
+    if (!queue || !event) return 0;
+
+    if (queue->count == TB_INPUT_QUEUE_CAPACITY) {
+        if (!tb_input_queue_remove_oldest_lossy(queue)) {
+            if (tb_input_event_is_lossy(event->kind)) {
+                return 0;
+            }
+
+            /* A queue made entirely of lifecycle events cannot safely discard
+             * an arbitrary key/button transition. Collapse it to the existing
+             * fail-safe command so the Sender releases every held input. */
+            memset(queue, 0, sizeof(*queue));
+            queue->events[0].kind = TB_INPUT_EVENT_DEACTIVATE_CONTROL;
+            queue->count = 1;
+            return -1;
+        }
+    }
+
+    queue->events[tb_input_queue_index(queue, queue->count)] = *event;
+    queue->count++;
+    return 1;
+}
+
+int tb_input_queue_pop(struct tb_input_queue *queue,
+                       struct tb_input_event *event) {
+    if (!queue || !event || queue->count == 0) return 0;
+    *event = queue->events[queue->head];
+    queue->head = (queue->head + 1) % TB_INPUT_QUEUE_CAPACITY;
+    queue->count--;
+    return 1;
+}

--- a/TargetBridge-Receiver/TBReceiverC/src/input_queue.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/input_queue.h
@@ -1,0 +1,54 @@
+#ifndef TB_INPUT_QUEUE_H
+#define TB_INPUT_QUEUE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define TB_INPUT_QUEUE_CAPACITY 128
+
+enum tb_input_event_kind {
+    TB_INPUT_EVENT_NONE = 0,
+    TB_INPUT_EVENT_MOVE,
+    TB_INPUT_EVENT_LEFT_DRAG,
+    TB_INPUT_EVENT_RIGHT_DRAG,
+    TB_INPUT_EVENT_OTHER_DRAG,
+    TB_INPUT_EVENT_SCROLL,
+    TB_INPUT_EVENT_LEFT_DOWN,
+    TB_INPUT_EVENT_LEFT_UP,
+    TB_INPUT_EVENT_RIGHT_DOWN,
+    TB_INPUT_EVENT_RIGHT_UP,
+    TB_INPUT_EVENT_OTHER_DOWN,
+    TB_INPUT_EVENT_OTHER_UP,
+    TB_INPUT_EVENT_KEY_DOWN,
+    TB_INPUT_EVENT_KEY_UP,
+    TB_INPUT_EVENT_SWITCH_PREV_TARGET,
+    TB_INPUT_EVENT_SWITCH_NEXT_TARGET,
+    TB_INPUT_EVENT_SWITCH_PREV_SPACE,
+    TB_INPUT_EVENT_SWITCH_NEXT_SPACE,
+    TB_INPUT_EVENT_DEACTIVATE_CONTROL
+};
+
+struct tb_input_event {
+    enum tb_input_event_kind kind;
+    int dx;
+    int dy;
+    int scroll_x;
+    int scroll_y;
+    uint16_t key_code;
+    int click_count;
+};
+
+struct tb_input_queue {
+    struct tb_input_event events[TB_INPUT_QUEUE_CAPACITY];
+    size_t head;
+    size_t count;
+};
+
+/* Returns 1 when the event was queued, 0 when a lossy motion event was
+ * discarded, and -1 when overload forced a safe control deactivation. */
+int tb_input_queue_push(struct tb_input_queue *queue,
+                        const struct tb_input_event *event);
+int tb_input_queue_pop(struct tb_input_queue *queue,
+                       struct tb_input_event *event);
+
+#endif

--- a/TargetBridge-Receiver/TBReceiverC/tests/test_input_queue.c
+++ b/TargetBridge-Receiver/TBReceiverC/tests/test_input_queue.c
@@ -1,0 +1,121 @@
+#include "input_queue.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int checks = 0;
+static int failures = 0;
+
+#define CHECK(condition, message) do { \
+    checks++; \
+    if (!(condition)) { \
+        fprintf(stderr, "FAIL: %s\n", message); \
+        failures++; \
+    } \
+} while (0)
+
+static struct tb_input_event event(enum tb_input_event_kind kind, int value) {
+    struct tb_input_event result;
+    memset(&result, 0, sizeof(result));
+    result.kind = kind;
+    result.dx = value;
+    result.key_code = (uint16_t)value;
+    return result;
+}
+
+int main(void) {
+    struct tb_input_queue queue = {0};
+    struct tb_input_event out;
+    int saw_down = 0;
+    int saw_up = 0;
+
+    struct tb_input_event first = event(TB_INPUT_EVENT_KEY_DOWN, 12);
+    struct tb_input_event second = event(TB_INPUT_EVENT_KEY_UP, 12);
+    CHECK(tb_input_queue_push(&queue, &first) == 1, "first event queued");
+    CHECK(tb_input_queue_push(&queue, &second) == 1, "second event queued");
+    CHECK(tb_input_queue_pop(&queue, &out) == 1 && out.kind == TB_INPUT_EVENT_KEY_DOWN,
+          "queue preserves FIFO order");
+    CHECK(tb_input_queue_pop(&queue, &out) == 1 && out.kind == TB_INPUT_EVENT_KEY_UP,
+          "queue preserves key release");
+
+    /* Exercise the same overflow policy after the circular head has wrapped. */
+    memset(&queue, 0, sizeof(queue));
+    for (int i = 0; i < 16; i++) {
+        struct tb_input_event warmup = event(TB_INPUT_EVENT_MOVE, i);
+        CHECK(tb_input_queue_push(&queue, &warmup) == 1, "wrap warmup queued");
+    }
+    for (int i = 0; i < 16; i++) {
+        CHECK(tb_input_queue_pop(&queue, &out) == 1, "wrap warmup popped");
+    }
+    for (int i = 0; i < TB_INPUT_QUEUE_CAPACITY - 1; i++) {
+        struct tb_input_event wrapped_move = event(TB_INPUT_EVENT_MOVE, 1000 + i);
+        CHECK(tb_input_queue_push(&queue, &wrapped_move) == 1, "wrapped motion queued");
+    }
+    CHECK(tb_input_queue_push(&queue, &first) == 1, "wrapped key down fills queue");
+    CHECK(tb_input_queue_push(&queue, &second) == 1,
+          "wrapped overflow preserves key release");
+    while (tb_input_queue_pop(&queue, &out)) {
+        if (out.kind == TB_INPUT_EVENT_KEY_DOWN) saw_down++;
+        if (out.kind == TB_INPUT_EVENT_KEY_UP) saw_up++;
+    }
+    CHECK(saw_down == 1 && saw_up == 1,
+          "wrapped eviction preserves lifecycle order");
+
+    memset(&queue, 0, sizeof(queue));
+    for (int i = 0; i < TB_INPUT_QUEUE_CAPACITY - 1; i++) {
+        struct tb_input_event move = event(TB_INPUT_EVENT_MOVE, i);
+        CHECK(tb_input_queue_push(&queue, &move) == 1, "motion burst queued");
+    }
+    CHECK(tb_input_queue_push(&queue, &first) == 1, "key down fills queue");
+    CHECK(tb_input_queue_push(&queue, &second) == 1,
+          "key up evicts motion instead of being discarded");
+    saw_down = 0;
+    saw_up = 0;
+    while (tb_input_queue_pop(&queue, &out)) {
+        if (out.kind == TB_INPUT_EVENT_KEY_DOWN) saw_down++;
+        if (out.kind == TB_INPUT_EVENT_KEY_UP) saw_up++;
+    }
+    CHECK(saw_down == 1, "key down survives motion overflow");
+    CHECK(saw_up == 1, "key up survives motion overflow");
+
+    memset(&queue, 0, sizeof(queue));
+    for (int i = 0; i < TB_INPUT_QUEUE_CAPACITY - 1; i++) {
+        struct tb_input_event move = event(TB_INPUT_EVENT_MOVE, i);
+        CHECK(tb_input_queue_push(&queue, &move) == 1, "mouse motion burst queued");
+    }
+    struct tb_input_event left_down = event(TB_INPUT_EVENT_LEFT_DOWN, 0);
+    struct tb_input_event left_up = event(TB_INPUT_EVENT_LEFT_UP, 0);
+    CHECK(tb_input_queue_push(&queue, &left_down) == 1, "mouse down fills queue");
+    CHECK(tb_input_queue_push(&queue, &left_up) == 1,
+          "mouse up evicts motion instead of being discarded");
+    saw_down = 0;
+    saw_up = 0;
+    while (tb_input_queue_pop(&queue, &out)) {
+        if (out.kind == TB_INPUT_EVENT_LEFT_DOWN) saw_down++;
+        if (out.kind == TB_INPUT_EVENT_LEFT_UP) saw_up++;
+    }
+    CHECK(saw_down == 1, "mouse down survives motion overflow");
+    CHECK(saw_up == 1, "mouse up survives motion overflow");
+
+    memset(&queue, 0, sizeof(queue));
+    for (int i = 0; i < TB_INPUT_QUEUE_CAPACITY; i++) {
+        struct tb_input_event critical = event(TB_INPUT_EVENT_KEY_DOWN, i);
+        CHECK(tb_input_queue_push(&queue, &critical) == 1, "critical event queued");
+    }
+    struct tb_input_event move = event(TB_INPUT_EVENT_MOVE, 5);
+    CHECK(tb_input_queue_push(&queue, &move) == 0,
+          "lossy motion is discarded before a lifecycle event");
+    CHECK(queue.count == TB_INPUT_QUEUE_CAPACITY,
+          "discarded motion leaves critical queue intact");
+
+    CHECK(tb_input_queue_push(&queue, &second) == -1,
+          "critical-only overflow requests safe deactivation");
+    CHECK(queue.count == 1, "unsafe backlog is collapsed");
+    CHECK(tb_input_queue_pop(&queue, &out) == 1 &&
+          out.kind == TB_INPUT_EVENT_DEACTIVATE_CONTROL,
+          "overflow emits the existing release-all command");
+    CHECK(tb_input_queue_pop(&queue, &out) == 0, "queue is empty after fail-safe");
+
+    printf("input queue tests: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Context

I have been using TargetBridge to reuse a 2017 4K iMac as the display and input station for a Mac mini M4 over a direct USB4/Thunderbolt Bridge link. It has been a great fit for that setup. While testing Receiver Master input and repeated reconnects, I found a small failure mode worth isolating from the larger feature work.

## Problem

The SDL fallback input queue is a fixed 128-event ring. When it fills, it currently overwrites the oldest event without considering its type. Under a burst of mouse motion or scrolling, this can discard a key-up or mouse-button-up event and leave the Sender with a logically held key or button.

## Change

- Move the queue policy into a small standalone module.
- Treat motion, drag and scroll events as lossy.
- Under pressure, evict the oldest lossy event before any key/button lifecycle event.
- If the queue contains only critical events, collapse to the existing deactivate-control fail-safe so the Sender releases all held input.
- Keep the queue bounded and preserve FIFO order in normal operation.

There is no protocol change.

## Validation

- Receiver parser tests: 67 checks passed.
- Input queue tests: 562 checks passed, including wraparound and key/button release survival.
- Queue tests also passed with AddressSanitizer and UndefinedBehaviorSanitizer.
- Full Receiver builds passed for arm64 and x86_64.
- Hardware-tested on a 2017 21.5-inch 4K iMac and Mac mini M4 over a direct USB4/Thunderbolt Bridge link.
- Three Receiver restart cycles and two Sender restart cycles reconnected successfully; input-state probes reported no held modifiers or mouse buttons after every cycle.

I am opening this as a draft so the queue policy and fail-safe behavior can be reviewed independently.