### PR TITLE
feat: expose non-interactive permission status

### DIFF
--- a/TargetBridge-Receiver/TBReceiverC/src/main.c
+++ b/TargetBridge-Receiver/TBReceiverC/src/main.c
@@ -1855,6 +1855,14 @@ static void build_display_host(char *buf, size_t bufsz, const char *ip_fallback,
 int main(int argc, char **argv) {
     int fullscreen = 1;
     for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--permission-status") == 0) {
+            printf(
+                "TB_PERMISSION_STATUS:screen_recording=0:accessibility=%d:input_monitoring=%d\n",
+                tb_receiver_accessibility_trusted(),
+                tb_receiver_input_monitoring_trusted()
+            );
+            return 0;
+        }
         if (strcmp(argv[i], "--windowed") == 0) fullscreen = 0;
     }
 

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderApp.swift
@@ -1,13 +1,31 @@
 import AppKit
+import ApplicationServices
+import Darwin
 import SwiftUI
 
 @main
 struct TBDisplaySenderApp: App {
-    @StateObject private var service = TBDisplaySenderService.shared
-    private let statusItemController = TBDisplaySenderStatusItemController(service: TBDisplaySenderService.shared)
+    @StateObject private var service: TBDisplaySenderService
+    private let statusItemController: TBDisplaySenderStatusItemController
 
     @MainActor
     init() {
+        // This probe is intentionally handled before constructing the shared
+        // service. The Setup Assistant can inspect the exact installed binary
+        // without opening a window, starting capture or attaching a display.
+        if CommandLine.arguments.contains("--permission-status") {
+            let screenRecording = CGPreflightScreenCaptureAccess() ? 1 : 0
+            let accessibility = AXIsProcessTrusted() ? 1 : 0
+            let inputMonitoring = CGPreflightListenEventAccess() ? 1 : 0
+            print("TB_PERMISSION_STATUS:screen_recording=\(screenRecording):accessibility=\(accessibility):input_monitoring=\(inputMonitoring)")
+            fflush(stdout)
+            Darwin.exit(EXIT_SUCCESS)
+        }
+
+        let sharedService = TBDisplaySenderService.shared
+        _service = StateObject(wrappedValue: sharedService)
+        statusItemController = TBDisplaySenderStatusItemController(service: sharedService)
+
         // LaunchAgent automation must not depend on SwiftUI restoring or showing
         // the main window on a headless Mac.
         TBSenderAutomation.handleLaunchArguments(CommandLine.arguments)


### PR DESCRIPTION
## Summary

Add a non-interactive permission-status command to the installed Sender and Receiver binaries.

Setup and support tools can now inspect the exact binary that will run without constructing the Sender service, opening a window, starting capture or attaching a virtual display.

Both binaries print the same stable single-line format:

TB_PERMISSION_STATUS:screen_recording=N:accessibility=N:input_monitoring=N

The Receiver reports screen recording as zero because it does not capture the screen; it reports its Accessibility and Input Monitoring trust directly.

## Scope

- two production files
- read-only command-line behavior
- no permission prompts or settings changes
- normal app startup is unchanged when the flag is absent

## Verification

- rebased onto maint-3.5 at v3.5.1-rc.3
- Receiver: 642 checks pass and full build succeeds
- Sender: all 111 XCTest cases pass
- both built binaries were executed with permission-status and returned the expected parseable line without opening their normal UI
