### PR TITLE
Sender: use low-latency cursor overlay in Receiver Master

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -350,6 +350,18 @@ enum TBInputControlRole: String, CaseIterable, Identifiable {
     case receiverMaster
 
     var id: String { rawValue }
+
+    func usesLowLatencyCursorOverlay(largeCursorEnabled: Bool) -> Bool {
+        largeCursorEnabled || self == .receiverMaster
+    }
+
+    func changesCursorCaptureMode(
+        from previousRole: TBInputControlRole,
+        largeCursorEnabled: Bool
+    ) -> Bool {
+        usesLowLatencyCursorOverlay(largeCursorEnabled: largeCursorEnabled)
+            != previousRole.usesLowLatencyCursorOverlay(largeCursorEnabled: largeCursorEnabled)
+    }
 }
 
 enum TBInputGestureMode: String, CaseIterable, Identifiable {
@@ -1179,6 +1191,10 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     }
     @Published var inputControlRole: TBInputControlRole = .off {
         didSet {
+            let cursorCaptureModeChanged = inputControlRole.changesCursorCaptureMode(
+                from: oldValue,
+                largeCursorEnabled: largeCursor
+            )
             inputRelayActive = (inputControlRole == .senderMaster)
             if inputControlRole != .receiverMaster {
                 injectedRemoteMouseLocation = nil
@@ -1186,6 +1202,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 releaseInjectedModifiersIfNeeded()
                 remoteHeldModifierKeyCodes.removeAll()
                 suppressedTriggerKeyCode = nil
+            }
+            if cursorCaptureModeChanged, isStreaming {
+                restartCaptureNow()
             }
         }
     }
@@ -2567,6 +2586,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 }
             }
 
+            let usesCursorOverlay = inputControlRole.usesLowLatencyCursorOverlay(
+                largeCursorEnabled: largeCursor
+            )
             let configuration = SCStreamConfiguration()
             configuration.width = preset.width
             configuration.height = preset.height
@@ -2574,7 +2596,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             configuration.queueDepth = preset.queueDepth
             configuration.pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
             configuration.shouldBeOpaque = true
-            configuration.showsCursor = !largeCursor
+            configuration.showsCursor = !usesCursorOverlay
             configuration.scalesToFit = true
             configuration.captureResolution = preset.captureResolution
             configuration.capturesAudio = shouldRelayAudio
@@ -2626,7 +2648,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             try await stream.startCapture()
             scStream = stream
             isStreaming = true
-            if largeCursor { startCursorUpdates(displayID: display.displayID) }
+            if usesCursorOverlay { startCursorUpdates(displayID: display.displayID) }
             beginCaptureActivity(wakeDisplay: false)
             startFPSTimer()
             startCaptureWatchdog()
@@ -2676,6 +2698,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private func startDirectDisplayStream(displayID: CGDirectDisplayID, preset: TBDisplayCapturePreset) -> Bool {
         guard let pipeline else { return false }
+        let usesCursorOverlay = inputControlRole.usesLowLatencyCursorOverlay(
+            largeCursorEnabled: largeCursor
+        )
         let codecName = activeCodecName ?? codecName(for: activeCodecType ?? preset.codecType)
         streamResolutionText = TBDisplaySenderL10n.streamSummary(
             preset: preset,
@@ -2687,14 +2712,14 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         // Deliver frames straight onto the pipeline's own queue — the handler
         // runs there, so encode happens off the main thread with no extra hop.
         let directCapture = TBDirectDisplayStreamCapture(pipeline: pipeline, queue: pipeline.queue)
-        guard directCapture.start(displayID: displayID, preset: preset, showCursor: !largeCursor) else {
+        guard directCapture.start(displayID: displayID, preset: preset, showCursor: !usesCursorOverlay) else {
             return false
         }
 
         directDisplayStream = directCapture
         captureDisplayText = TBDisplaySenderL10n.captureDisplayCGDisplayStream(language, id: displayID)
         isStreaming = true
-        if largeCursor { startCursorUpdates(displayID: displayID) }
+        if usesCursorOverlay { startCursorUpdates(displayID: displayID) }
         beginCaptureActivity(wakeDisplay: false)
         startFPSTimer()
         startCaptureWatchdog()
@@ -3076,7 +3101,10 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             return
         }
 
-        guard largeCursor, isStreaming, cursorDisplayID != kCGNullDirectDisplay else { return }
+        let usesCursorOverlay = inputControlRole.usesLowLatencyCursorOverlay(
+            largeCursorEnabled: largeCursor
+        )
+        guard usesCursorOverlay, isStreaming, cursorDisplayID != kCGNullDirectDisplay else { return }
         startCursorUpdates(displayID: cursorDisplayID)
     }
 

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBSenderAutomationParsingTests.swift
@@ -8,6 +8,54 @@ import XCTest
 /// silently reroute automation traffic.
 @MainActor
 final class TBSenderAutomationParsingTests: XCTestCase {
+    func testReceiverControlUsesSeparateCursorOverlayWithoutLargeCursor() {
+        XCTAssertTrue(
+            TBInputControlRole.receiverMaster.usesLowLatencyCursorOverlay(
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            TBInputControlRole.senderMaster.usesLowLatencyCursorOverlay(
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            TBInputControlRole.off.usesLowLatencyCursorOverlay(
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertTrue(
+            TBInputControlRole.off.usesLowLatencyCursorOverlay(
+                largeCursorEnabled: true
+            )
+        )
+
+        XCTAssertTrue(
+            TBInputControlRole.receiverMaster.changesCursorCaptureMode(
+                from: .off,
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertTrue(
+            TBInputControlRole.off.changesCursorCaptureMode(
+                from: .receiverMaster,
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            TBInputControlRole.senderMaster.changesCursorCaptureMode(
+                from: .off,
+                largeCursorEnabled: false
+            )
+        )
+        XCTAssertFalse(
+            TBInputControlRole.receiverMaster.changesCursorCaptureMode(
+                from: .off,
+                largeCursorEnabled: true
+            )
+        )
+    }
+
     func testHighFrameRatePresetsUseFiveCaptureSurfaces() {
         XCTAssertEqual(TBDisplayCapturePreset.standard1440p.queueDepth, 3)
         XCTAssertEqual(TBDisplayCapturePreset.smooth1440p60.queueDepth, 5)


### PR DESCRIPTION
## Context

While using Receiver Master on a 2017 4K iMac connected to a Mac mini M4, I found that cursor handling is better kept on TargetBridge's existing low-latency cursor channel instead of being baked into the video stream. This is a small, focused extraction from the hardware-tested setup.

## Problem

With Receiver Master enabled and Large Cursor disabled, the Sender still includes the macOS cursor in captured frames. A Receiver that presents its control cursor can therefore show both the delayed video cursor and the local/overlay cursor.

## Change

- Treat Receiver Master as a low-latency cursor-overlay mode.
- Exclude the captured cursor in both ScreenCaptureKit and direct CGDisplayStream paths.
- Start the existing cursor packet updates for Receiver Master even when Large Cursor is off.
- Soft-restart capture only when a live role change crosses between captured-cursor and overlay-cursor modes.
- Keep Off and Sender Master behavior unchanged; Large Cursor continues to force the overlay as before.

There is no protocol change.

## Validation

- All 110 Sender unit tests passed.
- Added focused coverage for role-to-cursor-mode selection and live role transitions.
- Hardware-tested on a 2017 21.5-inch 4K iMac and Mac mini M4 over a direct USB4/Thunderbolt Bridge link.
- Manual Receiver Master testing confirmed a single responsive cursor.
- Repeated Sender and Receiver reconnect cycles returned to an established session without stale input state.

I am opening this separately as a draft so cursor transport can be reviewed without the other Receiver/input changes.