### PR TITLE
fix(sender): preserve encoded frame references under backpressure

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -11,6 +11,17 @@ import Network
 @preconcurrency import ScreenCaptureKit
 import VideoToolbox
 
+/// Reserve network capacity before encoding. Once encoded, even a non-keyframe
+/// may be a reference for subsequent frames and must not be discarded locally.
+enum TBVideoQueueBudget {
+    static func canEncode(pending: Int, inFlight: Int, packetLimit: Int, encodeLimit: Int) -> Bool {
+        let limit = min(64, max(1, packetLimit))
+        let encoding = min(64, max(1, encodeLimit))
+        return pending >= 0 && inFlight >= 0 && pending < limit &&
+            inFlight < encoding && inFlight < limit - pending
+    }
+}
+
 enum TBDisplayCapturePreset: String, CaseIterable, Identifiable {
     case standard1440p
     case smooth1440p60
@@ -646,9 +657,10 @@ private final class TBVideoPipeline: @unchecked Sendable {
         guard running, let encoder = vtEncoder,
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
-        if preset.dropsBeforeEncodeWhenBacklogged,
-           (pendingVideoPackets >= preset.maxPendingVideoPackets ||
-            inFlightEncodeFrames >= preset.maxInFlightEncodeFrames) {
+        if !TBVideoQueueBudget.canEncode(pending: pendingVideoPackets,
+                                        inFlight: inFlightEncodeFrames,
+                                        packetLimit: preset.maxPendingVideoPackets,
+                                        encodeLimit: preset.maxInFlightEncodeFrames) {
             droppedBeforeEncodeFrames += 1
             return
         }
@@ -672,9 +684,10 @@ private final class TBVideoPipeline: @unchecked Sendable {
             droppedByFrameRatePacer += 1
             return
         }
-        if preset.dropsBeforeEncodeWhenBacklogged,
-           (pendingVideoPackets >= preset.maxPendingVideoPackets ||
-            inFlightEncodeFrames >= preset.maxInFlightEncodeFrames) {
+        if !TBVideoQueueBudget.canEncode(pending: pendingVideoPackets,
+                                        inFlight: inFlightEncodeFrames,
+                                        packetLimit: preset.maxPendingVideoPackets,
+                                        encodeLimit: preset.maxInFlightEncodeFrames) {
             droppedBeforeEncodeFrames += 1
             return
         }
@@ -742,10 +755,8 @@ private final class TBVideoPipeline: @unchecked Sendable {
         let notSync = attachments?.first?[kCMSampleAttachmentKey_NotSync] as? Bool ?? false
         let isKeyframe = !notSync
 
-        if !isKeyframe, pendingVideoPackets >= preset.maxPendingVideoPackets {
-            droppedAfterEncodeFrames += 1
-            return
-        }
+        // Capacity was reserved before encoding. Preserve the complete encoded
+        // reference chain; dropping here corrupts HEVC/H.264 until the next IDR.
 
         if isKeyframe,
            let format = CMSampleBufferGetFormatDescription(sampleBuffer),

--- a/TargetBridge-Sender/scripts/test_video_queue_budget.rb
+++ b/TargetBridge-Sender/scripts/test_video_queue_budget.rb
@@ -1,0 +1,41 @@
+# Execute the production policy, plus source guards for both capture paths.
+# Synthetic counters only; no display capture, network, credentials or input.
+require 'tmpdir'
+root = File.expand_path('..', __dir__)
+source = File.read(File.join(root, 'TBDisplaySender/TBDisplaySenderService.swift'))
+policy = source[/enum TBVideoQueueBudget \{.*?(?=\nenum TBDisplayCapturePreset)/m]
+abort 'missing production budget policy' unless policy
+abort 'both capture paths must reserve capacity' unless source.scan('if !TBVideoQueueBudget.canEncode(').size == 2
+encoded = source[/private func handleEncoded\(.*?(?=    \/\/\/ Raw passthrough)/m]
+abort 'encoded frames are still dropped' if encoded.include?('droppedAfterEncodeFrames +=')
+tests = <<~'SWIFT'
+import Foundation
+func admit(_ pending: Int, _ flight: Int, _ limit: Int = 3, _ enc: Int = 2) -> Bool {
+    TBVideoQueueBudget.canEncode(pending: pending, inFlight: flight, packetLimit: limit, encodeLimit: enc)
+}
+precondition(admit(0, 0) && admit(1, 1) && !admit(2, 1) && !admit(0, 2))
+precondition(!admit(-1, 0) && !admit(0, -1) && !admit(Int.max, 0))
+precondition(admit(0, 0, 0, 0) && !admit(1, 0, 0, 0))
+precondition(!admit(64, 0, Int.max, Int.max))
+// Explore all legal transitions: capture, encoder success/failure, transport ACK.
+// No post-encode discard is needed, including when ACKs are delayed indefinitely.
+for limit in 1...12 {
+    for enc in 1...12 {
+        for pending in 0...limit {
+            for flight in 0...(limit - pending) {
+                if admit(pending, flight, limit, enc) {
+                    precondition(pending + flight + 1 <= limit && flight + 1 <= enc)
+                }
+                if flight > 0 { precondition((pending + 1) + (flight - 1) <= limit) }
+            }
+        }
+    }
+}
+print("PASS production video budget: both paths, bounded reservations, delayed ACKs, encode failure, invalid limits; no post-encode discard")
+SWIFT
+Dir.mktmpdir('tb-video-budget.') do |dir|
+  file = File.join(dir, 'main.swift')
+  File.write(file, policy + tests)
+  abort 'compile failed' unless system('swiftc', '-module-cache-path', File.join(dir, 'cache'), file, '-o', File.join(dir, 'test'))
+  abort 'tests failed' unless system(File.join(dir, 'test'))
+end


### PR DESCRIPTION
## Why

Thanks again for TargetBridge and for the guidance to send small, tested follow-ups. While using a headless Mac mini with an iMac as its display, we reproduced HEVC missing-reference errors when the network queue briefly filled.

`handleEncoded` currently drops non-keyframes after VideoToolbox has encoded them. Those frames can be references for later frames, so sending the rest of the sequence can leave the Receiver unable to decode until a new keyframe.

## Focused change

- Reserve a shared budget for pending network packets plus in-flight encoder frames **before** encoding, on both capture paths.
- Keep every encoded frame, preserving the reference chain.
- Bound the queue even when transport acknowledgements are delayed; invalid experimental limits are clamped.
- No protocol, codec, bitrate, renderer or Receiver changes.

Based directly on current `maint-3.5` (`fb45b5f`); two files only. This is independent of the monitor-mode/onboarding drafts.

## Validation

- `ruby TargetBridge-Sender/scripts/test_video_queue_budget.rb` passes on Apple Silicon. It executes the production budget policy and checks both call sites, bounded reservations, delayed acknowledgements, encoding completion/failure and invalid limits.
- The exact rebased Sender source builds with Xcode for macOS arm64.
- Before/after installed builds: headless Mac mini M4 → iMac 24 M4, HEVC 4096×2304, same Wi-Fi path and preset. Two baseline sessions produced missing-reference errors; the corrected sessions produced none, with `droppedPost=0` and sampled pending+in-flight counts within the configured budget.
- This is a correctness/backpressure result, **not** an optical 60-FPS claim. Existing log intervals can include delayed bursts. H.264 uses the same policy but was not separately hardware-benchmarked in this run; raw NV12 is unchanged.

No personal certificates, logs containing desktop content, credentials, network configuration or generated build stamps are included.
