### PR TITLE
fix(receiver): allow display sleep before first session

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -1931,6 +1931,12 @@ int main(int argc, char **argv) {
     a.disp = tb_disp_create(fullscreen);
     if (!a.disp) { fprintf(stderr, "tb_disp_create failed\n"); return 1; }
 
+    /* SDL starts with screen-saver inhibition enabled. A Receiver that has not
+     * accepted a client yet never reaches close_client(), so release the
+     * assertion immediately while it is waiting for its first session. */
+    SDL_EnableScreenSaver();
+    fprintf(stderr, "[main] display sleep enabled while receiver is idle\n");
+
     /* Open SDL Audio Device */
     SDL_AudioSpec spec;
     SDL_zero(spec);


### PR DESCRIPTION
## Summary

Fix the Receiver display-sleep regression reported again in #132 on TargetBridge 3.5.

SDL starts with screen-saver inhibition enabled after the display is created. A Receiver waiting for its first client never reaches close_client(), so the inhibition remains active indefinitely. This change explicitly enables normal display sleep immediately after display initialization; the existing accept path still disables it for an active session and close_client() re-enables it afterward.

## Scope

- one production file
- no protocol or preference changes
- preserves the existing active-session behavior

## Verification

- rebased onto maint-3.5 at v3.5.1-rc.3
- Receiver make test: 67 parser checks, 562 input-queue checks, 13 receiver-profile checks; all pass
- full Receiver build succeeds
- verified on a 2017 Intel iMac running macOS Ventura: while the Receiver is waiting, PreventUserIdleDisplaySleep returns to 0

Closes #132.
