### PR TITLE
fix(sender): distinguish idle capture from a stalled pipeline

### DIFF
--- a/TargetBridge-Sender/TBDisplaySender/TBCaptureHealth.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBCaptureHealth.swift
@@ -1,0 +1,83 @@
+import Foundation
+import CoreGraphics
+import CoreMedia
+import ScreenCaptureKit
+
+/// Capture health is not FPS: event-driven capture may remain idle indefinitely.
+/// Owned by the pipeline under its snapshot lock. Times use monotonic uptime.
+struct TBCaptureHealth {
+    enum State: String {
+        case starting, active, idle, blank, suspended, stopped, unknown
+
+        init(_ status: SCFrameStatus) {
+            switch status {
+            case .complete, .started: self = .active
+            case .idle: self = .idle
+            case .blank: self = .blank
+            case .suspended: self = .suspended
+            case .stopped: self = .stopped
+            @unknown default: self = .unknown
+            }
+        }
+
+        init(_ status: CGDisplayStreamFrameStatus) {
+            switch status {
+            case .frameComplete: self = .active
+            case .frameIdle: self = .idle
+            case .frameBlank: self = .blank
+            case .stopped: self = .stopped
+            @unknown default: self = .unknown
+            }
+        }
+
+        init(sampleBuffer: CMSampleBuffer) {
+            guard let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false)
+                as? [[SCStreamFrameInfo: Any]],
+                  let raw = attachments.first?[SCStreamFrameInfo.status] as? Int,
+                  let status = SCFrameStatus(rawValue: raw) else {
+                self = .unknown
+                return
+            }
+            self.init(status)
+        }
+
+        var canContainFrame: Bool { self == .active || self == .unknown }
+        var isQuiescent: Bool { self == .idle || self == .blank || self == .suspended }
+    }
+
+    private(set) var state: State = .starting
+    private(set) var frameCount: UInt64 = 0
+    private(set) var idleCount: UInt64 = 0
+    private(set) var lastFrameAt: TimeInterval?
+    private var progressAt: TimeInterval
+
+    init(now: TimeInterval) { progressAt = now }
+
+    mutating func observe(_ next: State, now: TimeInterval) {
+        // A resumed stream gets a fresh grace period, but repeated callbacks
+        // without usable frames must not hide a genuine capture failure.
+        if state.isQuiescent && !next.isQuiescent && next != .stopped {
+            progressAt = now
+        }
+        state = next
+        if next == .idle { idleCount &+= 1 }
+    }
+
+    mutating func recordFrame(now: TimeInterval) {
+        state = .active
+        lastFrameAt = now
+        progressAt = now
+        frameCount &+= 1
+    }
+
+    func shouldRestart(now: TimeInterval, timeout: TimeInterval = 8) -> Bool {
+        if state == .stopped { return true }
+        // Blank/suspended are deliberate states, not failures; don't wake a
+        // sleeping display in a restart loop. System-wake recovery is separate.
+        if state == .blank || state == .suspended { return false }
+        // An idle event is a state transition, NOT a periodic heartbeat promise.
+        // Require a real first frame so initial idle cannot mask a failed start.
+        if state == .idle && lastFrameAt != nil { return false }
+        return now - progressAt >= timeout
+    }
+}

--- a/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
+++ b/TargetBridge-Sender/TBDisplaySender/TBDisplaySenderService.swift
@@ -410,6 +410,7 @@ private final class TBDirectDisplayStreamCapture {
             // Delivered on `queue` — the pipeline's own serial queue — so encode
             // runs here, off the main thread, with no extra hop.
             guard let self else { return }
+            self.pipeline.observeCaptureStatus(TBCaptureHealth.State(status))
             if status == .stopped {
                 // The stream has fully drained; no further frames will arrive, so
                 // it is now safe to release the stream and drop the self-retain.
@@ -449,7 +450,7 @@ private final class TBDirectDisplayStreamCapture {
 /// dedicated serial queue, off the main thread. SwiftUI layout (or any other
 /// main-thread work) therefore cannot stall frame delivery. All mutable encode
 /// state is confined to `queue`; the two values the main thread polls
-/// (`sentFrames`, `lastCaptureFrameAt`) are guarded by a small lock instead of
+/// (`sentFrames`, capture health) are guarded by a small lock instead of
 /// a per-frame hop back to main.
 private final class TBVideoPipeline: @unchecked Sendable {
     let queue = DispatchQueue(label: "fd.tbmonitor.sender.pipeline", qos: .userInteractive)
@@ -480,7 +481,7 @@ private final class TBVideoPipeline: @unchecked Sendable {
     private var droppedByFrameRatePacer = 0
     private var droppedBeforeEncodeFrames = 0
     private var droppedAfterEncodeFrames = 0
-    private var _lastCaptureFrameAt = Date()
+    private var captureHealth = TBCaptureHealth(now: ProcessInfo.processInfo.systemUptime)
 
     init(preset: TBDisplayCapturePreset,
          codecType: CMVideoCodecType,
@@ -537,9 +538,14 @@ private final class TBVideoPipeline: @unchecked Sendable {
         return _sentFrames
     }
 
-    var lastCaptureFrameAtSnapshot: Date {
+    var captureHealthSnapshot: TBCaptureHealth {
         lock.lock(); defer { lock.unlock() }
-        return _lastCaptureFrameAt
+        return captureHealth
+    }
+
+    func observeCaptureStatus(_ state: TBCaptureHealth.State) {
+        lock.lock(); defer { lock.unlock() }
+        captureHealth.observe(state, now: ProcessInfo.processInfo.systemUptime)
     }
 
     func diagnosticsSnapshot() -> (pending: Int, inFlight: Int, ptsSeq: CMTimeValue, captured: Int, droppedPacing: Int, droppedPre: Int, droppedPost: Int) {
@@ -558,7 +564,9 @@ private final class TBVideoPipeline: @unchecked Sendable {
 
     private func markCaptureFrame() {
         capturedFrames += 1
-        lock.lock(); _lastCaptureFrameAt = Date(); lock.unlock()
+        lock.lock()
+        captureHealth.recordFrame(now: ProcessInfo.processInfo.systemUptime)
+        lock.unlock()
     }
 
     // MARK: - Encoder setup (on `queue`)
@@ -633,6 +641,7 @@ private final class TBVideoPipeline: @unchecked Sendable {
     /// direct Thunderbolt Bridge link comfortably sustains.
     /// SCStream capture path. Must be dispatched onto `queue` by the caller.
     func encode(_ sampleBuffer: CMSampleBuffer) {
+        guard running, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
         markCaptureFrame()
         let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         guard frameRatePacer.shouldEmit(presentationTime: pts) else {
@@ -643,9 +652,7 @@ private final class TBVideoPipeline: @unchecked Sendable {
             sendRawFrame(sampleBuffer)
             return
         }
-        guard running, let encoder = vtEncoder,
-              let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
-        else { return }
+        guard let encoder = vtEncoder else { return }
         if preset.dropsBeforeEncodeWhenBacklogged,
            (pendingVideoPackets >= preset.maxPendingVideoPackets ||
             inFlightEncodeFrames >= preset.maxInFlightEncodeFrames) {
@@ -658,8 +665,8 @@ private final class TBVideoPipeline: @unchecked Sendable {
     /// CGDisplayStream capture path. Delivered directly on `queue` by
     /// `TBDirectDisplayStreamCapture`.
     func encodeDisplaySurface(_ surface: IOSurfaceRef, displayTime: UInt64) {
-        markCaptureFrame()
         guard running, let encoder = vtEncoder else { return }
+        markCaptureFrame()
 
         var pts = displayTime != 0
             ? CMClockMakeHostTimeFromSystemUnits(displayTime)
@@ -1274,6 +1281,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
     var onRemoteDeactivateInputRequest: (() -> Void)?
     nonisolated(unsafe) private var wakeObservers: [NSObjectProtocol] = []
     private var isRestartingCaptureAfterWake = false
+    private var captureRestartGeneration: UInt64 = 0
+    private var lastLoggedCaptureHealthState: TBCaptureHealth.State?
     nonisolated(unsafe) private var displayReconfigurationCallbackRegistered = false
     private var verboseLoggingTimer: Timer?
     private var captureHealthWatchdog: Timer?
@@ -1290,27 +1299,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private final class CaptureDelegate: NSObject, SCStreamOutput, SCStreamDelegate {
         var onFrame: ((CMSampleBuffer) -> Void)?
+        var onFrameStatus: ((TBCaptureHealth.State) -> Void)?
         var onAudio: ((CMSampleBuffer) -> Void)?
         var onError: ((Error) -> Void)?
-
-        private static func shouldProcessFrame(_ sampleBuffer: CMSampleBuffer) -> Bool {
-            guard let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false)
-                as? [[SCStreamFrameInfo: Any]],
-                  let rawStatus = attachments.first?[SCStreamFrameInfo.status] as? Int,
-                  let status = SCFrameStatus(rawValue: rawStatus)
-            else {
-                return true
-            }
-
-            switch status {
-            case .complete, .started:
-                return true
-            case .idle, .blank, .suspended, .stopped:
-                return false
-            @unknown default:
-                return true
-            }
-        }
 
         nonisolated func stream(_ stream: SCStream,
                                 didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
@@ -1320,7 +1311,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
                 return
             }
             guard type == .screen else { return }
-            guard Self.shouldProcessFrame(sampleBuffer) else { return }
+            let state = TBCaptureHealth.State(sampleBuffer: sampleBuffer)
+            onFrameStatus?(state)
+            guard state.canContainFrame else { return }
             onFrame?(sampleBuffer)
         }
 
@@ -1693,6 +1686,8 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         teardownCompletion: (@MainActor @Sendable () -> Void)? = nil
     ) {
         let connectionToClose = connection
+        captureRestartGeneration &+= 1
+        isRestartingCaptureAfterWake = false
         if persistArrangement {
             persistExtendedDisplayArrangementIfNeeded()
         }
@@ -2615,6 +2610,9 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             )
 
             let delegate = CaptureDelegate()
+            delegate.onFrameStatus = { state in
+                pipeline.observeCaptureStatus(state)
+            }
             delegate.onFrame = { sampleBuffer in
                 // ScreenCaptureKit already invokes this closure on pipeline.queue.
                 // Encode immediately so its IOSurface returns to WindowServer
@@ -2626,7 +2624,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
             }
             delegate.onError = { [weak self] error in
                 Task { @MainActor [weak self] in
-                    guard let self else { return }
+                    guard let self, self.pipeline === pipeline else { return }
                     self.setStatus(.captureError(self.formattedCaptureErrorMessage(for: error)))
                     self.stop(resetStatusTo: nil)
                 }
@@ -3285,6 +3283,7 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private func startCaptureWatchdog() {
         captureHealthWatchdog?.invalidate()
+        lastLoggedCaptureHealthState = nil
         captureHealthWatchdog = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.checkCaptureHealth()
@@ -3299,10 +3298,15 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
 
     private func checkCaptureHealth() {
         guard isStreaming, activeProfile != nil, !isRestartingCaptureAfterWake, let pipeline else { return }
-        let elapsed = Date().timeIntervalSince(pipeline.lastCaptureFrameAtSnapshot)
-        guard elapsed >= 8.0 else { return }
-        NSLog("TargetBridge: capture watchdog tripped — %.1fs since last frame, soft restart", elapsed)
-        scheduleCaptureRestart(reason: "watchdog (\(Int(elapsed))s without frames)", delaySeconds: 0.5)
+        let health = pipeline.captureHealthSnapshot
+        let now = ProcessInfo.processInfo.systemUptime
+        if health.state != lastLoggedCaptureHealthState {
+            lastLoggedCaptureHealthState = health.state
+            NSLog("TargetBridge: capture health state=%@ frames=%llu idleEvents=%llu", health.state.rawValue, health.frameCount, health.idleCount)
+        }
+        guard health.shouldRestart(now: now) else { return }
+        NSLog("TargetBridge: capture watchdog tripped — state=%@ frames=%llu idleEvents=%llu", health.state.rawValue, health.frameCount, health.idleCount)
+        scheduleCaptureRestart(reason: "watchdog (\(health.state.rawValue))", delaySeconds: 0.5, onlyIfUnhealthy: true)
     }
 
     private func logStreamSnapshot() {
@@ -3347,21 +3351,30 @@ final class TBDisplaySenderSession: NSObject, ObservableObject, Identifiable, @u
         isStreaming && activeProfile != nil && !isRestartingCaptureAfterWake
     }
 
-    private func scheduleCaptureRestart(reason: String, delaySeconds: Double) {
-        guard isStreaming, !isRestartingCaptureAfterWake, let profile = activeProfile else { return }
+    private func scheduleCaptureRestart(reason: String, delaySeconds: Double, onlyIfUnhealthy: Bool = false) {
+        guard isStreaming, !isRestartingCaptureAfterWake, let profile = activeProfile, let scheduledPipeline = pipeline else { return }
         isRestartingCaptureAfterWake = true
-        NSLog("TargetBridge: \(reason) — soft restart of capture pipeline")
+        captureRestartGeneration &+= 1
+        let generation = captureRestartGeneration
         Task { @MainActor [weak self] in
             if delaySeconds > 0 {
                 try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
             }
-            guard let self else { return }
-            guard self.isStreaming, self.activeProfile?.receiverName == profile.receiverName else {
-                self.isRestartingCaptureAfterWake = false
+            guard let self, self.captureRestartGeneration == generation else { return }
+            defer {
+                if self.captureRestartGeneration == generation {
+                    self.isRestartingCaptureAfterWake = false
+                }
+            }
+            // A delayed recovery must never restart a replacement connection,
+            // or interrupt a stream that recovered during the grace period.
+            guard self.isStreaming, self.pipeline === scheduledPipeline else { return }
+            if onlyIfUnhealthy && !scheduledPipeline.captureHealthSnapshot.shouldRestart(now: ProcessInfo.processInfo.systemUptime) {
+                NSLog("TargetBridge: capture watchdog recovery cancelled — capture is healthy")
                 return
             }
+            NSLog("TargetBridge: \(reason) — soft restart of capture pipeline")
             await self.softRestartCapture(for: profile)
-            self.isRestartingCaptureAfterWake = false
         }
     }
 

--- a/TargetBridge-Sender/TBDisplaySenderTests/TBCaptureHealthTests.swift
+++ b/TargetBridge-Sender/TBDisplaySenderTests/TBCaptureHealthTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+import CoreGraphics
+import CoreMedia
+import CoreVideo
+import ScreenCaptureKit
+@testable import TargetBridge
+
+final class TBCaptureHealthTests: XCTestCase {
+    func testStartupTimeoutWithoutCallbacks() {
+        let health = TBCaptureHealth(now: 100)
+        XCTAssertFalse(health.shouldRestart(now: 107.999))
+        XCTAssertTrue(health.shouldRestart(now: 108))
+    }
+
+    func testActiveCaptureStillDetectsSilentStall() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 2)
+        XCTAssertFalse(health.shouldRestart(now: 9.9))
+        XCTAssertTrue(health.shouldRestart(now: 10))
+    }
+
+    func testSingleIdleEventCanRemainHealthyForHours() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.idle, now: 2)
+        XCTAssertFalse(health.shouldRestart(now: 10))
+        XCTAssertFalse(health.shouldRestart(now: 86_400))
+        XCTAssertEqual(health.frameCount, 1)
+        XCTAssertEqual(health.idleCount, 1)
+    }
+
+    func testRepeatedIdleDoesNotInflateFrameCount() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        for time in 2...600 { health.observe(.idle, now: Double(time)) }
+        XCTAssertFalse(health.shouldRestart(now: 900))
+        XCTAssertEqual(health.frameCount, 1)
+        XCTAssertEqual(health.idleCount, 599)
+    }
+
+    func testIdleCannotMaskMissingFirstFrame() {
+        var health = TBCaptureHealth(now: 0)
+        for time in 1...9 { health.observe(.idle, now: Double(time)) }
+        XCTAssertTrue(health.shouldRestart(now: 10))
+        XCTAssertNil(health.lastFrameAt)
+    }
+
+    func testNewFramesResumeAfterLongIdle() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.idle, now: 2)
+        health.observe(.active, now: 600)
+        health.recordFrame(now: 600)
+        XCTAssertEqual(health.state, .active)
+        XCTAssertEqual(health.frameCount, 2)
+        XCTAssertFalse(health.shouldRestart(now: 607.9))
+        XCTAssertTrue(health.shouldRestart(now: 608))
+    }
+
+    func testResumedStatusGetsGraceButCannotMaskMissingFrames() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.idle, now: 2)
+        for time in 600...607 { health.observe(.active, now: Double(time)) }
+        XCTAssertFalse(health.shouldRestart(now: 607.9))
+        XCTAssertTrue(health.shouldRestart(now: 608))
+    }
+
+    func testBlankDoesNotTriggerWakeLoop() {
+        var health = TBCaptureHealth(now: 0)
+        health.observe(.blank, now: 1)
+        XCTAssertFalse(health.shouldRestart(now: 3600))
+        health.observe(.active, now: 3601)
+        XCTAssertFalse(health.shouldRestart(now: 3608))
+        XCTAssertTrue(health.shouldRestart(now: 3609))
+    }
+
+    func testSuspendedDoesNotTriggerWakeLoop() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.suspended, now: 2)
+        XCTAssertFalse(health.shouldRestart(now: 3600))
+        health.recordFrame(now: 3601)
+        XCTAssertFalse(health.shouldRestart(now: 3602))
+    }
+
+    func testStoppedAfterIdleRequiresRecovery() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.idle, now: 2)
+        health.observe(.stopped, now: 3)
+        XCTAssertTrue(health.shouldRestart(now: 3))
+    }
+
+    func testUnknownStatusDoesNotDisableWatchdog() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        health.observe(.unknown, now: 7)
+        XCTAssertTrue(health.shouldRestart(now: 9))
+    }
+
+    func testFreshPipelineDoesNotInheritOldIdleState() {
+        var old = TBCaptureHealth(now: 0)
+        old.recordFrame(now: 1)
+        old.observe(.idle, now: 2)
+        let fresh = TBCaptureHealth(now: 100)
+        XCTAssertFalse(old.shouldRestart(now: 200))
+        XCTAssertTrue(fresh.shouldRestart(now: 108))
+        XCTAssertEqual(fresh.frameCount, 0)
+    }
+
+    func testRecoveryRecheckCancelsAfterAFrameArrives() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        XCTAssertTrue(health.shouldRestart(now: 10))
+        health.recordFrame(now: 10.2)
+        XCTAssertFalse(health.shouldRestart(now: 10.5))
+    }
+
+    func testRecoveryRecheckCancelsAfterIdleNotification() {
+        var health = TBCaptureHealth(now: 0)
+        health.recordFrame(now: 1)
+        XCTAssertTrue(health.shouldRestart(now: 10))
+        health.observe(.idle, now: 10.2)
+        XCTAssertFalse(health.shouldRestart(now: 10.5))
+    }
+
+    func testScreenCaptureKitMappingsAndFiltering() {
+        for (status, expected) in [(SCFrameStatus.complete, TBCaptureHealth.State.active),
+                                   (.started, .active), (.idle, .idle), (.blank, .blank),
+                                   (.suspended, .suspended), (.stopped, .stopped)] {
+            XCTAssertEqual(TBCaptureHealth.State(status), expected)
+            XCTAssertEqual(expected.canContainFrame, expected == .active)
+        }
+        XCTAssertTrue(TBCaptureHealth.State.unknown.canContainFrame)
+    }
+
+    func testDirectDisplayStreamMappingsAndFiltering() {
+        for (status, expected) in [(CGDisplayStreamFrameStatus.frameComplete, TBCaptureHealth.State.active),
+                                   (.frameIdle, .idle), (.frameBlank, .blank), (.stopped, .stopped)] {
+            XCTAssertEqual(TBCaptureHealth.State(status), expected)
+            XCTAssertEqual(expected.canContainFrame, expected == .active)
+        }
+    }
+
+    func testRealSampleAttachmentParsing() throws {
+        var pixel: CVPixelBuffer?
+        XCTAssertEqual(CVPixelBufferCreate(kCFAllocatorDefault, 8, 8,
+            kCVPixelFormatType_32BGRA, nil, &pixel), kCVReturnSuccess)
+        var format: CMVideoFormatDescription?
+        XCTAssertEqual(CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault, imageBuffer: try XCTUnwrap(pixel),
+            formatDescriptionOut: &format), noErr)
+        var timing = CMSampleTimingInfo(duration: .invalid,
+            presentationTimeStamp: .zero, decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        XCTAssertEqual(CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault, imageBuffer: try XCTUnwrap(pixel),
+            formatDescription: try XCTUnwrap(format), sampleTiming: &timing,
+            sampleBufferOut: &sample), noErr)
+        let buffer = try XCTUnwrap(sample)
+        XCTAssertEqual(TBCaptureHealth.State(sampleBuffer: buffer), .unknown)
+        let array = try XCTUnwrap(CMSampleBufferGetSampleAttachmentsArray(buffer, createIfNecessary: true))
+        let dict = unsafeBitCast(CFArrayGetValueAtIndex(array, 0), to: NSMutableDictionary.self)
+        for status in [SCFrameStatus.complete, .idle, .blank, .started, .suspended, .stopped] {
+            dict[SCStreamFrameInfo.status] = status.rawValue
+            XCTAssertEqual(TBCaptureHealth.State(sampleBuffer: buffer), TBCaptureHealth.State(status))
+        }
+        dict[SCStreamFrameInfo.status] = 999
+        XCTAssertEqual(TBCaptureHealth.State(sampleBuffer: buffer), .unknown)
+    }
+}

--- a/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
+++ b/TargetBridge-Sender/TargetBridge.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4A8719A8C13A6560F4F0EB0D /* TBSenderAutomationParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED08E3D2FCC8194F8B8185C9 /* TBSenderAutomationParsingTests.swift */; };
 		4B770D1232C53EF66F011F7F /* TBAddonManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E4D00FB492A41B5218CD52 /* TBAddonManifest.swift */; };
 		4C59B780CEA3CC5F563BC86F /* TBInjectedClickStateTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4134F78ABD695DF9DB5D485B /* TBInjectedClickStateTracker.swift */; };
+		50C6F9D35F964ABF03193C5B /* TBCaptureHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8E93993FCAE2FCBA71C45B /* TBCaptureHealth.swift */; };
 		5109DFCF1BFD76222E7B4BDD /* TBDisplayProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419C88EEEA66EE0829BA975 /* TBDisplayProfileTests.swift */; };
 		55163F49604063EA7E86D079 /* TBConnectionDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6EB41D253E67E350F5E25D /* TBConnectionDiagnostics.swift */; };
 		58980FE95A48D8F8EDB42055 /* TBVirtualDisplayModeMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6630386DB9C3D210849E6211 /* TBVirtualDisplayModeMemory.swift */; };
@@ -33,6 +34,7 @@
 		7F103818097EEBD191C5ADBF /* TBConnectionDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405452C4DA622D0B8887623E /* TBConnectionDiagnosticsTests.swift */; };
 		7F1AE9053DA59169FB761FAA /* de.json in Resources */ = {isa = PBXBuildFile; fileRef = C3658E86F5BE2168F4591491 /* de.json */; };
 		7FB34AA1E75B01E7D1EC3E21 /* it.json in Resources */ = {isa = PBXBuildFile; fileRef = 036E14097FA59989FFC456FD /* it.json */; };
+		83FB3853596BEDEFAC5E129A /* TBCaptureHealthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11B4EB862393E5CE95426D4 /* TBCaptureHealthTests.swift */; };
 		8A729C68ECAC4642FA20A284 /* TBLocalizationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C932E960346E674A0659624 /* TBLocalizationStore.swift */; };
 		8D544352D7E2E226D551E46E /* TBInputBindingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20FE01BF2EA2F329442890AD /* TBInputBindingsView.swift */; };
 		8D9D2A40A1CD90BD4D4DFC2C /* TBDisplaySenderAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEA5EB707F01E1708DA9170 /* TBDisplaySenderAutomation.swift */; };
@@ -79,6 +81,7 @@
 		20FE01BF2EA2F329442890AD /* TBInputBindingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBInputBindingsView.swift; sourceTree = "<group>"; };
 		374B5A5AA247C6922BD9AF72 /* TBDisplaySenderAboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderAboutView.swift; sourceTree = "<group>"; };
 		37515A84B71F4B19C8EB65B4 /* TBInputBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBInputBindingTests.swift; sourceTree = "<group>"; };
+		3E8E93993FCAE2FCBA71C45B /* TBCaptureHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBCaptureHealth.swift; sourceTree = "<group>"; };
 		405452C4DA622D0B8887623E /* TBConnectionDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBConnectionDiagnosticsTests.swift; sourceTree = "<group>"; };
 		4134F78ABD695DF9DB5D485B /* TBInjectedClickStateTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBInjectedClickStateTracker.swift; sourceTree = "<group>"; };
 		4644CFB05098C895378B648A /* TBDisplaySenderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderManager.swift; sourceTree = "<group>"; };
@@ -99,6 +102,7 @@
 		A51B69D318A85FF3061D6ED4 /* input-dockstation.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "input-dockstation.json"; sourceTree = "<group>"; };
 		A7086193EE5710E2C37F86F1 /* TBConfigurationDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBConfigurationDiagnosticsTests.swift; sourceTree = "<group>"; };
 		B95D015FB8DF172C7418CB5D /* TBDisplaySenderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBDisplaySenderSettingsView.swift; sourceTree = "<group>"; };
+		C11B4EB862393E5CE95426D4 /* TBCaptureHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBCaptureHealthTests.swift; sourceTree = "<group>"; };
 		C242540F9DE94E1364F106F4 /* ReceiverBackedVirtualDisplaySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverBackedVirtualDisplaySession.swift; sourceTree = "<group>"; };
 		C3658E86F5BE2168F4591491 /* de.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = de.json; sourceTree = "<group>"; };
 		C9583EB47BCD79FA719EEA77 /* TBMonitorProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBMonitorProtocolTests.swift; sourceTree = "<group>"; };
@@ -131,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				C242540F9DE94E1364F106F4 /* ReceiverBackedVirtualDisplaySession.swift */,
+				3E8E93993FCAE2FCBA71C45B /* TBCaptureHealth.swift */,
 				A3F0782C970AA23871AE73A6 /* TBConfigurationDiagnostics.swift */,
 				4E4C95A1820A99E5DAED17DE /* TBDisplayProfile.swift */,
 				374B5A5AA247C6922BD9AF72 /* TBDisplaySenderAboutView.swift */,
@@ -159,6 +164,7 @@
 		578C8E4277884577DC1F2820 /* TBDisplaySenderTests */ = {
 			isa = PBXGroup;
 			children = (
+				C11B4EB862393E5CE95426D4 /* TBCaptureHealthTests.swift */,
 				A7086193EE5710E2C37F86F1 /* TBConfigurationDiagnosticsTests.swift */,
 				405452C4DA622D0B8887623E /* TBConnectionDiagnosticsTests.swift */,
 				D419C88EEEA66EE0829BA975 /* TBDisplayProfileTests.swift */,
@@ -361,6 +367,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83FB3853596BEDEFAC5E129A /* TBCaptureHealthTests.swift in Sources */,
 				7528751850893B52660870E4 /* TBConfigurationDiagnosticsTests.swift in Sources */,
 				7F103818097EEBD191C5ADBF /* TBConnectionDiagnosticsTests.swift in Sources */,
 				5109DFCF1BFD76222E7B4BDD /* TBDisplayProfileTests.swift in Sources */,
@@ -379,6 +386,7 @@
 				337BD561622AA19F43D3B95B /* ReceiverBackedVirtualDisplaySession.swift in Sources */,
 				4B770D1232C53EF66F011F7F /* TBAddonManifest.swift in Sources */,
 				E81B28F81AE82FF904E0871F /* TBAddonStore.swift in Sources */,
+				50C6F9D35F964ABF03193C5B /* TBCaptureHealth.swift in Sources */,
 				2819CE06D15CA7EDD1069062 /* TBConfigurationDiagnostics.swift in Sources */,
 				55163F49604063EA7E86D079 /* TBConnectionDiagnostics.swift in Sources */,
 				D81394631056BA19B9032116 /* TBDisplayProfile.swift in Sources */,

--- a/TargetBridge-Sender/scripts/test_capture_health.rb
+++ b/TargetBridge-Sender/scripts/test_capture_health.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# Run the actual model and XCTest file without launching the Sender or requesting
+# screen/input permissions. The temporary package has no external dependencies.
+require 'tmpdir'
+require 'fileutils'
+root = File.expand_path('..', __dir__)
+Dir.mktmpdir('tb-capture-health.') do |dir|
+  FileUtils.mkdir_p(File.join(dir, 'Sources/TargetBridge'))
+  FileUtils.mkdir_p(File.join(dir, 'Tests/TargetBridgeTests'))
+  FileUtils.cp(File.join(root, 'TBDisplaySender/TBCaptureHealth.swift'), File.join(dir, 'Sources/TargetBridge'))
+  FileUtils.cp(File.join(root, 'TBDisplaySenderTests/TBCaptureHealthTests.swift'), File.join(dir, 'Tests/TargetBridgeTests'))
+  File.write(File.join(dir, 'Package.swift'), <<~'SWIFT')
+    // swift-tools-version: 5.9
+    import PackageDescription
+    let package = Package(name: "CaptureHealthTests", platforms: [.macOS(.v14)],
+      targets: [.target(name: "TargetBridge"),
+                .testTarget(name: "TargetBridgeTests", dependencies: ["TargetBridge"])])
+  SWIFT
+  ok = system('swift', 'test', '--package-path', dir,
+    '--scratch-path', File.join(dir, 'build'), '--cache-path', File.join(dir, 'cache'),
+    '--config-path', File.join(dir, 'config'), '--security-path', File.join(dir, 'security'),
+    '--disable-sandbox')
+  abort 'Capture health tests failed' unless ok
+end


### PR DESCRIPTION
## Why

Thanks again for the project. While using an iMac as a monitor for a Mac mini, we found that an event-driven capture can legitimately stop producing frames on a static desktop. Treating every eight-second gap as a capture failure causes unnecessary restarts.

This is a focused follow-up, rebased on `maint-3.5` (`fb45b5f`), separate from pairing, login items, codecs, and rendering changes.

## Change

- Track real ScreenCaptureKit / CGDisplayStream status using a small, lock-protected monotonic capture-health model.
- Accept long idle only after a usable first frame; preserve timeout detection for startup and genuine active stalls.
- Do not restart blank/suspended capture in a wake loop.
- Recheck health after the watchdog delay, and use pipeline identity plus generation to prevent delayed recovery from restarting a stopped or replacement session.
- Ignore an obsolete capture delegate's error after its pipeline has been replaced.

The existing watchdog interval and timeout remain unchanged. No extra per-frame main-actor dispatch is added.

## Validation

- 17 executable XCTest cases against the production model: first-frame timeout, active stall, long/repeated idle, resume, blank/suspended/stopped/unknown states, fresh-pipeline isolation, recovery rechecks, both API mappings, and actual CMSampleBuffer attachment parsing.
- Reproducible without starting Sender or requesting capture/input permissions: `ruby TargetBridge-Sender/scripts/test_capture_health.rb` (macOS with full Xcode/XCTest selected). All 17 tests passed locally. The Mini's Command Line Tools alone lack XCTest, so the additional run there could not execute the suite; this is not counted as a pass.
- The rebased Sender and test target pass `xcodebuild build-for-testing` on Apple Silicon.
- Prior installed integration test: Mini M4 to iMac 24 M4; two sessions, a static capture remained idle beyond the eight-second threshold (about 13.6 seconds measured without a new frame), resumed frames without a watchdog restart, and stopped explicitly.

The model tests do not replace a physical sleep/wake matrix on Intel hardware. No new physical sleep or interactive GUI test is claimed for this PR.

## Scope / integration

Independent of #194, though both touch the capture entry guard in `TBDisplaySenderService.swift`; retain both the usable-frame guard here and the pre-encode reservation there if Git requires a small context resolution. No generated build metadata is included.
