### PR TITLE
fix(receiver): advertise the physical display profile

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/Makefile
+++ b/TargetBridge-Receiver/TBReceiverC/Makefile
@@ -34,7 +34,7 @@ ifeq ($(UNAME_S),Darwin)
 LDFLAGS  += -framework ApplicationServices -framework AppKit -framework CoreFoundation -framework CoreGraphics -framework CoreText -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework IOSurface -framework CoreServices -framework CoreAudio -framework SystemConfiguration
 endif
 
-C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/tb_i18n.c
+C_SRC = src/main.c src/net.c src/decoder.c src/display.c src/receiver_profile.c src/tb_i18n.c
 OBJC_SRC = src/tb_gesture_bridge.m src/tb_display_tweaks.m
 OBJ = $(C_SRC:.c=.o) $(OBJC_SRC:.m=.o)
 BIN = tbreceiver
@@ -60,12 +60,16 @@ TEST_LDFLAGS =
 ifeq ($(UNAME_S),Darwin)
 TEST_LDFLAGS += -framework CoreFoundation -framework SystemConfiguration
 endif
-TEST_BIN = test_net_parser
+TEST_BIN = test_net_parser test_receiver_profile
 
-$(TEST_BIN): tests/test_net_parser.c src/net.c src/net.h src/proto.h
+test_net_parser: tests/test_net_parser.c src/net.c src/net.h src/proto.h
 	$(CC) $(TEST_CFLAGS) -Isrc tests/test_net_parser.c src/net.c $(TEST_LDFLAGS) -o $@
 
 test: $(TEST_BIN)
-	./$(TEST_BIN)
+	./test_net_parser
+	./test_receiver_profile
+
+test_receiver_profile: tests/test_receiver_profile.c src/receiver_profile.c src/receiver_profile.h
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_receiver_profile.c src/receiver_profile.c -o $@
 
 .PHONY: all clean test

--- a/TargetBridge-Receiver/TBReceiverC/src/display.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.c
@@ -1329,8 +1329,10 @@ int tb_disp_get_info(struct tb_display *d, struct tb_display_info *info) {
 
     SDL_DisplayMode mode;
     if (SDL_GetCurrentDisplayMode(display_index, &mode) == 0) {
-        info->active_w = (uint32_t)mode.w;
-        info->active_h = (uint32_t)mode.h;
+        info->logical_w = (uint32_t)mode.w;
+        info->logical_h = (uint32_t)mode.h;
+        info->active_w = info->logical_w;
+        info->active_h = info->logical_h;
     }
 
     int window_w = 0, window_h = 0;
@@ -1341,12 +1343,17 @@ int tb_disp_get_info(struct tb_display *d, struct tb_display_info *info) {
         info->drawable_h = (uint32_t)drawable_h;
     }
 
-    /* On Retina/5K macOS displays SDL_GetCurrentDisplayMode may report the
-     * logical desktop size (for example 2560x1440) while the renderer
-     * drawable exposes the true backing pixel size (for example 5120x2880).
-     * For the TB stream UI we want the actual panel pixel size. */
-    if (info->drawable_w > info->active_w) info->active_w = info->drawable_w;
-    if (info->drawable_h > info->active_h) info->active_h = info->drawable_h;
+    /* SDL reports a logical desktop mode on Retina displays. Query the
+     * receiver window's NSScreen for native pixels instead of using its
+     * transient drawable, which is only window-sized before fullscreen. */
+    uint32_t native_w = 0, native_h = 0;
+    if (tb_receiver_content_display_pixels(&native_w, &native_h) == 0) {
+        info->active_w = native_w;
+        info->active_h = native_h;
+    } else {
+        if (info->drawable_w > info->active_w) info->active_w = info->drawable_w;
+        if (info->drawable_h > info->active_h) info->active_h = info->drawable_h;
+    }
 
     info->window_w = (uint32_t)window_w;
     info->window_h = (uint32_t)window_h;

--- a/TargetBridge-Receiver/TBReceiverC/src/display.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/display.h
@@ -9,6 +9,8 @@
 struct tb_display;
 
 struct tb_display_info {
+    uint32_t logical_w;
+    uint32_t logical_h;
     uint32_t active_w;
     uint32_t active_h;
     uint32_t window_w;

--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -16,6 +16,7 @@
 #include "net.h"
 #include "decoder.h"
 #include "display.h"
+#include "receiver_profile.h"
 #include "proto.h"
 #include "tb_gesture_bridge.h"
 #include "tb_display_tweaks.h"
@@ -1733,17 +1734,12 @@ static void send_receiver_info(struct app *a) {
     struct tb_display_info info;
     if (tb_disp_get_info(a->disp, &info) < 0) return;
 
-    /* Always advertise the intended iMac target panel, not the transient
-     * SDL window/debug drawable size. Using the drawable here breaks the
-     * sender's virtual display creation path when running windowed or on
-     * scaled desktops because macOS rejects a HiDPI mode larger than the
-     * advertised backing panel. */
-    const uint32_t panel_w = 5120;
-    const uint32_t panel_h = 2880;
-    const uint32_t mode_w = 2560;
-    const uint32_t mode_h = 1440;
-    const uint32_t capture_w = 2560;
-    const uint32_t capture_h = 1440;
+    struct tb_receiver_profile profile;
+    if (tb_receiver_profile_from_dimensions(info.logical_w, info.logical_h,
+                                            info.active_w, info.active_h,
+                                            &profile) < 0) {
+        return;
+    }
 
     char escaped_name[256];
     size_t out = 0;
@@ -1764,16 +1760,17 @@ static void send_receiver_info(struct app *a) {
         sizeof(json),
         "{\"receiverName\":\"%s\",\"panelWidth\":%u,\"panelHeight\":%u,"
         "\"modeWidth\":%u,\"modeHeight\":%u,\"refreshRate\":60,"
-        "\"hiDPI\":true,\"captureWidth\":%u,\"captureHeight\":%u,"
+        "\"hiDPI\":%s,\"captureWidth\":%u,\"captureHeight\":%u,"
         "\"supportsHEVCDecode\":%s,\"supportsRawNV12\":true,\"inputMonitoringTrusted\":%s,\"accessibilityTrusted\":%s,"
         "\"supportsNightShift\":%s,\"supportsTrueTone\":%s}",
         escaped_name,
-        panel_w,
-        panel_h,
-        mode_w,
-        mode_h,
-        capture_w,
-        capture_h,
+        profile.panel_w,
+        profile.panel_h,
+        profile.mode_w,
+        profile.mode_h,
+        profile.hi_dpi ? "true" : "false",
+        profile.capture_w,
+        profile.capture_h,
         tb_dec_supports_hevc_hwdecode() ? "true" : "false",
         tb_receiver_input_monitoring_trusted() ? "true" : "false",
         tb_receiver_accessibility_trusted() ? "true" : "false",
@@ -1791,8 +1788,9 @@ static void send_receiver_info(struct app *a) {
 
     if (send_all(a->client_fd, pkt, packet_len) == 0) {
         fprintf(stderr,
-                "[main] sent display profile: panel=%ux%u mode=%ux%u hidpi name=%s\n",
-                panel_w, panel_h, mode_w, mode_h, info.name);
+                "[main] sent display profile: panel=%ux%u mode=%ux%u hidpi=%d name=%s\n",
+                profile.panel_w, profile.panel_h, profile.mode_w, profile.mode_h,
+                profile.hi_dpi, info.name);
     }
     free(pkt);
 }

--- a/TargetBridge-Receiver/TBReceiverC/src/receiver_profile.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/receiver_profile.c
@@ -1,0 +1,24 @@
+#include "receiver_profile.h"
+
+#include <string.h>
+
+int tb_receiver_profile_from_dimensions(uint32_t logical_w,
+                                        uint32_t logical_h,
+                                        uint32_t panel_w,
+                                        uint32_t panel_h,
+                                        struct tb_receiver_profile *out) {
+    if (!out || !panel_w || !panel_h) return -1;
+
+    memset(out, 0, sizeof(*out));
+    out->panel_w = panel_w;
+    out->panel_h = panel_h;
+    out->capture_w = panel_w;
+    out->capture_h = panel_h;
+
+    const int hi_dpi = logical_w && logical_h &&
+        panel_w >= logical_w * 2 && panel_h >= logical_h * 2;
+    out->hi_dpi = hi_dpi;
+    out->mode_w = hi_dpi ? logical_w : panel_w;
+    out->mode_h = hi_dpi ? logical_h : panel_h;
+    return 0;
+}

--- a/TargetBridge-Receiver/TBReceiverC/src/receiver_profile.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/receiver_profile.h
@@ -1,0 +1,27 @@
+/* receiver_profile.h — sender-facing geometry derived from the receiver panel. */
+
+#ifndef TB_RECEIVER_PROFILE_H
+#define TB_RECEIVER_PROFILE_H
+
+#include <stdint.h>
+
+struct tb_receiver_profile {
+    uint32_t panel_w;
+    uint32_t panel_h;
+    uint32_t mode_w;
+    uint32_t mode_h;
+    uint32_t capture_w;
+    uint32_t capture_h;
+    int hi_dpi;
+};
+
+/* Build the DISPLAY_PROFILE dimensions from the receiver's logical desktop
+ * mode and its native panel pixels. A Retina panel is advertised as HiDPI
+ * only when its backing dimensions are at least 2x the logical mode. */
+int tb_receiver_profile_from_dimensions(uint32_t logical_w,
+                                        uint32_t logical_h,
+                                        uint32_t panel_w,
+                                        uint32_t panel_h,
+                                        struct tb_receiver_profile *out);
+
+#endif

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.h
@@ -1,6 +1,8 @@
 #ifndef TB_GESTURE_BRIDGE_H
 #define TB_GESTURE_BRIDGE_H
 
+#include <stdint.h>
+
 typedef void (*tb_gesture_space_switch_callback)(int direction, void *context);
 
 void tb_gesture_bridge_install(tb_gesture_space_switch_callback callback, void *context);
@@ -13,5 +15,9 @@ int tb_window_on_active_space(void *sdl_window);
 /* Keep the fullscreen monitor surface above Notification Center while a
  * session is active, restoring the normal window level on Stop/disconnect. */
 void tb_receiver_set_monitor_shield(int active);
+
+/* Return the native pixel dimensions of the screen that hosts the receiver
+ * window. This avoids treating a windowed SDL drawable as the panel size. */
+int tb_receiver_content_display_pixels(uint32_t *width, uint32_t *height);
 
 #endif

--- a/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
+++ b/TargetBridge-Receiver/TBReceiverC/src/tb_gesture_bridge.m
@@ -1,6 +1,7 @@
 #import "tb_gesture_bridge.h"
 
 #import <AppKit/AppKit.h>
+#import <CoreGraphics/CoreGraphics.h>
 #include <stdio.h>
 
 static NSWindow *tb_receiver_content_window(void) {
@@ -17,6 +18,28 @@ static NSWindow *tb_receiver_content_window(void) {
         }
     }
     return content;
+}
+
+int tb_receiver_content_display_pixels(uint32_t *width, uint32_t *height) {
+    if (!width || !height) return -1;
+    *width = 0;
+    *height = 0;
+
+    @autoreleasepool {
+        NSWindow *content = tb_receiver_content_window();
+        NSScreen *screen = content.screen ?: NSScreen.mainScreen;
+        NSNumber *screen_number = screen.deviceDescription[@"NSScreenNumber"];
+        if (!screen_number) return -1;
+
+        CGDirectDisplayID display = (CGDirectDisplayID)screen_number.unsignedIntValue;
+        const size_t pixels_w = CGDisplayPixelsWide(display);
+        const size_t pixels_h = CGDisplayPixelsHigh(display);
+        if (!pixels_w || !pixels_h) return -1;
+
+        *width = (uint32_t)pixels_w;
+        *height = (uint32_t)pixels_h;
+        return 0;
+    }
 }
 
 static BOOL g_monitor_shield_active = NO;

--- a/TargetBridge-Receiver/TBReceiverC/tests/test_receiver_profile.c
+++ b/TargetBridge-Receiver/TBReceiverC/tests/test_receiver_profile.c
@@ -1,0 +1,61 @@
+#include "../src/receiver_profile.h"
+
+#include <stdio.h>
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(condition, message) do {                                   \
+    checks++;                                                              \
+    if (!(condition)) {                                                    \
+        failures++;                                                        \
+        fprintf(stderr, "FAIL %s:%d — %s\\n", __FILE__, __LINE__, message); \
+    }                                                                      \
+} while (0)
+
+static void test_retina_5k(void) {
+    struct tb_receiver_profile p;
+    CHECK(tb_receiver_profile_from_dimensions(2560, 1440, 5120, 2880, &p) == 0,
+          "5K profile builds");
+    CHECK(p.hi_dpi, "5K panel is HiDPI");
+    CHECK(p.mode_w == 2560 && p.mode_h == 1440, "5K uses logical mode");
+    CHECK(p.capture_w == 5120 && p.capture_h == 2880, "5K capture uses native pixels");
+}
+
+static void test_retina_4k(void) {
+    struct tb_receiver_profile p;
+    CHECK(tb_receiver_profile_from_dimensions(2048, 1152, 4096, 2304, &p) == 0,
+          "4K profile builds");
+    CHECK(p.hi_dpi, "4K panel is HiDPI");
+    CHECK(p.mode_w == 2048 && p.mode_h == 1152, "4K uses logical mode");
+}
+
+static void test_non_retina_1080p(void) {
+    struct tb_receiver_profile p;
+    CHECK(tb_receiver_profile_from_dimensions(1920, 1080, 1920, 1080, &p) == 0,
+          "1080p profile builds");
+    CHECK(!p.hi_dpi, "1080p panel is not HiDPI");
+    CHECK(p.mode_w == 1920 && p.mode_h == 1080, "1080p uses native mode");
+    CHECK(p.capture_w == 1920 && p.capture_h == 1080, "1080p capture uses native pixels");
+}
+
+static void test_invalid_panel(void) {
+    struct tb_receiver_profile p;
+    CHECK(tb_receiver_profile_from_dimensions(1920, 1080, 0, 1080, &p) < 0,
+          "zero panel width is rejected");
+    CHECK(tb_receiver_profile_from_dimensions(1920, 1080, 1920, 1080, NULL) < 0,
+          "NULL output is rejected");
+}
+
+int main(void) {
+    test_retina_5k();
+    test_retina_4k();
+    test_non_retina_1080p();
+    test_invalid_panel();
+    if (!failures) {
+        printf("receiver profile tests: %d checks passed\n", checks);
+        return 0;
+    }
+    fprintf(stderr, "receiver profile tests: %d/%d checks FAILED\n", failures, checks);
+    return 1;
+}


### PR DESCRIPTION
## Summary

The Receiver currently advertises a fixed 5120×2880 / 2560×1440 HiDPI profile regardless of its actual panel. This makes non-5K receivers appear as 5K targets and can force inappropriate virtual-display geometry.

This change derives the profile from the screen hosting the Receiver window:

- obtains native panel pixels from the matching macOS `NSScreen`;
- keeps SDL's logical desktop mode separately;
- reports HiDPI only when the native backing dimensions are at least 2× the logical mode;
- sends native geometry for non-Retina displays, including 1920×1080.

The existing drawable fallback remains in place if native screen lookup is unavailable.

## Verification

- `make test` passes: 67 packet-parser checks and 13 receiver-profile checks.
- Added profile coverage for 5K Retina, 4K Retina, non-Retina 1080p, and invalid dimensions.
- Objective-C bridge compiles with `-mmacosx-version-min=11.0` in syntax-only validation.

A full local Receiver link was not possible in this checkout because the required FFmpeg/SDL pkg-config packages are not installed on this host.