### PR TITLE
fix(receiver): release audio device while idle

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -108,6 +108,7 @@ struct app {
     int      input_tap_consumes_events;
 
     SDL_AudioDeviceID audio_device;
+    uint64_t audio_retry_after_ms;
 
     uint8_t audio_buf[AUDIO_BUF_CAP];
     int     audio_buf_head;
@@ -979,6 +980,62 @@ static void audio_callback(void *userdata, Uint8 *stream, int len) {
     }
 }
 
+/* Keep the output device closed while Receiver is waiting for a Sender.  On
+ * macOS an open SDL output device is enough for coreaudiod to assert
+ * PreventUserIdleSystemSleep, even when the callback only produces silence.
+ * Opening lazily also means sessions with audio disabled never touch the
+ * system output device. */
+static int tb_audio_open_for_frame(struct app *a) {
+    if (!a) return 0;
+    if (a->audio_device != 0) return 1;
+
+    uint64_t now = now_ms();
+    if (now < a->audio_retry_after_ms) return 0;
+
+    SDL_AudioSpec spec;
+    SDL_zero(spec);
+    spec.freq = 48000;
+    spec.format = AUDIO_S16LSB;
+    spec.channels = 2;
+    spec.samples = 1024;
+    spec.callback = audio_callback;
+    spec.userdata = a;
+
+    SDL_AudioSpec obtained;
+    SDL_zero(obtained);
+    a->audio_device = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained, 0);
+    if (a->audio_device == 0) {
+        /* Audio packets arrive frequently.  Avoid retrying (and logging) for
+         * every packet if the output device is temporarily unavailable. */
+        a->audio_retry_after_ms = now + 5000;
+        fprintf(stderr, "[main] warning: SDL_OpenAudioDevice failed: %s; retrying in 5s\n",
+                SDL_GetError());
+        return 0;
+    }
+
+    a->audio_retry_after_ms = 0;
+    fprintf(stderr,
+            "[main] SDL audio device opened on first audio frame: "
+            "48000Hz stereo 16-bit PCM (obtained %d samples)\n",
+            obtained.samples);
+    return 1;
+}
+
+static void tb_audio_close_for_idle(struct app *a) {
+    if (!a) return;
+
+    if (a->audio_device != 0) {
+        SDL_CloseAudioDevice(a->audio_device);
+        a->audio_device = 0;
+        fprintf(stderr, "[main] SDL audio device closed for idle Receiver\n");
+    }
+
+    a->audio_buf_head = 0;
+    a->audio_buf_tail = 0;
+    a->audio_buf_size = 0;
+    a->audio_retry_after_ms = 0;
+}
+
 /* Drive the receiver's master output volume knob (with the system volume HUD).
  * level is clamped to 0.0..1.0. Sets the default output device's scalar volume,
  * preferring the master element and falling back to per-channel when a device
@@ -1157,7 +1214,10 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
         }
         break;
     case TB_PKT_AUDIO_FRAME:
-        if (a->audio_device != 0) {
+        {
+            int opened_for_frame = a->audio_device == 0;
+            if (!tb_audio_open_for_frame(a)) break;
+
             SDL_LockAudioDevice(a->audio_device);
 
             // Limit audio backlog to 150ms (150 * 192 = 28800 bytes) to cushion
@@ -1183,6 +1243,10 @@ static void on_packet(uint8_t type, const uint8_t *payload, size_t len, void *ud
             }
 
             SDL_UnlockAudioDevice(a->audio_device);
+
+            /* SDL opens devices paused.  Queue the first packet before
+             * starting playback so the callback does not begin with silence. */
+            if (opened_for_frame) SDL_PauseAudioDevice(a->audio_device, 0);
         }
         break;
     case TB_PKT_INPUT_EVENT:
@@ -1813,13 +1877,7 @@ static void close_client(struct app *a) {
     tb_parser_free(&a->parser);
     tb_parser_init(&a->parser, on_packet, a);
     tb_dec_reset(a->dec);   /* fresh decoder for next session */
-    if (a->audio_device != 0) {
-        SDL_LockAudioDevice(a->audio_device);
-        a->audio_buf_head = 0;
-        a->audio_buf_tail = 0;
-        a->audio_buf_size = 0;
-        SDL_UnlockAudioDevice(a->audio_device);
-    }
+    tb_audio_close_for_idle(a);
     fprintf(stderr, "[main] client disconnected\n");
 }
 
@@ -1930,24 +1988,6 @@ int main(int argc, char **argv) {
 
     a.disp = tb_disp_create(fullscreen);
     if (!a.disp) { fprintf(stderr, "tb_disp_create failed\n"); return 1; }
-
-    /* Open SDL Audio Device */
-    SDL_AudioSpec spec;
-    SDL_zero(spec);
-    spec.freq = 48000;
-    spec.format = AUDIO_S16LSB; // 16-bit signed, little-endian PCM
-    spec.channels = 2;          // Stereo
-    spec.samples = 1024;        // Buffer size (approx 21.3ms)
-    spec.callback = audio_callback;
-    spec.userdata = &a;
-    SDL_AudioSpec obtained;
-    a.audio_device = SDL_OpenAudioDevice(NULL, 0, &spec, &obtained, 0);
-    if (a.audio_device != 0) {
-        SDL_PauseAudioDevice(a.audio_device, 0); // Start playing (unpaused)
-        fprintf(stderr, "[main] SDL audio device opened: 48000Hz stereo 16-bit PCM (obtained %d samples)\n", obtained.samples);
-    } else {
-        fprintf(stderr, "[main] warning: SDL_OpenAudioDevice failed: %s\n", SDL_GetError());
-    }
 
     struct tb_display_info boot_info;
     if (tb_disp_get_info(a.disp, &boot_info) == 0) {
@@ -2181,9 +2221,7 @@ int main(int argc, char **argv) {
     bonjour_deinit(&a);
     tb_parser_free(&a.parser);
     tb_dec_destroy(a.dec);
-    if (a.audio_device != 0) {
-        SDL_CloseAudioDevice(a.audio_device);
-    }
+    tb_audio_close_for_idle(&a);
     tb_disp_destroy(a.disp);
     fprintf(stderr, "[main] bye\n");
     return 0;


### PR DESCRIPTION
## Summary

Keep the Receiver audio output device closed while it is waiting for a Sender, and open it lazily on the first audio packet.

On macOS, an open SDL output device can cause coreaudiod to hold PreventUserIdleSystemSleep even when the callback only emits silence. It also touches the system output unnecessarily for sessions where audio relay is disabled.

## Behavior

- no audio device is opened while the Receiver is idle
- the device opens on the first audio frame and playback starts after that frame is queued
- the device and queued samples are released when the client disconnects
- failed device opens are rate-limited to one retry every five seconds
- existing audio packet and buffering behavior is otherwise unchanged

## Verification

- rebased onto maint-3.5 at v3.5.1-rc.3
- Receiver make test: 67 parser checks, 562 input-queue checks, 13 receiver-profile checks; all pass
- full Receiver build succeeds
- verified on a 2017 Intel iMac: audio opens during an active relayed-audio session and the Receiver no longer owns a coreaudiod sleep assertion after disconnect
