### PR TITLE
docs: add maintainer update and support notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!IMPORTANT]
+> **A personal update from the maintainer**
+>
+> First, thank you to everyone who uses, tests, contributes to, and supports TargetBridge. Unexpected health issues have recently prevented me from continuing work on new features. Thank you for your patience and understanding while I focus on my health.
+>
+> If TargetBridge has been useful to you, please consider [supporting the project through GitHub Sponsors](https://github.com/sponsors/swellweb), with a one-time or monthly contribution. Your support helps sustain maintenance and future updates so more people can benefit. Contributions are entirely optional; testing, feedback, and code contributions are just as appreciated.
+
 ![TargetBridge Overview](images/connection-diagram.svg)
 
 # TargetBridge


### PR DESCRIPTION
## Summary
Adds a prominent personal update at the top of the README, thanking the community and explaining the pause in feature development due to health issues.

Includes an optional invitation to support maintenance and future updates through one-time or monthly GitHub sponsorships, while recognizing testing, feedback, and code contributions.

## Scope and verification
- README only: 7 added lines.
- No application code, version, packaging, or release changes.
- Based directly on main; no development-branch changes included.
- git diff --check passed. Runtime tests are not applicable to this documentation-only change.